### PR TITLE
[HOTFIX] 온보딩레이아웃에 use client 추가

### DIFF
--- a/src/app-pages/onboarding/ui/OnBoardingPage.tsx
+++ b/src/app-pages/onboarding/ui/OnBoardingPage.tsx
@@ -8,7 +8,6 @@ import { FormProvider, useForm } from 'react-hook-form';
 
 export default function OnBoardingPage() {
   const profileImageUrl = useAuthStore((state) => state.profileImageUrl);
-  console.log('zustand에서 읽은 프로필 URL:', profileImageUrl);
 
   const methods = useForm<OnBoardingFormData>({
     defaultValues: {

--- a/src/widgets/onboarding/ui/OnBoardingLayout.tsx
+++ b/src/widgets/onboarding/ui/OnBoardingLayout.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { SolidButton } from '@/shared/ui/solid-button/SolidButton';
 import { AppHeader } from '@/widgets/header/ui/AppHeader';
 import React from 'react';


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 any가 사용되지 않았습니다
- [x] 스토리북에 추가했습니다 (해당 시)
- [x] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈
- close #89 

## 📌 작업 목적
- 온보딩 레이아웃에 use client 추가

## 🔨 주요 작업 내용
- 온보딩 레이아웃에 'use client'를 추가하였습니다.

## ⚠️ 기존 문제 
-  온보딩 레이아웃에서 클라이언트 상태와 이벤트 핸들러를 사용하지만 use client 선언을 하지 않았습니다.

## ☑️ 해결 방법
- 'use client'를 추가하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 온보딩 레이아웃을 클라이언트 컴포넌트로 전환하여 브라우저 상호작용 및 상태 관리 일관성을 개선했습니다. 사용자 흐름이나 화면 구성의 가시적 변화는 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->