### PR TITLE
[FIX] 온보딩 완료 시 member_id 저장 및 회원 상태에 따른 페이지 분기 처리

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,35 +1,5 @@
 'use client';
 
-import { useEffect } from 'react';
-import { useRouter } from 'next/navigation';
-import { useAuthStore } from '@/features/auth/model/useAuthStore';
-import { getValidStatus } from '@/features/auth/api/getValidStatus';
-
 export default function RootPage() {
-  const router = useRouter();
-  const { accessToken } = useAuthStore();
-
-  useEffect(() => {
-    const checkStatus = async () => {
-      if (!accessToken) {
-        router.replace('/login');
-        return;
-      }
-
-      try {
-        const res = await getValidStatus();
-        if (res.data) {
-          router.replace('/onboarding');
-        } else {
-          router.replace('/home');
-        }
-      } catch {
-        router.replace('/login'); // 토큰 만료 or API 에러
-      }
-    };
-
-    void checkStatus();
-  }, [accessToken, router]);
-
-  return <div>로딩중...</div>;
+  return <div>로딩 중...</div>;
 }

--- a/src/app-pages/home/ui/HomePage.tsx
+++ b/src/app-pages/home/ui/HomePage.tsx
@@ -1,6 +1,17 @@
+'use client';
+
 import { SurfIcon } from '@/shared/ui/icon/SurfIcon';
