### PR TITLE
[REFACTOR] Header 텍스트 버튼 영역을 TextButton 컴포넌트로 교체

### DIFF
--- a/src/shared/ui/header/Header.stories.tsx
+++ b/src/shared/ui/header/Header.stories.tsx
@@ -83,7 +83,7 @@ export const TextBtnHeader: StoryObj<TextBtnHeaderProps> = {
     onClickBack: () => alert('뒤로가기 클릭'),
     title: '글쓰기',
     text: '완료',
-    isActive: true,
+    isDisabled: false,
     onClickTextBtn: () => alert('완료 버튼 클릭'),
   },
 };

--- a/src/shared/ui/header/Header.tsx
+++ b/src/shared/ui/header/Header.tsx
@@ -1,7 +1,7 @@
 import React, { ComponentProps } from 'react';
 import { SurfIcon } from '../icon/SurfIcon';
 import { TextInput } from '../text-input/TextInput';
-import { TextButton } from '../text-button/TextButton';
+import { ButtonVariant, TextButton } from '../text-button/TextButton';
 
 type SurfIconName = ComponentProps<typeof SurfIcon>['name'];
 
@@ -50,7 +50,8 @@ export type TextBtnHeaderProps = {
   onClickBack?: () => void;
   title?: string;
   text: string;
-  isActive?: boolean;
+  isDisabled?: boolean;
+  btnVariant?: ButtonVariant;
   onClickTextBtn?: () => void;
 };
 
@@ -152,7 +153,8 @@ export function Header(props: HeaderProps) {
         onClickBack,
         title = '',
         text,
-        isActive,
+        isDisabled,
+        btnVariant = 'secondary',
         onClickTextBtn,
       } = props;
       content = (
@@ -162,8 +164,8 @@ export function Header(props: HeaderProps) {
           <div className="ml-auto flex justify-center">
             <TextButton
               size="s"
-              variant="secondary"
-              isDisabled={!isActive}
+              variant={btnVariant}
+              isDisabled={isDisabled}
               onClick={onClickTextBtn}
             >
               {text}

--- a/src/shared/ui/header/Header.tsx
+++ b/src/shared/ui/header/Header.tsx
@@ -1,6 +1,7 @@
 import React, { ComponentProps } from 'react';
 import { SurfIcon } from '../icon/SurfIcon';
 import { TextInput } from '../text-input/TextInput';
+import { TextButton } from '../text-button/TextButton';
 
 type SurfIconName = ComponentProps<typeof SurfIcon>['name'];
 
@@ -158,14 +159,16 @@ export function Header(props: HeaderProps) {
         <>
           {renderLeftIcon(hasLeftIcon, onClickBack)}
           {renderTitle(title)}
-          <button
-            className={`text-body-14-600--1-20 ml-auto cursor-pointer p-[0.5rem] ${
-              isActive ? 'text-foreground-normal' : 'text-background-quaternary'
-            }`}
-            onClick={onClickTextBtn}
-          >
-            {text}
-          </button>
+          <div className="ml-auto flex justify-center">
+            <TextButton
+              size="s"
+              variant="secondary"
+              isDisabled={!isActive}
+              onClick={onClickTextBtn}
+            >
+              {text}
+            </TextButton>
+          </div>
         </>
       );
       break;

--- a/src/shared/ui/text-button/TextButton.tsx
+++ b/src/shared/ui/text-button/TextButton.tsx
@@ -7,7 +7,7 @@ import { SurfIcon } from '@/shared/ui/icon/SurfIcon';
 type SurfIconName = ComponentProps<typeof SurfIcon>['name'];
 
 type ButtonSize = 's' | 'm' | 'l';
-type ButtonVariant = 'primary' | 'secondary' | 'warning';
+export type ButtonVariant = 'primary' | 'secondary' | 'warning';
 
 export type TextButtonProps = Omit<
   ButtonHTMLAttributes<HTMLButtonElement>,


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 코드에 any가 사용되지 않았습니다
- [ ] 스토리북에 추가했습니다 (해당 시)
- [ ] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈
- close #68 

## 📌 작업 목적
-  Header 텍스트 버튼 영역을 TextButton 컴포넌트로 교체

## 🔨 주요 작업 내용
-  Header 텍스트 버튼 영역을 TextButton 컴포넌트로 교체

## 🧪 테스트 방법
- `pnpm storybook`
- Shared/UI/Header/TextBtnHeader
- 기존과 같이 동작하는지 확인합니다.

## 📷 실행 영상 또는 스크린샷
<img width="547" height="582" alt="image" src="https://github.com/user-attachments/assets/f18ed721-f08f-411d-ac95-96e01174f382" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 헤더의 텍스트 액션 버튼을 공용 버튼 컴포넌트로 교체해 동작은 유지하면서 비활성화 처리 방식을 정리했습니다.
  * 프로퍼티 이름이 변경되어(이전 isActive → isDisabled) 사용 방식이 더 명확해졌습니다.

* **Style**
  * 버튼을 우측 정렬된 플렉스 컨테이너에 배치하고 소형·보조 스타일을 적용해 레이아웃과 시각적 일관성을 개선했습니다.

* **문서/예제**
  * 스토리 예제의 플래그 이름을 변경해 샘플 사용법을 최신화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->