### PR TITLE
[FEAT] 피드백 앰플리튜드 로그

### DIFF
--- a/src/app-pages/mypage/settings/feedback/ui/FeedbackPage.tsx
+++ b/src/app-pages/mypage/settings/feedback/ui/FeedbackPage.tsx
@@ -1,8 +1,15 @@
 'use client';
 
+import { useEffect } from 'react';
 import { FeedbackForm } from '@/features/feedback/ui/FeedbackForm';
+import { FEEDBACK_EVENTS } from '@/features/feedback/model/types';
+import { trackFeedbackEvent } from '@/features/feedback/lib/trackFeedbackEvent';
 
 export default function FeedbackPage() {
+  useEffect(() => {
+    trackFeedbackEvent(FEEDBACK_EVENTS.VIEW_FEEDBACK_PAGE, { page_name: window.location.href });
+  }, []);
+
   return (
     <>
       <FeedbackForm />

--- a/src/app-pages/mypage/settings/feedback/ui/FeedbackPage.tsx
+++ b/src/app-pages/mypage/settings/feedback/ui/FeedbackPage.tsx
@@ -7,7 +7,7 @@ import { trackFeedbackEvent } from '@/features/feedback/lib/trackFeedbackEvent';
 
 export default function FeedbackPage() {
   useEffect(() => {
-    trackFeedbackEvent(FEEDBACK_EVENTS.VIEW_FEEDBACK_PAGE, { page_name: window.location.href });
+    trackFeedbackEvent(FEEDBACK_EVENTS.VIEW_FEEDBACK_PAGE, { page_name: 'feedback' });
   }, []);
 
   return (

--- a/src/features/feedback/lib/trackFeedbackEvent.ts
+++ b/src/features/feedback/lib/trackFeedbackEvent.ts
@@ -1,0 +1,4 @@
+import { createDomainTracker } from '@/shared/lib/createDomainTracker';
+import { FeedbackEventPropsMap } from './../model/types';
+
+export const trackFeedbackEvent = createDomainTracker<FeedbackEventPropsMap>();

--- a/src/features/feedback/model/types.ts
+++ b/src/features/feedback/model/types.ts
@@ -1,0 +1,13 @@
+// Amplitude 피드백 이벤트 이름
+export const FEEDBACK_EVENTS = {
+  VIEW_FEEDBACK_PAGE: 'view_feedback',
+  SUBMITTED_FEEDBACK_TEXT_LENGTH: 'enter_feedback_text',
+  SUBMIT_FEEDBACK_RESULT: 'click_feedback_submit',
+};
+
+// Amplitude 이벤트별 속성 타입 매핑
+export type FeedbackEventPropsMap = {
+  [FEEDBACK_EVENTS.VIEW_FEEDBACK_PAGE]: { page_name: string };
+  [FEEDBACK_EVENTS.SUBMITTED_FEEDBACK_TEXT_LENGTH]: { text_length: number };
+  [FEEDBACK_EVENTS.SUBMIT_FEEDBACK_RESULT]: { success: boolean };
+};

--- a/src/features/feedback/model/types.ts
+++ b/src/features/feedback/model/types.ts
@@ -3,7 +3,7 @@ export const FEEDBACK_EVENTS = {
   VIEW_FEEDBACK_PAGE: 'view_feedback',
   SUBMITTED_FEEDBACK_TEXT_LENGTH: 'enter_feedback_text',
   SUBMIT_FEEDBACK_RESULT: 'click_feedback_submit',
-};
+} as const;
 
 // Amplitude 이벤트별 속성 타입 매핑
 export type FeedbackEventPropsMap = {

--- a/src/features/feedback/model/types.ts
+++ b/src/features/feedback/model/types.ts
@@ -2,12 +2,10 @@
 export const FEEDBACK_EVENTS = {
   VIEW_FEEDBACK_PAGE: 'view_feedback',
   SUBMITTED_FEEDBACK_TEXT_LENGTH: 'enter_feedback_text',
-  SUBMIT_FEEDBACK_RESULT: 'click_feedback_submit',
 } as const;
 
 // Amplitude 이벤트별 속성 타입 매핑
 export type FeedbackEventPropsMap = {
   [FEEDBACK_EVENTS.VIEW_FEEDBACK_PAGE]: { page_name: string };
   [FEEDBACK_EVENTS.SUBMITTED_FEEDBACK_TEXT_LENGTH]: { text_length: number };
-  [FEEDBACK_EVENTS.SUBMIT_FEEDBACK_RESULT]: { success: boolean };
 };

--- a/src/features/feedback/ui/FeedbackForm.tsx
+++ b/src/features/feedback/ui/FeedbackForm.tsx
@@ -4,18 +4,31 @@ import { useState } from 'react';
 import { SolidButton } from '@/shared/ui/solid-button/SolidButton';
 import { usePostFeedback } from '@/features/feedback/model/usePostFeedback';
 import { TextArea } from '@/shared/ui/text-area/TextArea';
+import { FEEDBACK_EVENTS } from '../model/types';
+import { trackFeedbackEvent } from '../lib/trackFeedbackEvent';
 
 export const FeedbackForm = () => {
   const [content, setContent] = useState('');
   const { mutate: submit, isPending } = usePostFeedback();
 
   const handleSubmit = () => {
-    if (!content.trim() || isPending) return;
+    const trimmed = content.trim();
+    if (!trimmed || isPending) return;
+
+    const textLength = trimmed.length;
+
     submit(
       { content },
       {
         onSuccess: () => {
+          trackFeedbackEvent(FEEDBACK_EVENTS.SUBMIT_FEEDBACK_RESULT, { success: true });
+          trackFeedbackEvent(FEEDBACK_EVENTS.SUBMITTED_FEEDBACK_TEXT_LENGTH, {
+            text_length: textLength,
+          });
           setContent('');
+        },
+        onError: () => {
+          trackFeedbackEvent(FEEDBACK_EVENTS.SUBMIT_FEEDBACK_RESULT, { success: false });
         },
       },
     );

--- a/src/features/feedback/ui/FeedbackForm.tsx
+++ b/src/features/feedback/ui/FeedbackForm.tsx
@@ -4,8 +4,8 @@ import { useState } from 'react';
 import { SolidButton } from '@/shared/ui/solid-button/SolidButton';
 import { usePostFeedback } from '@/features/feedback/model/usePostFeedback';
 import { TextArea } from '@/shared/ui/text-area/TextArea';
-import { FEEDBACK_EVENTS } from '../model/types';
-import { trackFeedbackEvent } from '../lib/trackFeedbackEvent';
+import { FEEDBACK_EVENTS } from '@/features/feedback/model/types';
+import { trackFeedbackEvent } from '@/features/feedback/lib/trackFeedbackEvent';
 
 export const FeedbackForm = () => {
   const [content, setContent] = useState('');
@@ -18,7 +18,7 @@ export const FeedbackForm = () => {
     const textLength = trimmed.length;
 
     submit(
-      { content },
+      { content: trimmed },
       {
         onSuccess: () => {
           trackFeedbackEvent(FEEDBACK_EVENTS.SUBMIT_FEEDBACK_RESULT, { success: true });

--- a/src/features/feedback/ui/FeedbackForm.tsx
+++ b/src/features/feedback/ui/FeedbackForm.tsx
@@ -21,7 +21,6 @@ export const FeedbackForm = () => {
       { content: trimmed },
       {
         onSuccess: () => {
-          trackFeedbackEvent(FEEDBACK_EVENTS.SUBMIT_FEEDBACK_RESULT, { success: true });
           trackFeedbackEvent(FEEDBACK_EVENTS.SUBMITTED_FEEDBACK_TEXT_LENGTH, {
             text_length: textLength,
           });

--- a/src/features/feedback/ui/FeedbackForm.tsx
+++ b/src/features/feedback/ui/FeedbackForm.tsx
@@ -26,9 +26,7 @@ export const FeedbackForm = () => {
           });
           setContent('');
         },
-        onError: () => {
-          trackFeedbackEvent(FEEDBACK_EVENTS.SUBMIT_FEEDBACK_RESULT, { success: false });
-        },
+        onError: () => {},
       },
     );
   };


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 any가 사용되지 않았습니다
- [x] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈
- close #112 

## 📌 작업 목적
- amplitude 피드백 기능 관련 로그 심기

## 🔨 주요 작업 내용
- 페이지 처음 마운트 시 페이지 경로 로그
- 피드백 제출 성공 시 성공 여부와 제출된 피드백 글자수 로그
- 피드백 제출 실패 시 실패 로그 전달

## 🧪 테스트 방법
1. `pnpm run dev` 후 `http://localhost:3000/mypage/settings` 에 접속
2. 피드백 보내기 목록 아이템 클릭 : view_feedback 이벤트 발생하는지 amplitude에서 확인
3. 피드백 제출 성공 시 click_feedback_submit과 enter_feedback_text 가 같이 찍히고 제출한 글자수와 enter_feedback_text 이벤트의 속성(text_length)가 같은지 확인
4. 피드백 제출 실패 시 click_feedback_submit가 아래 예시 사진처럼 이벤트 속성이 success: false로 나오는지 확인

## 📷 실행 영상 또는 스크린샷
<img width="500" height="300" alt="image" src="https://github.com/user-attachments/assets/5185b04a-83cf-4d6c-ac05-7b142520fd45" />
<img width="500" height="400" alt="image" src="https://github.com/user-attachments/assets/d163ed55-de43-4161-8583-ec98382b9241" />
<img width="500" height="400" alt="image" src="https://github.com/user-attachments/assets/83c1c596-6770-4db0-8654-ea7a5b115bbf" />


## 💬 논의할 점
- 개발 모드에서 useEffect 는 마운트 → 언마운트 → 재마운트를 한 번 더 실행해서 이펙트가 2번 돈다고 합니다! 그래서 로컬에서 실행에서 테스트 시에 view_feedback 로그가 두 번 찍힙니당

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 피드백 페이지 방문 및 제출 관련 사용자 행위를 자동으로 수집하는 이벤트 추적이 추가되었습니다(페이지뷰, 제출 텍스트 길이, 제출 결과).

- **버그 수정**
  - 입력값 트리밍 적용으로 공백만 있는 제출이 차단됩니다.
  - 유효성 검사와 제출 로직이 트리밍된 텍스트 기준으로 일치하도록 개선되었습니다.
  - 제출 성공/오류 시 관련 이벤트가 적절히 기록되도록 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->