### PR TITLE
[REFACTOR] Alert 컴포넌트 prop 추가 및 Alert 스토리북 개선

### DIFF
--- a/src/shared/ui/alert/Alert.stories.tsx
+++ b/src/shared/ui/alert/Alert.stories.tsx
@@ -7,6 +7,9 @@ const meta = {
   tags: ['autodocs'],
   parameters: {
     layout: 'centered',
+    docs: {
+      story: { inline: false, height: '300px' },
+    },
   },
   argTypes: {
     state: {
@@ -16,7 +19,7 @@ const meta = {
     },
     title: { control: 'text', description: '제목' },
     infoText: { control: 'text', description: '설명 텍스트' },
-    actions: { table: { disable: true } }, // 배열 + 함수 포함 → 컨트롤 비활성화
+    actions: { table: { disable: true } },
   },
 } satisfies Meta<typeof Alert>;
 
@@ -33,6 +36,8 @@ export const DefaultTwoButtons: Story = {
       { type: 'solid', label: '취소', variant: 'secondary', onClick: () => console.log('cancel') },
       { type: 'solid', label: '로그아웃', variant: 'primary', onClick: () => alert('confirm') },
     ],
+    isOpen: true,
+    onClose: () => alert('모달 닫기'),
   },
 };
 
@@ -43,6 +48,8 @@ export const OneButton: Story = {
     title: '설정이 저장되었습니다',
     infoText: '변경 사항이 정상적으로 반영되었어요.',
     actions: [{ type: 'solid', label: '확인', variant: 'primary', onClick: () => alert('ok') }],
+    isOpen: true,
+    onClose: () => alert('모달 닫기'),
   },
 };
 
@@ -53,6 +60,8 @@ export const ErrorState: Story = {
     title: '문제가 발생했어요',
     infoText: '네트워크 상태를 확인한 뒤 다시 시도해 주세요.',
     actions: [{ type: 'text', label: '확인', variant: 'primary', onClick: () => alert('ack') }],
+    isOpen: true,
+    onClose: () => alert('모달 닫기'),
   },
 };
 
@@ -66,6 +75,8 @@ export const CustomSolidVariants: Story = {
       { type: 'solid', label: '취소', variant: 'secondary', onClick: () => console.log('cancel') },
       { type: 'solid', label: '삭제', variant: 'danger', onClick: () => alert('delete') },
     ],
+    isOpen: true,
+    onClose: () => alert('모달 닫기'),
   },
 };
 
@@ -80,5 +91,7 @@ export const LongText: Story = {
       { type: 'solid', label: '취소', variant: 'secondary', onClick: () => console.log('cancel') },
       { type: 'solid', label: '진행', variant: 'primary', onClick: () => alert('proceed') },
     ],
+    isOpen: true,
+    onClose: () => alert('모달 닫기'),
   },
 };

--- a/src/shared/ui/alert/Alert.tsx
+++ b/src/shared/ui/alert/Alert.tsx
@@ -30,71 +30,85 @@ type AlertProps = {
   title: string;
   infoText?: string;
   actions: AlertAction[];
+  isOpen: boolean;
+  onClose: () => void;
 };
 
