### PR TITLE
[REFACTOR] 도메인별 트래킹 함수 생성용 팩토리 함수 제작

### DIFF
--- a/src/features/auth/lib/trackAuthEvent.ts
+++ b/src/features/auth/lib/trackAuthEvent.ts
@@ -1,9 +1,4 @@
-import { trackEvent } from '@/shared/lib/trackEvent';
+import { createDomainTracker } from '@/shared/lib/createDomainTracker';
 import { AuthEventPropsMap } from '../model/types';
 
-export function trackAuthEvent<K extends keyof AuthEventPropsMap>(
-  eventName: K,
-  eventProps: AuthEventPropsMap[K],
-) {
-  trackEvent<AuthEventPropsMap, K>(eventName, eventProps);
-}
+export const trackAuthEvent = createDomainTracker<AuthEventPropsMap>();

--- a/src/shared/lib/createDomainTracker.ts
+++ b/src/shared/lib/createDomainTracker.ts
@@ -8,8 +8,11 @@ export function createDomainTracker<const M extends Record<string, Record<string
 >(
   eventName: K,
   eventProps: M[K],
-) => void {
-  return function <K extends keyof M>(eventName: K, eventProps: M[K]): void {
+) => ReturnType<typeof trackEvent> {
+  return function <K extends keyof M>(
+    eventName: K,
+    eventProps: M[K],
+  ): ReturnType<typeof trackEvent> {
     return trackEvent<M, K>(eventName, eventProps);
   };
 }

--- a/src/shared/lib/createDomainTracker.ts
+++ b/src/shared/lib/createDomainTracker.ts
@@ -3,8 +3,13 @@ import { trackEvent } from './trackEvent';
 /**
  * 도메인별 트래킹 함수를 생성하는 팩토리
  */
-export function createDomainTracker<const M extends Record<string, Record<string, unknown>>>() {
-  return function <K extends keyof M>(eventName: K, eventProps: M[K]) {
-    trackEvent<M, K>(eventName, eventProps);
+export function createDomainTracker<const M extends Record<string, Record<string, unknown>>>(): <
+  K extends keyof M,
+>(
+  eventName: K,
+  eventProps: M[K],
+) => void {
+  return function <K extends keyof M>(eventName: K, eventProps: M[K]): void {
+    return trackEvent<M, K>(eventName, eventProps);
   };
 }

--- a/src/shared/lib/createDomainTracker.ts
+++ b/src/shared/lib/createDomainTracker.ts
@@ -1,0 +1,10 @@
+import { trackEvent } from './trackEvent';
+
+/**
+ * 도메인별 트래킹 함수를 생성하는 팩토리
+ */
+export function createDomainTracker<const M extends Record<string, Record<string, unknown>>>() {
+  return function <K extends keyof M>(eventName: K, eventProps: M[K]) {
+    trackEvent<M, K>(eventName, eventProps);
+  };
+}


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 any가 사용되지 않았습니다
- [x] 스토리북에 추가했습니다 (해당 시)
- [x] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈
- close #110

## 📌 작업 목적
- 도메인별 트래킹 함수를 생성하는 팩토리 함수를 작성하여 추후 쉽게 도메인 전용 래퍼를 정의할 수 있게 합니다.

## 🔨 주요 작업 내용
- `createDomainTracker.ts` 제작
- `trackAuthEvent` 리팩토링

## ⚠️ 기존 문제
- Amplitude 이벤트 트래킹 시, 각 도메인(`auth`, `activity-score`, `onboarding` 등)마다 타입 안전성을 확보하기 위해 `trackEvent` 함수를 직접 확장해야 하는 중복 구조가 존재함.

## ☑️ 해결 방법
- 도메인별 `EventPropsMap` 타입만 전달하면 자동으로 트래킹 함수를 생성하는 제너릭 팩토리 함수 `createDomainTracker()`를 구현.
- 각 도메인에서는 `export const trackXxxEvent = createDomainTracker<XxxEventPropsMap>();` 한 줄로 래퍼 함수를 정의할 수 있도록 개선함.

## 🧪 테스트 방법
- 로그인 시 라이브 이벤트에서 로그가 잘 찍히는지 확인해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 도메인별 이벤트 트래커 생성 기능이 추가되었습니다.
- 리팩터
  - 인증 이벤트 추적 로직이 도메인 트래커 기반으로 재구성되어 공개 API가 호출형 함수에서 상수 트래커로 변경되었습니다.
- 영향
  - 이벤트 추적 동작은 그대로 유지되며, 사용자 경험상 가시적 변화는 없습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->