### PR TITLE
[REFACTOR] 활동점수 페이지 스크롤 영역 변경

### DIFF
--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -5,7 +5,7 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
   return (
     <div className="flex h-full w-full flex-col">
       <AppHeader />
-      <section className="flex-1 overflow-auto">{children}</section>
+      <section className="flex-1">{children}</section>
       <AppNavigation />
     </div>
   );

--- a/app/(sub)/layout.tsx
+++ b/app/(sub)/layout.tsx
@@ -4,7 +4,7 @@ export default function SubLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex h-full w-full flex-col">
       <AppHeader />
-      <section className="h-full w-full flex-1 overflow-auto">{children}</section>
+      <section className="h-full w-full flex-1">{children}</section>
     </div>
   );
 }

--- a/src/app-pages/activity-score/ui/ActivityScorePage.tsx
+++ b/src/app-pages/activity-score/ui/ActivityScorePage.tsx
@@ -50,7 +50,7 @@ export default function ActivityScorePage() {
   }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   return (
-    <div className="flex flex-col items-center">
+    <div className="flex h-full flex-col items-center">
       <h1 className="sr-only">활동 점수</h1>
 
       {/* 활동 점수 카드 */}
@@ -90,7 +90,7 @@ export default function ActivityScorePage() {
       </div>
 
       {/* 활동 점수 리스트 */}
-      <div className="flex w-full flex-col gap-[2.25rem] px-[1rem] py-[1.88rem]">
+      <div className="flex w-full flex-1 flex-col gap-[2.25rem] overflow-y-auto px-[1rem] pt-[1.88rem]">
         {isHistoryLoading && (
           <div aria-live="polite" aria-busy="true">
             불러오는 중...
@@ -111,7 +111,7 @@ export default function ActivityScorePage() {
         )}
 
         {!isHistoryLoading && !isHistoryError && history.length === 0 && (
-          <div className="text-body-14-600--1-20 text-foreground-hint py-[1rem] text-center">
+          <div className="text-body-14-600--1-20 text-foreground-hint text-center">
             활동 내역이 없습니다.
           </div>
         )}

--- a/src/app-pages/bylaws/ui/BylawsPage.tsx
+++ b/src/app-pages/bylaws/ui/BylawsPage.tsx
@@ -3,7 +3,7 @@ import { bylawsData } from '@/app-pages/bylaws/model/data';
 
 export default function BylawsPage() {
   return (
-    <div className="flex h-dvh flex-col overflow-y-auto pt-[1.25rem]">
+    <div className="flex h-full flex-col overflow-y-auto pt-[1.25rem]">
       <AccordionGroup accordions={bylawsData} />
     </div>
   );

--- a/src/app-pages/bylaws/ui/BylawsPage.tsx
+++ b/src/app-pages/bylaws/ui/BylawsPage.tsx
@@ -3,7 +3,7 @@ import { bylawsData } from '@/app-pages/bylaws/model/data';
 
 export default function BylawsPage() {
   return (
-    <div className="flex flex-col pt-[1.25rem]">
+    <div className="flex h-dvh flex-col overflow-y-auto pt-[1.25rem]">
       <AccordionGroup accordions={bylawsData} />
     </div>
   );


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 any가 사용되지 않았습니다
- [x] 스토리북에 추가했습니다 (해당 시)
- [x] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈
- close #104

## 📌 작업 목적
- 활동점수 페이지의 스크롤 영역을 화면 전체에서 활동 기록 영역으로 변경합니다.

## 🔨 주요 작업 내용
- main 및 sub layout에서 `overflow-auto` 삭제
- 스크롤이 필요한 페이지는 페이지 내에서 개별적으로 `overflow-auto`를 써주면 됩니다.

## ⚠️ 기존 문제 (선택)
- 활동기록 영역에 스크롤을 지정해도 부모 layout에서 overflow-auto가 있어 스크롤바가 2개 생김

## ☑️ 해결 방법 (선택)
- main 및 sub layout에서 `overflow-auto` 삭제

## 🧪 테스트 방법
- main 및 sub layout 변경사항을 확인하고, 자신의 페이지에서 (스크롤이 있을시) 스크롤이 잘 되는지 확인해주세요!!

## 📷 실행 영상 또는 스크린샷
https://github.com/user-attachments/assets/66549056-e8e8-452a-bf7b-8591a3125d64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 스타일
  - 메인 레이아웃: 강제 스크롤 제거로 자연스러운 페이지 스크롤 동작.
  - 서브 레이아웃: overflow 제어 축소로 일관된 스크롤 경험.
  - 활동 점수 페이지: 컨테이너 전체 높이 적용, 내역 영역에 세로 스크롤과 패딩 조정, 빈 상태 텍스트 여백 정리.
  - 내규 페이지: 전체 높이 기반 레이아웃 및 세로 스크롤 활성화로 긴 콘텐츠 탐색성 향상.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->