### PR TITLE
[FEAT] 폴더구조 확정 및 레이아웃 기반 라우팅 구성 

### DIFF
--- a/app/(main)/chat/page.tsx
+++ b/app/(main)/chat/page.tsx
@@ -1,0 +1,4 @@
+import { ChatPage } from '@/app-pages/chat/ui/ChatPage';
+export default function Page() {
+  return <ChatPage />;
+}

--- a/app/(main)/home/page.tsx
+++ b/app/(main)/home/page.tsx
@@ -1,0 +1,4 @@
+import { HomePage } from '@/app-pages/home/ui/HomePage';
+export default function Page() {
+  return <HomePage />;
+}

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { AppHeader } from '@/widgets/header/ui/AppHeader';
+import { AppNavigation } from '@/widgets/navigation/ui/AppNavigation';
+
+export default function MainLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="bg-background-normal flex h-full w-full flex-col">
+      <AppHeader />
+      <main className="flex-1 px-[1rem]">{children}</main>
+      <AppNavigation />
+    </div>
+  );
+}

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -1,13 +1,11 @@
-'use client';
-
 import { AppHeader } from '@/widgets/header/ui/AppHeader';
 import { AppNavigation } from '@/widgets/navigation/ui/AppNavigation';
 
 export default function MainLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="bg-background-normal flex h-full w-full flex-col">
+    <div className="flex h-full w-full flex-col">
       <AppHeader />
-      <main className="flex-1 px-[1rem]">{children}</main>
+      <section className="flex-1 px-[1rem]">{children}</section>
       <AppNavigation />
     </div>
   );

--- a/app/(main)/mypage/page.tsx
+++ b/app/(main)/mypage/page.tsx
@@ -1,4 +1,4 @@
-import MyPage from '@/app-pages/mypage/ui/MyPage';
+import { MyPage } from '@/app-pages/mypage/ui/MyPage';
 export default function Page() {
   return <MyPage />;
 }

--- a/app/(sub)/layout.tsx
+++ b/app/(sub)/layout.tsx
@@ -1,12 +1,10 @@
-'use client';
-
 import { AppHeader } from '@/widgets/header/ui/AppHeader';
 
 export default function SubLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="bg-background-normal flex h-full w-full flex-col">
+    <div className="flex h-full w-full flex-col">
       <AppHeader />
-      <main className="flex-1 px-[1rem]">{children}</main>
+      <section className="flex-1 px-[1rem]">{children}</section>
     </div>
   );
 }

--- a/app/(sub)/layout.tsx
+++ b/app/(sub)/layout.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { AppHeader } from '@/widgets/header/ui/AppHeader';
+
+export default function SubLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="bg-background-normal flex h-full w-full flex-col">
+      <AppHeader />
+      <main className="flex-1 px-[1rem]">{children}</main>
+    </div>
+  );
+}

--- a/app/(sub)/onboarding/page.tsx
+++ b/app/(sub)/onboarding/page.tsx
@@ -1,0 +1,5 @@
+import { OnBoardingPage } from '@/app-pages/onboarding/ui/OnBoardingPage';
+
+export default function Page() {
+  return <OnBoardingPage />;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,7 +13,9 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         />
       </head>
       <body className="flex min-h-screen items-center justify-center bg-gray-100">
-        <main className="h-dvh w-dvw sm:h-[50.75rem] sm:w-[360px]">{children}</main>
+        <main className="bg-background-normal h-dvh w-dvw sm:h-[50.75rem] sm:w-[360px]">
+          {children}
+        </main>
       </body>
     </html>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,9 +13,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         />
       </head>
       <body className="flex min-h-screen items-center justify-center bg-gray-100">
-        <main className="bg-background-normal h-dvh w-dvw sm:h-[50.75rem] sm:w-[360px]">
-          {children}
-        </main>
+        <main className="bg-background-normal h-dvh w-dvw sm:w-[360px]">{children}</main>
       </body>
     </html>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,7 +12,9 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css"
         />
       </head>
-      <body>{children}</body>
+      <body className="flex min-h-screen items-center justify-center bg-gray-100">
+        <main className="h-dvh w-dvw sm:h-[50.75rem] sm:w-[360px]">{children}</main>
+      </body>
     </html>
   );
 }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,4 +1,4 @@
