### PR TITLE
[FEAT] 회칙 앰플리튜드 로그

### DIFF
--- a/app/(sub)/layout.tsx
+++ b/app/(sub)/layout.tsx
@@ -4,7 +4,7 @@ export default function SubLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex h-full w-full flex-col">
       <AppHeader />
-      <section className="h-full w-full flex-1">{children}</section>
+      <section className="h-full w-full flex-1 overflow-hidden">{children}</section>
     </div>
   );
 }

--- a/src/app-pages/bylaws/ui/BylawsPage.tsx
+++ b/src/app-pages/bylaws/ui/BylawsPage.tsx
@@ -12,7 +12,7 @@ export default function BylawsPage() {
   useEffect(() => {
     if (trackRef.current) return;
     trackRef.current = true;
-    trackBylawsEvent(BYLAWS_EVENTS.VIEW_RULES_MAIN, { page_name: '회칙 메인' });
+    trackBylawsEvent(BYLAWS_EVENTS.VIEW_RULES_MAIN, { page_name: 'bylaws' });
   }, []);
 
   // 스크롤 퍼센트 트래킹

--- a/src/app-pages/bylaws/ui/BylawsPage.tsx
+++ b/src/app-pages/bylaws/ui/BylawsPage.tsx
@@ -12,7 +12,6 @@ export default function BylawsPage() {
   useEffect(() => {
     if (trackRef.current) return;
     trackRef.current = true;
-    console.log('📄 페이지 진입 트래킹 전송');
     trackBylawsEvent(BYLAWS_EVENTS.VIEW_RULES_MAIN, { page_name: '회칙 메인' });
   }, []);
 
@@ -30,7 +29,6 @@ export default function BylawsPage() {
     const fire = (t: number) => {
       if (!sent.has(t)) {
         sent.add(t);
-        console.log(`🔥 ${t}% 트래킹 이벤트 전송`);
         trackBylawsEvent(BYLAWS_EVENTS.SCROLL_RULES_PAGE, { percent: t });
       }
     };
@@ -63,7 +61,6 @@ export default function BylawsPage() {
     const interval = setInterval(() => {
       const cur = el.scrollHeight;
       if (cur !== prevScrollHeight) {
-        console.log('📏 scrollHeight 변경 감지 → baseline 재설정');
         prevScrollHeight = cur;
         const p = getPercent();
         sent = new Set(THRESHOLDS.filter((t) => t <= p));

--- a/src/app-pages/bylaws/ui/BylawsPage.tsx
+++ b/src/app-pages/bylaws/ui/BylawsPage.tsx
@@ -1,10 +1,24 @@
-import { AccordionGroup } from '@/shared/ui/accordion/AccordionGroup';
+'use client';
+
+import { BylawsAccordionGroup } from '@/features/bylaws/ui/BylawsAccordionGroup';
 import { bylawsData } from '@/app-pages/bylaws/model/data';
+import { useEffect, useRef } from 'react';
+import { trackBylawsEvent } from '@/features/bylaws/lib/trackBylawsEvent';
+import { BYLAWS_EVENTS } from '@/features/bylaws/model/types';
 
 export default function BylawsPage() {
+  // 페이지뷰 트래킹을 위한 ref
+  const trackRef = useRef(false);
+
+  useEffect(() => {
+    if (trackRef.current) return;
+    trackRef.current = true;
+    trackBylawsEvent(BYLAWS_EVENTS.VIEW_RULES_MAIN, { page_name: '회칙 메인' });
+  }, []);
+
   return (
     <div className="flex h-full flex-col overflow-y-auto pt-[1.25rem]">
-      <AccordionGroup accordions={bylawsData} />
+      <BylawsAccordionGroup accordions={bylawsData} />
     </div>
   );
 }

--- a/src/app-pages/bylaws/ui/BylawsPage.tsx
+++ b/src/app-pages/bylaws/ui/BylawsPage.tsx
@@ -7,15 +7,18 @@ import { trackBylawsEvent } from '@/features/bylaws/lib/trackBylawsEvent';
 import { BYLAWS_EVENTS } from '@/features/bylaws/model/types';
 import { useDynamicScrollTracking } from '@/shared/hooks/useDynamicScrollTracking';
 import { useCallback } from 'react';
+import { usePageName } from '@/shared/analytics/lib/getPageName';
 
 export default function BylawsPage() {
   // 페이지 진입 트래킹 (최초 1회)
   const trackRef = useRef(false);
+  const pageName = usePageName();
+
   useEffect(() => {
     if (trackRef.current) return;
     trackRef.current = true;
-    trackBylawsEvent(BYLAWS_EVENTS.VIEW_RULES_MAIN, { page_name: 'bylaws' });
-  }, []);
+    trackBylawsEvent(BYLAWS_EVENTS.VIEW_RULES_MAIN, { page_name: pageName });
+  }, [pageName]);
 
   // 스크롤 퍼센트 트래킹
   const handleScrollThreshold = useCallback((percent: number) => {

--- a/src/app-pages/bylaws/ui/BylawsPage.tsx
+++ b/src/app-pages/bylaws/ui/BylawsPage.tsx
@@ -5,6 +5,7 @@ import { bylawsData } from '@/app-pages/bylaws/model/data';
 import { useEffect, useRef } from 'react';
 import { trackBylawsEvent } from '@/features/bylaws/lib/trackBylawsEvent';
 import { BYLAWS_EVENTS } from '@/features/bylaws/model/types';
+import { useDynamicScrollTracking } from '@/shared/hooks/useDynamicScrollTracking';
 
 export default function BylawsPage() {
   // 페이지 진입 트래킹 (최초 1회)
@@ -16,63 +17,9 @@ export default function BylawsPage() {
   }, []);
 
   // 스크롤 퍼센트 트래킹
-  const scrollerRef = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    const el = scrollerRef.current;
-    if (!el) return;
-
-    const THRESHOLDS = [0, 25, 50, 75, 100];
-    let sent = new Set<number>();
-    let prevScrollHeight = el.scrollHeight;
-
-    // 퍼센트 기준에 도달했을 때 이벤트 전송
-    const fire = (t: number) => {
-      if (!sent.has(t)) {
-        sent.add(t);
-        trackBylawsEvent(BYLAWS_EVENTS.SCROLL_RULES_PAGE, { percent: t });
-      }
-    };
-
-    // 현재 스크롤 퍼센트 계산
-    const getPercent = () => {
-      const max = el.scrollHeight - el.clientHeight;
-      if (max <= 0) return 0;
-
-      const ratio = el.scrollTop / max;
-      // 거의 끝까지 내렸다면 강제로 100으로 처리
-      if (ratio >= 0.99) return 100;
-
-      return Math.floor((el.scrollTop / max) * 100);
-    };
-
-    // 스크롤 시 퍼센트 체크
-    const onScroll = () => {
-      const p = getPercent();
-      THRESHOLDS.forEach((t) => {
-        if (p >= t && !sent.has(t)) fire(t);
-      });
-    };
-
-    // 초기 0% 트래킹
-    fire(0);
-    el.addEventListener('scroll', onScroll, { passive: true });
-
-    // scrollHeight 변화 감시 (아코디언 열림 등)
-    // Note: 페이지 높이 변경 시 sent를 재설정하여, 새로운 높이 기준으로 임계치를 다시 트래킹
-    const interval = setInterval(() => {
-      const cur = el.scrollHeight;
-      if (cur !== prevScrollHeight) {
-        prevScrollHeight = cur;
-        const p = getPercent();
-        sent = new Set(THRESHOLDS.filter((t) => t <= p));
-      }
-    }, 1000);
-
-    return () => {
-      el.removeEventListener('scroll', onScroll);
-      clearInterval(interval);
-    };
-  }, []);
+  const scrollerRef = useDynamicScrollTracking<HTMLDivElement>((percent) => {
+    trackBylawsEvent(BYLAWS_EVENTS.SCROLL_RULES_PAGE, { percent });
+  });
 
   return (
     <main

--- a/src/app-pages/bylaws/ui/BylawsPage.tsx
+++ b/src/app-pages/bylaws/ui/BylawsPage.tsx
@@ -6,6 +6,7 @@ import { useEffect, useRef } from 'react';
 import { trackBylawsEvent } from '@/features/bylaws/lib/trackBylawsEvent';
 import { BYLAWS_EVENTS } from '@/features/bylaws/model/types';
 import { useDynamicScrollTracking } from '@/shared/hooks/useDynamicScrollTracking';
+import { useCallback } from 'react';
 
 export default function BylawsPage() {
   // 페이지 진입 트래킹 (최초 1회)
@@ -17,9 +18,11 @@ export default function BylawsPage() {
   }, []);
 
   // 스크롤 퍼센트 트래킹
-  const scrollerRef = useDynamicScrollTracking<HTMLDivElement>((percent) => {
+  const handleScrollThreshold = useCallback((percent: number) => {
     trackBylawsEvent(BYLAWS_EVENTS.SCROLL_RULES_PAGE, { percent });
-  });
+  }, []);
+
+  const scrollerRef = useDynamicScrollTracking<HTMLDivElement>(handleScrollThreshold);
 
   return (
     <main

--- a/src/app-pages/bylaws/ui/BylawsPage.tsx
+++ b/src/app-pages/bylaws/ui/BylawsPage.tsx
@@ -7,17 +7,77 @@ import { trackBylawsEvent } from '@/features/bylaws/lib/trackBylawsEvent';
 import { BYLAWS_EVENTS } from '@/features/bylaws/model/types';
 
 export default function BylawsPage() {
-  // 페이지뷰 트래킹을 위한 ref
+  // 페이지 진입 트래킹 (최초 1회)
   const trackRef = useRef(false);
-
   useEffect(() => {
     if (trackRef.current) return;
     trackRef.current = true;
+    console.log('📄 페이지 진입 트래킹 전송');
     trackBylawsEvent(BYLAWS_EVENTS.VIEW_RULES_MAIN, { page_name: '회칙 메인' });
   }, []);
 
+  // 스크롤 퍼센트 트래킹
+  const scrollerRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const el = scrollerRef.current;
+    if (!el) return;
+
+    const THRESHOLDS = [0, 25, 50, 75, 100];
+    let sent = new Set<number>();
+    let prevScrollHeight = el.scrollHeight;
+
+    // 퍼센트 기준에 도달했을 때 이벤트 전송
+    const fire = (t: number) => {
+      if (!sent.has(t)) {
+        sent.add(t);
+        console.log(`🔥 ${t}% 트래킹 이벤트 전송`);
+        trackBylawsEvent(BYLAWS_EVENTS.SCROLL_RULES_PAGE, { percent: t });
+      }
+    };
+
+    // 현재 스크롤 퍼센트 계산
+    const getPercent = () => {
+      const max = el.scrollHeight - el.clientHeight;
+      if (max <= 0) return 0;
+
+      const ratio = el.scrollTop / max;
+      // 거의 끝까지 내렸다면 강제로 100으로 처리
+      if (ratio >= 0.99) return 100;
+
+      return Math.floor((el.scrollTop / max) * 100);
+    };
+
+    // 스크롤 시 퍼센트 체크
+    const onScroll = () => {
+      const p = getPercent();
+      THRESHOLDS.forEach((t) => {
+        if (p >= t && !sent.has(t)) fire(t);
+      });
+    };
+
+    // 초기 0% 트래킹
+    fire(0);
+    el.addEventListener('scroll', onScroll, { passive: true });
+
+    // scrollHeight 변화 감시 (아코디언 열림 등)
+    const interval = setInterval(() => {
+      const cur = el.scrollHeight;
+      if (cur !== prevScrollHeight) {
+        console.log('📏 scrollHeight 변경 감지 → baseline 재설정');
+        prevScrollHeight = cur;
+        const p = getPercent();
+        sent = new Set(THRESHOLDS.filter((t) => t <= p));
+      }
+    }, 1000);
+
+    return () => {
+      el.removeEventListener('scroll', onScroll);
+      clearInterval(interval);
+    };
+  }, []);
+
   return (
-    <div className="flex h-full flex-col overflow-y-auto pt-[1.25rem]">
+    <div ref={scrollerRef} className="h-full overflow-y-auto pt-[1.25rem]">
       <BylawsAccordionGroup accordions={bylawsData} />
     </div>
   );

--- a/src/app-pages/bylaws/ui/BylawsPage.tsx
+++ b/src/app-pages/bylaws/ui/BylawsPage.tsx
@@ -58,6 +58,7 @@ export default function BylawsPage() {
     el.addEventListener('scroll', onScroll, { passive: true });
 
     // scrollHeight 변화 감시 (아코디언 열림 등)
+    // Note: 페이지 높이 변경 시 sent를 재설정하여, 새로운 높이 기준으로 임계치를 다시 트래킹
     const interval = setInterval(() => {
       const cur = el.scrollHeight;
       if (cur !== prevScrollHeight) {
@@ -74,8 +75,13 @@ export default function BylawsPage() {
   }, []);
 
   return (
-    <div ref={scrollerRef} className="h-full overflow-y-auto pt-[1.25rem]">
+    <main
+      ref={scrollerRef}
+      className="h-full overflow-y-auto pt-[1.25rem]"
+      role="main"
+      aria-label="회칙 목록"
+    >
       <BylawsAccordionGroup accordions={bylawsData} />
-    </div>
+    </main>
   );
 }

--- a/src/features/bylaws/lib/trackBylawsEvent.ts
+++ b/src/features/bylaws/lib/trackBylawsEvent.ts
@@ -1,0 +1,4 @@
+import { createDomainTracker } from '@/shared/lib/createDomainTracker';
+import { BylawsEventPropsMap } from '../model/types';
+
+export const trackBylawsEvent = createDomainTracker<BylawsEventPropsMap>();

--- a/src/features/bylaws/model/types.ts
+++ b/src/features/bylaws/model/types.ts
@@ -6,3 +6,21 @@ export type AccordionItemData = {
   scoreChange?: string;
   descriptions?: string[];
 };
+
+/**
+ *  이벤트 이름
+ */
+export const BYLAWS_EVENTS = {
+  VIEW_RULES_MAIN: 'view_rules_main',
+  CLICK_RULES_SECTION: 'click_rules_section',
+  SCROLL_RULES_PAGE: 'scroll_rules_page',
+} as const;
+
+/**
+ * 이벤트별 속성 타입 매핑
+ */
+export type BylawsEventPropsMap = {
+  [BYLAWS_EVENTS.VIEW_RULES_MAIN]: { page_name: string };
+  [BYLAWS_EVENTS.CLICK_RULES_SECTION]: { section_name: string };
+  [BYLAWS_EVENTS.SCROLL_RULES_PAGE]: { percent: number };
+};

--- a/src/features/bylaws/ui/BylawsAccordionGroup.tsx
+++ b/src/features/bylaws/ui/BylawsAccordionGroup.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { AccordionGroup } from '@/shared/ui/accordion/AccordionGroup';
+import { AccordionGroupProps } from '@/shared/ui/accordion/types';
+import { trackBylawsEvent } from '@/features/bylaws/lib/trackBylawsEvent';
+import { BYLAWS_EVENTS } from '@/features/bylaws/model/types';
+
+export const BylawsAccordionGroup = ({ accordions }: AccordionGroupProps) => {
+  const handleClick = (title: string, isOpen: boolean) => {
+    if (isOpen) {
+      trackBylawsEvent(BYLAWS_EVENTS.CLICK_RULES_SECTION, {
+        section_name: title,
+      });
+    }
+  };
+
+  // accordionGroup이 render만 담당하므로,
+  // children으로 트래킹용 클릭 핸들러를 넘긴다.
+  const accordionsWithTracking = accordions.map((section) => ({
+    ...section,
+    onToggle: (isOpen: boolean) => handleClick(section.title, isOpen),
+  }));
+
+  return <AccordionGroup accordions={accordionsWithTracking} />;
+};

--- a/src/shared/analytics/lib/getPageName.ts
+++ b/src/shared/analytics/lib/getPageName.ts
@@ -1,11 +1,11 @@
 import { usePathname } from 'next/navigation';
 
 /**
- * 데이터 분석용 page_name 생성 훅
+ * 데이터 분석 용 page_name(현재 pathname) 제공 훅
  *
  * @description
- * - Amplitude, GA, 내부 로그 트래킹용 page_name을 생성하기 위한 전용 유틸입니다.
- * - 실제 UI 경로나 라우팅과 분리하여, 분석 목적의 페이지 식별자 관리만 담당합니다.
+ * - 현재 경로(pathname)를 분석용 page_name으로 제공하는 래퍼 유틸입니다.
+ * - 향후 pathname → 분석 페이지명 매핑 로직 추가 시, 이 훅만 수정하면 모든 트래킹에 반영됩니다.
  *
  * @returns {string} 분석용 page_name (예: "/mypage/activity-score/bylaws")
  *

--- a/src/shared/analytics/lib/getPageName.ts
+++ b/src/shared/analytics/lib/getPageName.ts
@@ -1,5 +1,18 @@
 import { usePathname } from 'next/navigation';
 
+/**
+ * 데이터 분석용 page_name 생성 훅
+ *
+ * @description
+ * - Amplitude, GA, 내부 로그 트래킹용 page_name을 생성하기 위한 전용 유틸입니다.
+ * - 실제 UI 경로나 라우팅과 분리하여, 분석 목적의 페이지 식별자 관리만 담당합니다.
+ *
+ * @returns {string} 분석용 page_name (예: "/mypage/activity-score/bylaws")
+ *
+ * @example
+ * const pageName = usePageName();
+ * trackCommonEvent('VIEW_PAGE', { page_name: pageName });
+ */
 export function usePageName() {
   const pathname = usePathname();
   return pathname;

--- a/src/shared/analytics/lib/getPageName.ts
+++ b/src/shared/analytics/lib/getPageName.ts
@@ -1,0 +1,6 @@
+import { usePathname } from 'next/navigation';
+
+export function usePageName() {
+  const pathname = usePathname();
+  return pathname;
+}

--- a/src/shared/hooks/useDynamicScrollTracking.ts
+++ b/src/shared/hooks/useDynamicScrollTracking.ts
@@ -3,11 +3,9 @@
 import { useEffect, useRef } from 'react';
 
 /**
- * useScrollTrackingDynamic
- *
- * - 스크롤 퍼센트 기준 임계치(0/25/50/75/100%) 도달 시 콜백 실행
- * - scrollHeight 변화(아코디언 열림 등)에 따라 퍼센트 기준 자동 재계산
- * - 퍼센트 감소 및 재트래킹 정상 작동
+ * 스크롤 퍼센트 기준 임계치(0/25/50/75/100%) 도달 시 콜백 실행
+ * scrollHeight 변화(아코디언 열림 등)에 따라 퍼센트 기준 자동 재계산
+ * 퍼센트 감소 및 재트래킹 정상 작동
  */
 export function useDynamicScrollTracking<T extends HTMLElement>(
   onThresholdReach: (percent: number) => void,

--- a/src/shared/hooks/useDynamicScrollTracking.ts
+++ b/src/shared/hooks/useDynamicScrollTracking.ts
@@ -26,7 +26,9 @@ export function useDynamicScrollTracking<T extends HTMLElement>(
     const fire = (t: number) => {
       if (!sent.has(t)) {
         sent.add(t);
-        console.log(`[scroll-tracking] fire → ${t}%`);
+        if (process.env.NODE_ENV === 'development') {
+          console.log(`[scroll-tracking] fire → ${t}%`);
+        }
         onThresholdReach(t);
       }
     };
@@ -59,7 +61,9 @@ export function useDynamicScrollTracking<T extends HTMLElement>(
     const interval = setInterval(() => {
       const cur = el.scrollHeight;
       if (cur !== prevScrollHeight) {
-        console.log(`[scroll-tracking] scrollHeight changed → ${prevScrollHeight} → ${cur}`);
+        if (process.env.NODE_ENV === 'development') {
+          console.log(`[scroll-tracking] scrollHeight changed → ${prevScrollHeight} → ${cur}`);
+        }
         prevScrollHeight = cur;
         const p = getPercent();
         sent = new Set(THRESHOLDS.filter((t) => t <= p));

--- a/src/shared/hooks/useDynamicScrollTracking.ts
+++ b/src/shared/hooks/useDynamicScrollTracking.ts
@@ -1,0 +1,76 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+/**
+ * useScrollTrackingDynamic
+ *
+ * - 스크롤 퍼센트 기준 임계치(0/25/50/75/100%) 도달 시 콜백 실행
+ * - scrollHeight 변화(아코디언 열림 등)에 따라 퍼센트 기준 자동 재계산
+ * - 퍼센트 감소 및 재트래킹 정상 작동
+ */
+export function useDynamicScrollTracking<T extends HTMLElement>(
+  onThresholdReach: (percent: number) => void,
+) {
+  const scrollerRef = useRef<T>(null);
+
+  useEffect(() => {
+    const el = scrollerRef.current;
+    if (!el) return;
+
+    const THRESHOLDS = [0, 25, 50, 75, 100];
+    let sent = new Set<number>();
+    let prevScrollHeight = el.scrollHeight;
+
+    // 퍼센트 기준 도달 시 이벤트 전송
+    const fire = (t: number) => {
+      if (!sent.has(t)) {
+        sent.add(t);
+        console.log(`[scroll-tracking] fire → ${t}%`);
+        onThresholdReach(t);
+      }
+    };
+
+    // 현재 스크롤 퍼센트 계산
+    const getPercent = () => {
+      const max = el.scrollHeight - el.clientHeight;
+      if (max <= 0) return 0;
+
+      const ratio = el.scrollTop / max;
+      if (ratio >= 0.99) return 100; // 거의 끝까지 내렸다면 강제로 100 처리
+
+      return Math.floor((el.scrollTop / max) * 100);
+    };
+
+    // 스크롤 시 퍼센트 체크
+    const onScroll = () => {
+      const p = getPercent();
+      THRESHOLDS.forEach((t) => {
+        if (p >= t && !sent.has(t)) fire(t);
+      });
+    };
+
+    // 초기 0% 트래킹
+    fire(0);
+    el.addEventListener('scroll', onScroll, { passive: true });
+
+    // scrollHeight 변화 감시 (아코디언 열림 등)
+    // Note: 페이지 높이 변경 시 sent를 재설정하여, 새로운 높이 기준으로 임계치를 다시 트래킹
+    const interval = setInterval(() => {
+      const cur = el.scrollHeight;
+      if (cur !== prevScrollHeight) {
+        console.log(`[scroll-tracking] scrollHeight changed → ${prevScrollHeight} → ${cur}`);
+        prevScrollHeight = cur;
+        const p = getPercent();
+        sent = new Set(THRESHOLDS.filter((t) => t <= p));
+      }
+    }, 1000);
+
+    return () => {
+      el.removeEventListener('scroll', onScroll);
+      clearInterval(interval);
+    };
+  }, [onThresholdReach]);
+
+  return scrollerRef;
+}

--- a/src/shared/ui/accordion/Accordion.tsx
+++ b/src/shared/ui/accordion/Accordion.tsx
@@ -41,6 +41,7 @@ export function Accordion({
   return (
     <div className={`${isOpen ? '' : 'border-border-normal border-b'}`}>
       <button
+        type="button"
         disabled={isDisabled}
         onClick={handleToggle}
         className="disabled:bg-background-quaternary text-foreground-normal text-body-16-600--1 flex w-full cursor-pointer items-center justify-between p-[1rem] disabled:cursor-not-allowed"

--- a/src/shared/ui/accordion/Accordion.tsx
+++ b/src/shared/ui/accordion/Accordion.tsx
@@ -18,10 +18,17 @@ export function Accordion({
   isDisabled = false,
   children,
   renderTitle,
+  onToggle,
 }: AccordionProps) {
   const [isOpen, setIsOpen] = useState(defaultOpen);
   const [maxHeight, setMaxHeight] = useState('0px');
   const contentRef = useRef<HTMLDivElement>(null);
+
+  const handleToggle = () => {
+    const next = !isOpen;
+    setIsOpen(next);
+    onToggle?.(next); // 토글 상태 변화를 외부에 알림
+  };
 
   useEffect(() => {
     if (isOpen && contentRef.current) {
@@ -35,7 +42,7 @@ export function Accordion({
     <div className={`${isOpen ? '' : 'border-border-normal border-b'}`}>
       <button
         disabled={isDisabled}
-        onClick={() => setIsOpen(!isOpen)}
+        onClick={handleToggle}
         className="disabled:bg-background-quaternary text-foreground-normal text-body-16-600--1 flex w-full cursor-pointer items-center justify-between p-[1rem] disabled:cursor-not-allowed"
       >
         <span>

--- a/src/shared/ui/accordion/AccordionGroup.tsx
+++ b/src/shared/ui/accordion/AccordionGroup.tsx
@@ -16,6 +16,7 @@ export const AccordionGroup = ({ accordions }: AccordionGroupProps) => {
           title={accordion.title}
           isDisabled={accordion.isDisabled}
           renderTitle={accordion.renderTitle}
+          onToggle={accordion.onToggle}
         >
           {accordion.children}
         </Accordion>

--- a/src/shared/ui/accordion/types.ts
+++ b/src/shared/ui/accordion/types.ts
@@ -4,6 +4,7 @@ export type AccordionGroupData = {
   isDisabled?: boolean;
   children: React.ReactNode;
   renderTitle?: (index: number | undefined, title: string) => React.ReactNode;
+  onToggle?: (isOpen: boolean) => void;
 };
 
 // 아코디언 그룹 컴포넌트가 받을 props
@@ -19,4 +20,5 @@ export type AccordionProps = {
   isDisabled?: boolean;
   children: React.ReactNode;
   renderTitle?: (index: number | undefined, title: string) => React.ReactNode;
+  onToggle?: (isOpen: boolean) => void;
 };


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 any가 사용되지 않았습니다
- [x] 스토리북에 추가했습니다 (해당 시)
- [x] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈
- close #120

## 📌 작업 목적
- 회칙 목록, 회칙 카테고리 클릭, 회칙 스크롤 로그 심기

## 🔨 주요 작업 내용
- 회칙 목록 : 회칙 페이지 진입 시 이벤트 전송
- 회칙 카테고리 클릭 : 회칙 아코디언 오픈 시 회칙 제목 전송
- 회칙 스크롤 : 페이지 단위 스크롤 퍼센트 트래킹, 0, 25, 50, 75, 100% 스크롤마다 전송
- 동적 스크롤 트래킹 커스텀훅화
- page_name 반환 함수 유틸화

## 🧪 테스트 방법
- `http://localhost:3000/mypage/activity-score/bylaws` 접속 후 앰플리튜드 라이브 이벤트 창에서 로그 확인하기
- 페이지 진입시 -> view_rules_main 이벤트 속성 : 회칙 메인
- 회칙 섹션 클릭시 -> click_rules_section 이벤트 속성 : 출결 안내 | 활동 점수 득점 ...
- 스크롤시 -> scroll_rules_page 이벤트 속성 : 0, 25, 50, 75, 100, 개발 모드에서는 strict mode가 적용되어 있어 0% 로그가 두 번 전송됩니다. 정상적인 작동이라고 봐주시면 됩니다!

## 📷 실행 영상 또는 스크린샷
- 로그는 삭제하고 푸시하였습니다!
https://github.com/user-attachments/assets/5e2f8ade-3d8b-4519-99ca-55cca1bd2b37

## 💬 논의할 점
- 추후 성능 개선을 위해 스크롤 감지에 debouncing을 적용해볼 수 있을 것 같습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 규정(Bylaws) 페이지에 일회성 페이지뷰 및 스크롤 퍼센트(0/25/50/75/100%) 기반 이벤트 트래킹 추가.
  * 섹션별 아코디언 토글 이벤트 트래킹을 위한 그룹 컴포넌트 추가.
  * 현재 경로를 제공하는 페이지명 훅 추가.

* **개선**
  * 스크롤 컨테이너 높이 변동 감지로 임계값 재계산·재발화 지원해 수집 정확도 향상.

* **UI**
  * 아코디언에 토글 콜백 지원 추가 및 메인 영역에 ARIA 레이블 적용.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->