+import { SolidButton } from '@/shared/ui/solid-button/SolidButton';
+import * as amplitude from '@amplitude/analytics-browser';
 
 export const HomePage = () => {
+  const handleTestEvent = () => {
+    amplitude.track('TEST_EVENT', {
+      page: 'HomePage',
+      clickedAt: new Date().toISOString(),
+    });
+    console.info('[Amplitude] TEST_EVENT 전송 완료');
+  };
   return (
     <div>
       <h1 className="text-head-26-700--1 text-background-primary">안녕하세요 hello world</h1>
@@ -18,6 +29,10 @@ export const HomePage = () => {
         size="l"
         className="cursor-pointer text-[color:var(--color-foreground-primary)] hover:text-[color:var(--color-foreground-warning)]"
       />
+
+      <SolidButton size="s" variant="primary" onClick={handleTestEvent}>
+        Amplitude 이벤트 테스트
+      </SolidButton>
     </div>
   );
 };

--- a/src/app/providers/AnalyticsProvider.tsx
+++ b/src/app/providers/AnalyticsProvider.tsx
@@ -2,11 +2,14 @@
 
 import { useEffect } from 'react';
 import * as amplitude from '@amplitude/analytics-browser';
+import { useAuthStore } from '@/features/auth/model/useAuthStore';
 const AMPLITUDE_API_KEY = process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY ?? '';
 
 let amplitudeInitialized = false;
 
 export function AnalyticsProvider() {
+  const memberId = useAuthStore((s) => s.memberId);
+
   const initAmplitude = () => {
     if (!AMPLITUDE_API_KEY || amplitudeInitialized) return;
     try {
@@ -26,6 +29,16 @@ export function AnalyticsProvider() {
   useEffect(() => {
     initAmplitude();
   }, []);
+
+  // memberId 변경 시 Amplitude userId 업데이트
+  useEffect(() => {
+    if (!amplitudeInitialized) return;
+    if (memberId) {
+      amplitude.setUserId(`member-${memberId}`);
+    } else {
+      amplitude.setUserId(undefined);
+    }
+  }, [memberId]);
 
   // 페이지 이탈 시점에 안전하게 이벤트 전송
   useEffect(() => {

--- a/src/app/providers/AuthProvider.tsx
+++ b/src/app/providers/AuthProvider.tsx
@@ -1,27 +1,81 @@
 'use client';
 
-import { ReactNode, useEffect } from 'react';
+import { ReactNode, useCallback, useEffect, useRef } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
 import { useAuthStore } from '@/features/auth/model/useAuthStore';
 import { useAuthHydrated } from '@/features/auth/model/useAuthHydrated';
+import { getValidStatus } from '@/features/auth/api/getValidStatus';
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const router = useRouter();
   const pathname = usePathname();
-  const accessToken = useAuthStore((s) => s.accessToken);
+  const { accessToken, setAuth, clearAuth } = useAuthStore();
   const hydrated = useAuthHydrated();
+  const isRedirecting = useRef(false);
+
+  const redirectTo = useCallback(
+    (path: string) => {
+      if (isRedirecting.current) return;
+      isRedirecting.current = true;
+      router.replace(path);
+    },
+    [router],
+  );
 
   useEffect(() => {
     if (!hydrated) return;
 
-    // 온보딩 구현 후, 온보딩 필요 시 온보딩 페이지로 이동하는 로직 추가 예정
-    if (!accessToken) {
-      router.replace('/login');
-    }
-  }, [pathname, accessToken, router, hydrated]);
+    const checkAuth = async () => {
+      // 1. 토큰 없으면 로그인 페이지로 이동
+      if (!accessToken) {
+        redirectTo('/login');
+        return;
+      }
+
+      try {
+        // 2. 유효성 검사 API 호출
+        const res = await getValidStatus();
+        const { memberId, needOnboarding, memberStatus } = res.data;
+
+        setAuth({ memberId });
+
+        // 3. 온보딩 필요 시
+        if (needOnboarding) {
+          redirectTo('/onboarding');
+          return;
+        }
+
+        // 4. 상태별 분기 처리
+        switch (memberStatus) {
+          case 'REGISTERING':
+            redirectTo('/onboarding');
+            break;
+          case 'WAITING':
+            // 추후 가입 대기 페이지로 변경
+            redirectTo('/login');
+            break;
+          case 'APPROVED':
+            // 승인된 경우엔 현재 페이지 그대로 렌더링
+            redirectTo('/home');
+            break;
+          case 'REJECTED':
+            redirectTo('/login');
+            break;
+          default:
+            redirectTo('/login');
+            break;
+        }
+      } catch (error) {
+        console.error('[AuthProvider] auth check failed:', error);
+        clearAuth();
+        redirectTo('/login');
+      }
+    };
+
+    void checkAuth();
+  }, [hydrated, accessToken, pathname, router, setAuth, clearAuth, redirectTo]);
 
   if (!hydrated) {
-    // 추후 로딩 페이지 추가 예정
     return <div>로딩중...</div>;
   }
 

--- a/src/app/providers/AuthProvider.tsx
+++ b/src/app/providers/AuthProvider.tsx
@@ -56,7 +56,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             break;
           case 'APPROVED':
             // 승인된 경우엔 현재 페이지 그대로 렌더링
-            redirectTo('/home');
             break;
           case 'REJECTED':
             redirectTo('/login');

--- a/src/app/providers/AuthProvider.tsx
+++ b/src/app/providers/AuthProvider.tsx
@@ -40,6 +40,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     if (!hydrated) return;
+    let isCancelled = false;
 
     const checkAuth = async () => {
       // 1. 토큰이 없으면 로그인 페이지로 이동
@@ -51,6 +52,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       try {
         // 2. 유효성 검사 API 호출
         const res = await getValidStatus();
+        if (isCancelled) return;
         const { memberId, needOnboarding, memberStatus } = res.data;
         setAuth({ memberId });
 
@@ -64,6 +66,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         const target = redirectRules[memberStatus]?.(pathname);
         if (target && pathname !== target) redirectRef.current(target);
       } catch (err) {
+        if (isCancelled) return;
         console.error('[AuthProvider] auth check failed:', err);
         clearAuth();
         if (pathname !== '/login') redirectRef.current('/login');
@@ -71,6 +74,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     };
 
     void checkAuth();
+    return () => {
+      isCancelled = true;
+    };
   }, [hydrated, accessToken, pathname, router, setAuth, clearAuth, redirectRules]);
 
   if (!hydrated) return <div>로딩중...</div>;

--- a/src/app/providers/AuthProvider.tsx
+++ b/src/app/providers/AuthProvider.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ReactNode, useCallback, useEffect, useRef } from 'react';
+import { ReactNode, useEffect, useMemo, useRef } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
 import { useAuthStore } from '@/features/auth/model/useAuthStore';
 import { useAuthHydrated } from '@/features/auth/model/useAuthHydrated';
@@ -11,30 +11,40 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const pathname = usePathname();
   const { accessToken, setAuth, clearAuth } = useAuthStore();
   const hydrated = useAuthHydrated();
+
+  // 중복 이동 방지용 리다이렉트 상태
   const isRedirecting = useRef(false);
 
-  const redirectTo = useCallback(
-    (path: string) => {
-      if (pathname === path) return;
-      if (isRedirecting.current) return;
-      isRedirecting.current = true;
-      router.replace(path);
-    },
-    [router, pathname],
-  );
+  // 리다이렉트 동작 수행
+  const redirectRef = useRef<(path: string) => void>(() => {});
+  redirectRef.current = (path: string) => {
+    if (pathname === path || isRedirecting.current) return;
+    isRedirecting.current = true;
+    router.replace(path);
+  };
 
-  // 경로가 바뀌면 리다이렉트 가드 초기화
+  // 경로 변경 시 리다이렉트 상태 초기화
   useEffect(() => {
     isRedirecting.current = false;
   }, [pathname]);
+
+  const redirectRules = useMemo(
+    () => ({
+      REGISTERING: () => '/onboarding',
+      WAITING: () => '/login',
+      REJECTED: () => '/login',
+      APPROVED: (path: string) => (path === '/' || path === '/onboarding' ? '/home' : null),
+    }),
+    [],
+  );
 
   useEffect(() => {
     if (!hydrated) return;
 
     const checkAuth = async () => {
-      // 1. 토큰 없으면 로그인 페이지로 이동
+      // 1. 토큰이 없으면 로그인 페이지로 이동
       if (!accessToken) {
-        redirectTo('/login');
+        if (pathname !== '/login') redirectRef.current('/login');
         return;
       }
 
@@ -42,47 +52,27 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         // 2. 유효성 검사 API 호출
         const res = await getValidStatus();
         const { memberId, needOnboarding, memberStatus } = res.data;
-
         setAuth({ memberId });
 
-        // 3. 온보딩 필요 시
-        if (needOnboarding) {
-          redirectTo('/onboarding');
+        // 3. 온보딩이 필요한 경우
+        if (needOnboarding && pathname !== '/onboarding') {
+          redirectRef.current('/onboarding');
           return;
         }
 
-        // 4. 상태별 분기 처리
-        switch (memberStatus) {
-          case 'REGISTERING':
-            redirectTo('/onboarding');
-            break;
-          case 'WAITING':
-            // 추후 가입 대기 페이지로 변경
-            redirectTo('/login');
-            break;
-          case 'APPROVED':
-            // 승인된 경우엔 현재 페이지 그대로 렌더링
-            break;
-          case 'REJECTED':
-            redirectTo('/login');
-            break;
-          default:
-            redirectTo('/login');
-            break;
-        }
-      } catch (error) {
-        console.error('[AuthProvider] auth check failed:', error);
+        // 4. 상태별 리다이렉트 처리
+        const target = redirectRules[memberStatus]?.(pathname);
+        if (target && pathname !== target) redirectRef.current(target);
+      } catch (err) {
+        console.error('[AuthProvider] auth check failed:', err);
         clearAuth();
-        redirectTo('/login');
+        if (pathname !== '/login') redirectRef.current('/login');
       }
     };
 
     void checkAuth();
-  }, [hydrated, accessToken, router, setAuth, clearAuth, redirectTo]);
+  }, [hydrated, accessToken, pathname, router, setAuth, clearAuth, redirectRules]);
 
-  if (!hydrated) {
-    return <div>로딩중...</div>;
-  }
-
+  if (!hydrated) return <div>로딩중...</div>;
   return <>{children}</>;
 }