-export const Alert = ({ state = 'default', title, infoText, actions }: AlertProps) => {
+export const Alert = ({
+  state = 'default',
+  title,
+  infoText,
+  actions,
+  isOpen,
+  onClose,
+}: AlertProps) => {
   const uid = useId();
   const titleId = `${uid}-title`;
   const descId = infoText ? `${uid}-desc` : undefined;
 
   const isError = state === 'error';
 
+  if (!isOpen) return null;
+
   return (
-    <section
-      className="bg-background-normal flex w-[17.18rem] flex-col gap-[1rem] overflow-hidden rounded-[0.5rem] px-[1.25rem] pt-[1.25rem] pb-[1rem]"
-      role={isError ? 'alert' : undefined}
-      aria-labelledby={titleId}
-      aria-describedby={descId}
-    >
-      <div className="flex flex-col gap-[0.25rem]">
-        <span id={titleId} className="text-foreground-normal text-body-16-600--1">
-          {title}
-        </span>
-        {infoText && (
-          <span id={descId} className="text-foreground-normal-darker text-body-14-400--2-22">
-            {infoText}
+    <div className="absolute inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 w-full bg-black/60" onClick={onClose} aria-hidden />
+      <section
+        className="bg-background-normal relative z-10 flex w-[17.18rem] flex-col gap-[1rem] overflow-hidden rounded-[0.5rem] px-[1.25rem] pt-[1.25rem] pb-[1rem]"
+        role={isError ? 'alert' : undefined}
+        aria-labelledby={titleId}
+        aria-describedby={descId}
+      >
+        <div className="flex flex-col gap-[0.25rem]">
+          <span id={titleId} className="text-foreground-normal text-body-16-600--1">
+            {title}
           </span>
-        )}
-      </div>
+          {infoText && (
+            <span id={descId} className="text-foreground-normal-darker text-body-14-400--2-22">
+              {infoText}
+            </span>
+          )}
+        </div>
 
-      <div className="flex flex-row gap-2">
-        {actions.map((action, idx) => {
-          const isBtnSingle = actions.length === 1;
-          const wrapperClass =
-            action.type === 'text' && isBtnSingle ? 'ml-auto inline-flex w-auto' : 'flex-1';
+        <div className="flex flex-row gap-2">
+          {actions.map((action, idx) => {
+            const isBtnSingle = actions.length === 1;
+            const wrapperClass =
+              action.type === 'text' && isBtnSingle ? 'ml-auto inline-flex w-auto' : 'flex-1';
 
-          if (action.type === 'text') {
+            if (action.type === 'text') {
+              return (
+                <div key={idx} className={wrapperClass}>
+                  <TextButton
+                    size="m"
+                    variant={action.variant ?? 'primary'}
+                    isDisabled={action.isDisabled}
+                    onClick={action.onClick}
+                    data-testid={action.testId}
+                  >
+                    {action.label}
+                  </TextButton>
+                </div>
+              );
+            }
+
+            // type === 'solid'
             return (
-              <div key={idx} className={wrapperClass}>
-                <TextButton
-                  size="m"
-                  variant={action.variant ?? 'primary'}
-                  isDisabled={action.isDisabled}
-                  onClick={action.onClick}
-                  data-testid={action.testId}
-                >
-                  {action.label}
-                </TextButton>
-              </div>
+              <SolidButton
+                key={idx}
+                size="m"
+                variant={action.variant ?? 'primary'}
+                isDisabled={action.isDisabled}
+                onClick={action.onClick}
+                data-testid={action.testId}
+              >
+                {action.label}
+              </SolidButton>
             );
-          }
-
-          // type === 'solid'
-          return (
-            <SolidButton
-              key={idx}
-              size="m"
-              variant={action.variant ?? 'primary'}
-              isDisabled={action.isDisabled}
-              onClick={action.onClick}
-              data-testid={action.testId}
-            >
-              {action.label}
-            </SolidButton>
-          );
-        })}
-      </div>
-    </section>
+          })}
+        </div>
+      </section>
+    </div>
   );
 };
 


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 any가 사용되지 않았습니다
- [x] 스토리북에 추가했습니다 (해당 시)
- [x] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈
- close #87 

## 📌 작업 목적
- Alert 컴포넌트 prop 추가 및 Alert 스토리북 개선

## 🔨 주요 작업 내용
### 🔧 Alert 컴포넌트 모달 기능 추가

### **파일**: `src/shared/ui/alert/Alert.tsx`

#### 1. 새로운 Props 추가
```typescript
type AlertProps = {
  // ... 기존 props
  isOpen: boolean;        // 모달 열림/닫힘 상태 제어
  onClose: () => void;    // 모달 닫기 콜백 함수
};
```

#### 2. 모달 UI 구조 개선
- **조건부 렌더링**: `if (!isOpen) return null;`로 모달 표시 제어
- **오버레이 추가**: `absolute inset-0 z-50`로 전체 화면 오버레이
- **배경 딤 처리**: `bg-black/60` 배경 클릭 시 `onClose` 호출
- **레이어링**: `relative z-10`로 모달 콘텐츠를 배경 위에 표시

---

### **파일**: `src/shared/ui/alert/Alert.stories.tsx`

#### 1. 문서 설정 개선
```typescript
docs: {
  story: { inline: false, height: '300px' },
}
```

#### 2. 모든 스토리에 필수 속성 추가
5개 스토리 모두에 다음 속성 추가:
```typescript
isOpen: true,
onClose: () => alert('모달 닫기'),
```


## 🧪 테스트 방법
- `pnpm run storybook` 후 shared/ui 폴더에 Alert 컴포넌트 확인


## 📷 실행 영상 또는 스크린샷
<img width="500" height="350" alt="image" src="https://github.com/user-attachments/assets/c5b3eac9-13bd-4e72-a170-63e4d7ac32c0" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - Alert에 모달 동작 추가: isOpen으로 열림 상태 제어, onClose로 닫힘 처리
  - 배경 오버레이 및 배경 클릭 시 닫기 지원, 뒤 콘텐츠 상호작용 차단
  - 기존 제목/설명/버튼 렌더링은 유지하며 접근성 속성 유지

- 문서화
  - 스토리북 스토리에 isOpen/onClose 제어 항목 추가로 데모 상호작용 강화
  - 문서 보기 설정 조정(인라인 비활성화, 높이 지정)으로 미리보기 가독성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->