### PR TITLE
[REFACTOR] policy 상세 화면 라우터 올바른 경로로 수정

### DIFF
--- a/src/app-pages/mypage/settings/policy/ui/PolicyPage.tsx
+++ b/src/app-pages/mypage/settings/policy/ui/PolicyPage.tsx
@@ -11,7 +11,7 @@ export default function PolicyPage() {
       <PolicyItem
         rightIconName="ChevronRight"
         onClick={() => {
-          router.push('/mypage/settings/policy/service-policy');
+          router.push('/mypage/settings/policy/service');
         }}
       >
         [필수] SURF 이용약관
@@ -19,7 +19,7 @@ export default function PolicyPage() {
       <PolicyItem
         rightIconName="ChevronRight"
         onClick={() => {
-          router.push('/mypage/settings/policy/personal-info-policy');
+          router.push('/mypage/settings/policy/personal-info');
         }}
       >
         [필수] 개인정보 수집·이용 동의서
@@ -27,7 +27,7 @@ export default function PolicyPage() {
       <PolicyItem
         rightIconName="ChevronRight"
         onClick={() => {
-          router.push('/mypage/settings/policy/marketing-info-policy');
+          router.push('/mypage/settings/policy/marketing-info');
         }}
       >
         [선택] 마케팅 정보 수신 동의

--- a/src/shared/config/routes.tsx
+++ b/src/shared/config/routes.tsx
@@ -141,7 +141,7 @@ export const createRouteConfig = (router: RouterInstance): RouteConfig[] => [
   // 약관 상세 페이지
   {
     id: 'mypage-policy-service-policy',
-    path: '/mypage/settings/policy/service-policy',
+    path: '/mypage/settings/policy/service',
     backPath: '/mypage/settings/policy',
     header: {
       mode: HeaderMode.Default,
@@ -151,7 +151,7 @@ export const createRouteConfig = (router: RouterInstance): RouteConfig[] => [
   },
   {
     id: 'mypage-policy-personal-info-policy',
-    path: '/mypage/settings/policy/personal-info-policy',
+    path: '/mypage/settings/policy/personal-info',
     backPath: '/mypage/settings/policy',
     header: {
       mode: HeaderMode.Default,
@@ -161,7 +161,7 @@ export const createRouteConfig = (router: RouterInstance): RouteConfig[] => [
   },
   {
     id: 'mypage-policy-marketing-info-policy',
-    path: '/mypage/settings/policy/marketing-info-policy',
+    path: '/mypage/settings/policy/marketing-info',
     backPath: '/mypage/settings/policy',
     header: {
       mode: HeaderMode.Default,


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 any가 사용되지 않았습니다
- [x] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈
- close #107 

## 📌 작업 목적
- policy 상세 화면 라우터 올바른 경로로 수정

## 🔨 주요 작업 내용
- 이용약관 화면에서 각 약관의 상세 화면으로 이동하는 라우터 경로를 올바른 경로로 수정함

## 🧪 테스트 방법
- `pnpm run dev` 이후 `http://localhost:3000/mypage/settings/policy` 접속하여 각 약관 상세 화면 확인하시면 됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 마이페이지 > 설정 > 정책의 약관 상세 페이지 이동 경로를 최신 URL로 업데이트했습니다. 서비스 이용약관, 개인정보 처리방침, 마케팅 정보 수신 동의 링크가 새 경로(/service, /personal-info, /marketing-info)로 정상 이동하며, 기존 경로로 인한 진입 오류(예: 404) 가능성을 해소했습니다. 메뉴 내 이동 일관성이 향상되었습니다.
- 리팩터링
  - 약관 상세 페이지 관련 라우팅 구성을 정리하여 경로 명명 규칙을 통일했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->