--- a/src/app/providers/AuthProvider.tsx
+++ b/src/app/providers/AuthProvider.tsx
@@ -22,6 +22,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     [router],
   );
 
+  // 경로가 바뀌면 리다이렉트 가드 초기화
+  useEffect(() => {
+    isRedirecting.current = false;
+  }, [pathname]);
+
   useEffect(() => {
     if (!hydrated) return;
 

--- a/src/app/providers/AuthProvider.tsx
+++ b/src/app/providers/AuthProvider.tsx
@@ -15,11 +15,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const redirectTo = useCallback(
     (path: string) => {
+      if (pathname === path) return;
       if (isRedirecting.current) return;
       isRedirecting.current = true;
       router.replace(path);
     },
-    [router],
+    [router, pathname],
   );
 
   // 경로가 바뀌면 리다이렉트 가드 초기화
@@ -77,7 +78,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     };
 
     void checkAuth();
-  }, [hydrated, accessToken, pathname, router, setAuth, clearAuth, redirectTo]);
+  }, [hydrated, accessToken, router, setAuth, clearAuth, redirectTo]);
 
   if (!hydrated) {
     return <div>로딩중...</div>;

--- a/src/features/auth/api/types.ts
+++ b/src/features/auth/api/types.ts
@@ -1,8 +1,21 @@
+export const MEMBER_STATUS = {
+  REGISTERING: 'REGISTERING', // 가입중
+  WAITING: 'WAITING', // 대기중
+  APPROVED: 'APPROVED', // 승인됨
+  REJECTED: 'REJECTED', // 거절됨
+} as const;
+
+export type MemberStatusType = keyof typeof MEMBER_STATUS;
+
 // 온보딩 필요 여부 응답
 export type ValidStatusResponse = {
   code: number;
   message: string;
-  data: boolean;
+  data: {
+    memberId: number;
+    needOnboarding: boolean;
+    memberStatus: MemberStatusType;
+  };
 };
 
 // 카카오로그인 회원 정보 응답

--- a/src/features/auth/model/types.ts
+++ b/src/features/auth/model/types.ts
@@ -3,10 +3,11 @@ export type AuthData = {
   nickname: string | null;
   email: string | null;
   profileImageUrl: string | null;
+  memberId: number | null;
 };
 
 export type AuthState = AuthData & {
-  setAuth: (auth: AuthData) => void;
+  setAuth: (auth: Partial<AuthData>) => void;
   clearAuth: () => void;
 };
 

--- a/src/features/auth/model/useAuthStore.ts
+++ b/src/features/auth/model/useAuthStore.ts
@@ -7,13 +7,14 @@ const initialState: AuthData = {
   nickname: null,
   email: null,
   profileImageUrl: null,
+  memberId: null,
 };
 
 export const useAuthStore = create<AuthState>()(
   persist(
     (set) => ({
       ...initialState,
-      setAuth: (auth) => set(auth),
+      setAuth: (auth) => set((state) => ({ ...state, ...auth })),
       clearAuth: () => set(initialState),
     }),
     {


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 any가 사용되지 않았습니다
- [x] 스토리북에 추가했습니다 (해당 시)
- [x] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈
- close #116 

## 📌 작업 목적
- 온보딩 완료 시 member_id 저장 및 회원 상태에 따른 페이지 분기 처리

## 🔨 주요 작업 내용
- ValidStatusResponse의 memberStatus 값(REGISTERING, WAITING, APPROVED, REJECTED)에 따라 라우팅을 세분화하도록 AuthProvider와 RootPage의 로직을 개선했습니다.
- 로그인 시 memberId를 Zustand auth-storage 및 localStorage에 저장하고,
이후 memberId 값이 변경되면 AnalyticsProvider에서 자동으로 Amplitude userId로 동기화되도록 구현했습니다.
- isRedirecting 및 useCallback을 사용해 중복 리다이렉션을 방지하고,
회원 상태별로 다음과 같이 이동 경로를 분기합니다.
  - REGISTERING → /onboarding
  - WAITING → /login (추후 변경 예정)
  - APPROVED → /home
  - REJECTED → /login
 
## ⚠️ 기존 문제 
- 기존에는 온보딩 완료 여부만으로 페이지 분기가 이뤄져, 회원의 승인 상태(WAITING, APPROVED, REJECTED)에 따른 세부 분기 처리가 불가능했습니다.

## ☑️ 해결 방법 
- memberStatus 기반 조건 분기 로직을 추가하여, 회원 상태에 맞는 페이지로 자동 이동하도록 구조 개선

## 🧪 테스트 방법
- 로그인 시 `/home` 으로 정상 이동되는지 확인
- `/login`, `/onboarding` 페이지 직접 접근 시 홈으로 리다이렉션되는지 확인
- 홈 화면에서 Amplitude 테스트 버튼 클릭 시, Amplitude > Live Event 탭에서 User ID가 member-{id} 형식으로 정상 표시되는지 확인


## 📷 실행 영상 또는 스크린샷
<img width="450" height="178" alt="image" src="https://github.com/user-attachments/assets/05c07a4f-18db-428e-917a-4fd3dcedfe81" />
<img width="1881" height="459" alt="image" src="https://github.com/user-attachments/assets/d847221a-1048-451e-a7c2-a42efee67fcb" />


## 💬 논의할 점
- REGISTERING, WAITING, APPROVED, REJECTED 각 상태에 따라 어떤 페이지로 보낼 것인지에 대한 논의가 필요합니다!
- 홈 이벤트 테스트 버튼은 전부 확인되면 제거할 예정입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 인증 상태를 API로 검증해 회원 상태(온보딩·승인 등)에 따라 자동으로 이동하는 인증 흐름을 도입했습니다.
  * 홈 화면에 “Amplitude 이벤트 테스트” 버튼을 추가해 이벤트 전송을 직접 확인할 수 있습니다.
  * Amplitude 연동을 강화해 로그인 상태 변경 시 사용자 식별 정보가 실시간으로 반영됩니다.

* **Bug Fixes**
  * 인증 오류 시 인증 정보를 초기화하고 로그인 페이지로 안내하도록 개선했습니다.

* **Style**
  * 로딩 문구를 “로딩 중...”으로 통일하고 불필요한 클라이언트 측 리다이렉트 로직을 간소화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->