-import LoginPage from '@/app-pages/login/ui/LoginPage';
+import { LoginPage } from '@/app-pages/login/ui/LoginPage';
 export default function Page() {
   return <LoginPage />;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,15 +1,6 @@
-'use client';
-
-import { useRouter } from 'next/navigation';
-import { useEffect } from 'react';
+import { redirect } from 'next/navigation';
 
 export default function RootPage() {
-  const router = useRouter();
-
-  useEffect(() => {
-    router.replace('/home');
-  }, [router]);
-
-  // 추후 로딩 페이지로 대체
-  return <div>초기화 중...</div>;
+  // 추후 로그인 로직 반영 예정
+  redirect('/home');
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,1 +1,15 @@
-export { HomePage as default } from '@/app-pages/home/ui/HomePage';
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+
+export default function RootPage() {
+  const router = useRouter();
+
+  useEffect(() => {
+    router.replace('/home');
+  }, [router]);
+
+  // 추후 로딩 페이지로 대체
+  return <div>초기화 중...</div>;
+}

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,5 +1,0 @@
-import SignUpPage from '@/app-pages/signup/ui/SignUpPage';
-
-export default function Page() {
-  return <SignUpPage />;
-}

--- a/src/app-pages/chat/ui/ChatPage.tsx
+++ b/src/app-pages/chat/ui/ChatPage.tsx
@@ -1,0 +1,7 @@
+export function ChatPage() {
+  return (
+    <>
+      <div>chat</div>
+    </>
+  );
+}

--- a/src/app-pages/login/ui/LoginPage.tsx
+++ b/src/app-pages/login/ui/LoginPage.tsx
@@ -1,4 +1,4 @@
-export default function LoginPage() {
+export function LoginPage() {
   return (
     <>
       <div>login</div>

--- a/src/app-pages/mypage/ui/MyPage.tsx
+++ b/src/app-pages/mypage/ui/MyPage.tsx
@@ -1,4 +1,4 @@
-export default function MyPage() {
+export function MyPage() {
   return (
     <>
       <div>mypage</div>

--- a/src/app-pages/onboarding/ui/OnBoardingPage.tsx
+++ b/src/app-pages/onboarding/ui/OnBoardingPage.tsx
@@ -1,0 +1,7 @@
+export function OnBoardingPage() {
+  return (
+    <>
+      <div>onboarding</div>
+    </>
+  );
+}

--- a/src/app-pages/signup/ui/SignUpPage.tsx
+++ b/src/app-pages/signup/ui/SignUpPage.tsx
@@ -1,7 +1,0 @@
-export default function SignUpPage() {
-  return (
-    <>
-      <div>signup</div>
-    </>
-  );
-}

--- a/src/shared/config/routes.tsx
+++ b/src/shared/config/routes.tsx
@@ -4,6 +4,7 @@ import { DummyLogo } from '@/shared/ui/logo/DummyLogo';
 export type RouteConfig = {
   id: string;
   path: string;
+  backPath?: string | null;
   header: HeaderProps;
 };
 

--- a/src/shared/config/routes.tsx
+++ b/src/shared/config/routes.tsx
@@ -1,0 +1,56 @@
+import { HeaderMode, HeaderProps } from '@/shared/ui/header/Header';
+import { DummyLogo } from '@/shared/ui/logo/DummyLogo';
+
+export type RouteConfig = {
+  id: string;
+  path: string;
+  header: HeaderProps;
+};
+
+export const ROUTE_CONFIG: RouteConfig[] = [
+  {
+    id: 'home',
+    path: '/home',
+    header: {
+      mode: HeaderMode.Default,
+      title: '홈',
+      hasLeftIcon: true,
+      icons: [
+        { label: 'Search', onClickIcon: () => alert('검색') },
+        { label: 'Share', onClickIcon: () => alert('공유') },
+        { label: 'DotsVertical', onClickIcon: () => alert('메뉴') },
+      ],
+    },
+  },
+  {
+    id: 'chat',
+    path: '/chat',
+    header: {
+      mode: HeaderMode.Default,
+      title: '채팅',
+      hasLeftIcon: true,
+      icons: [
+        { label: 'Search', onClickIcon: () => alert('검색') },
+        { label: 'Share', onClickIcon: () => alert('공유') },
+        { label: 'DotsVertical', onClickIcon: () => alert('메뉴') },
+      ],
+    },
+  },
+  {
+    id: 'mypage',
+    path: '/mypage',
+    header: {
+      mode: HeaderMode.Logo,
+      logo: <DummyLogo />,
+      icons: [{ label: 'Search', onClickIcon: () => alert('설정') }],
+    },
+  },
+  {
+    id: 'onboarding',
+    path: '/onboarding',
+    header: {
+      mode: HeaderMode.Default,
+      hasLeftIcon: true,
+    },
+  },
+];

--- a/src/shared/config/routes.tsx
+++ b/src/shared/config/routes.tsx
@@ -4,7 +4,7 @@ import { DummyLogo } from '@/shared/ui/logo/DummyLogo';
 export type RouteConfig = {
   id: string;
   path: string;
-  backPath?: string | null;
+  backPath?: string;
   header: HeaderProps;
 };
 

--- a/src/shared/ui/bottom-navigation/BottomNavigation.tsx
+++ b/src/shared/ui/bottom-navigation/BottomNavigation.tsx
@@ -18,7 +18,7 @@ export function BottomNavigation({ activeId, onNavigate }: BottomNavigationProps
     <nav
       role="navigation"
       aria-label="하단 네비게이션"
-      className="bg-background-normal absolute bottom-0 left-0 flex h-[4.5rem] w-full justify-around rounded-t-[0.625rem] pb-[0.75rem] shadow-[0_2px_30px_0_rgba(0,0,0,0.10)]"
+      className="bg-background-normal bottom-0 left-0 flex h-[4.5rem] w-full justify-around rounded-t-[0.625rem] pb-[0.75rem] shadow-[0_2px_30px_0_rgba(0,0,0,0.10)]"
     >
       {navItems.map((item) => (
         <button

--- a/src/shared/ui/header/Header.tsx
+++ b/src/shared/ui/header/Header.tsx
@@ -176,7 +176,7 @@ export function Header(props: HeaderProps) {
   }
 
   return (
-    <header className="bg-background-normal-lighter absolute top-0 flex h-[3rem] w-full items-center justify-between px-[0.5rem] py-[0.25rem]">
+    <header className="bg-background-normal-lighter top-0 flex h-[3rem] w-full items-center justify-between px-[0.5rem] py-[0.25rem]">
       {content}
     </header>
   );

--- a/src/shared/ui/logo/DummyLogo.tsx
+++ b/src/shared/ui/logo/DummyLogo.tsx
@@ -1,0 +1,3 @@
+export function DummyLogo() {
+  return <div className="flex h-full w-[8rem] items-center bg-gray-300" />;
+}

--- a/src/shared/ui/text-input/TextInput.tsx
+++ b/src/shared/ui/text-input/TextInput.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {
   forwardRef,
   useRef,

--- a/src/widgets/header/ui/AppHeader.tsx
+++ b/src/widgets/header/ui/AppHeader.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { usePathname, useRouter } from 'next/navigation';
+import { Header, HeaderMode, HeaderProps } from '@/shared/ui/header/Header';
+import { ROUTE_CONFIG } from '@/shared/config/routes';
+
+export function AppHeader() {
+  const pathname = usePathname();
+  const router = useRouter();
+
+  // 현재 경로에 맞는 route 설정 찾기
+  const currentRoute = ROUTE_CONFIG.find((item) => pathname === item.path);
+
+  // 추후 404 페이지로 대체
+  if (!currentRoute) return null;
+
+  function getHeaderProps(header: HeaderProps, back: () => void): HeaderProps {
+    if (header.mode === HeaderMode.Logo || !header.hasLeftIcon) return header;
+    return { ...header, onClickBack: back };
+  }
+
+  const headerProps = getHeaderProps(currentRoute.header, () => router.back());
+
+  return <Header {...headerProps} />;
+}

--- a/src/widgets/header/ui/AppHeader.tsx
+++ b/src/widgets/header/ui/AppHeader.tsx
@@ -19,7 +19,20 @@ export function AppHeader() {
     return { ...header, onClickBack: back };
   }
 
-  const headerProps = getHeaderProps(currentRoute.header, () => router.back());
+  // 뒤로가기 동작 정의
+  const handleBack = () => {
+    const { backPath } = currentRoute;
+
+    if (typeof backPath === 'string') {
+      // backPath가 지정된 경우 - 항상 해당 경로로 이동
+      router.push(backPath);
+    } else {
+      // backPath가 없는 경우 - 브라우저 히스토리 기반 이동
+      router.back();
+    }
+  };
+
+  const headerProps = getHeaderProps(currentRoute.header, handleBack);
 
   return <Header {...headerProps} />;
 }

--- a/src/widgets/navigation/ui/AppNavigation.tsx
+++ b/src/widgets/navigation/ui/AppNavigation.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { useRouter, usePathname } from 'next/navigation';
+import { BottomNavigation } from '@/shared/ui/bottom-navigation/BottomNavigation';
+import { ROUTE_CONFIG } from '@/shared/config/routes';
+
+export function AppNavigation() {
+  const router = useRouter();
+  const pathname = usePathname();
+
+  // 현재 활성화된 메뉴 ID 계산
+  const activeId = ROUTE_CONFIG.find((item) => pathname === item.path)?.id ?? 'home';
+
+  const handleNavigate = (id: string) => {
+    const target = ROUTE_CONFIG.find((item) => item.id === id);
+    if (target) router.push(target.path);
+  };
+
+  return <BottomNavigation activeId={activeId} onNavigate={handleNavigate} />;
+}

--- a/src/widgets/navigation/ui/AppNavigation.tsx
+++ b/src/widgets/navigation/ui/AppNavigation.tsx
@@ -9,11 +9,12 @@ export function AppNavigation() {
   const pathname = usePathname();
 
   // 현재 활성화된 메뉴 ID 계산
+  // 추후 not found page 추가 예정
   const activeId = ROUTE_CONFIG.find((item) => pathname === item.path)?.id ?? 'home';
 
   const handleNavigate = (id: string) => {
     const target = ROUTE_CONFIG.find((item) => item.id === id);
-    if (target) router.push(target.path);
+    if (target && pathname !== target.path) router.push(target.path);
   };
 
   return <BottomNavigation activeId={activeId} onNavigate={handleNavigate} />;


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 any가 사용되지 않았습니다
- [x] 스토리북에 추가했습니다 (해당 시)
- [x] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈
- close #63 

## 📌 작업 목적
- 폴더 구조를 확정하였으며 (main)/(sub) 레이아웃 기반 라우팅을 구성하였습니다.

## 🔨 주요 작업 내용
- `app/(main)/layout.tsx` → 공통 헤더 + 바텀네비 
- `app/(sub)/layout.tsx` → 공통 헤더
- `ROUTE_CONFIG` 정의 및 `AppHeader`, `AppNavigation` 구현
- weight와 height는 미확정이므로 임의의 사이즈로 고정해두었습니다.


## 🧪 테스트 방법
`pnpm dev`
- `/home`, `/chat`, `/mypage` 접근 시 MainLayout이 적용되는지 확인
- `/onboarding` 접근 시 SubLayout이 적용되는지 확인
- `/login` 접근 시 RootLayout이 적용되는지 확인
- 라우팅 시 헤더 타이틀과 바텀 네비게이션 활성 상태가 올바르게 반영되는지 확인


## 📷 실행 영상 또는 스크린샷
- `/home`
<img width="421" height="835" alt="image" src="https://github.com/user-attachments/assets/c925a515-7dab-41ea-b2eb-e4da6889c636" />

- `/chat`
<img width="433" height="812" alt="image" src="https://github.com/user-attachments/assets/292a2561-6880-4283-99cc-566d9cd7e28a" />

-  `/mypage`
<img width="430" height="799" alt="image" src="https://github.com/user-attachments/assets/0bbbc6ba-827c-4c1a-96f2-10bb0bea1f8b" />


-  `/onboarding`
<img width="401" height="800" alt="image" src="https://github.com/user-attachments/assets/3b3f6dfc-39a1-472f-beb3-2db8a16673f1" />

-  `/login`
<img width="387" height="817" alt="image" src="https://github.com/user-attachments/assets/245bcd76-27c2-4c63-8918-0aac2854b4c7" />


## 💬 논의할 점
- 설정 아이콘이 라벨로 검색되지 않아 디자인 측에 문의가 필요할 것 같습니다!



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 홈·채팅·온보딩·마이페이지 페이지 및 관련 컴포넌트 추가, ROUTE_CONFIG로 라우트/헤더 구성
  - 공통 레이아웃 도입: 상단 헤더(AppHeader)·하단 내비(AppNavigation)·메인 영역
  - 더미 로고 컴포넌트 추가

- **스타일**
  - 전체 body/main 컨테이너 레이아웃·배경 개선
  - Header 및 BottomNavigation의 absolute 클래스 제거로 레이아웃 안정화

- **기타**
  - 루트 접속 시 /home으로 자동 리다이렉트
  - 회원가입 페이지 제거; Login/MyPage export 형식 변경, TextInput에 클라이언트 지시자 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->