### PR TITLE
[HOTFIX] 게시글 목록 조회 화면 스크롤 버그 수정

### DIFF
--- a/app/(sub)/layout.tsx
+++ b/app/(sub)/layout.tsx
@@ -4,7 +4,7 @@ export default function SubLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex h-full w-full flex-col">
       <AppHeader />
-      <section className="h-full w-full flex-1">{children}</section>
+      <section className="h-full w-full flex-1 overflow-hidden">{children}</section>
     </div>
   );
 }

--- a/src/app-pages/mypage/settings/my-posts/ui/MyPostsPage.tsx
+++ b/src/app-pages/mypage/settings/my-posts/ui/MyPostsPage.tsx
@@ -4,5 +4,9 @@ import { useInfiniteMyPosts } from '@/features/post/model/useMyPosts';
 import { PostListPage } from '@/widgets/post-list/ui/PostListPage';
 
 export default function MyPostsPage() {
-  return <PostListPage useInfiniteQueryHook={useInfiniteMyPosts} />;
+  return (
+    <div className="flex h-full">
+      <PostListPage useInfiniteQueryHook={useInfiniteMyPosts} />
+    </div>
+  );
 }

--- a/src/app-pages/mypage/settings/policy/ui/MarketingPolicyPage.tsx
+++ b/src/app-pages/mypage/settings/policy/ui/MarketingPolicyPage.tsx
@@ -4,7 +4,7 @@ import { PolicyDetailItem } from '@/entities/policy/ui/PolicyDetailItem';
 
 export default function MarketingPolicyPage() {
   return (
-    <div className="flex h-full pb-[3.81rem]">
+    <div className="flex h-full">
       <PolicyDetailItem policyId="MarketingPolicy" />
     </div>
   );

--- a/src/app-pages/mypage/settings/policy/ui/PersonalInfoPolicyPage.tsx
+++ b/src/app-pages/mypage/settings/policy/ui/PersonalInfoPolicyPage.tsx
@@ -4,7 +4,7 @@ import { PolicyDetailItem } from '@/entities/policy/ui/PolicyDetailItem';
 
 export default function PersonalInfoPolicyPage() {
   return (
-    <div className="flex h-full pb-[4.75rem]">
+    <div className="flex h-full">
       <PolicyDetailItem policyId="PersonalInfoPolicy" />
     </div>
   );

--- a/src/app-pages/mypage/settings/policy/ui/ServicePolicyPage.tsx
+++ b/src/app-pages/mypage/settings/policy/ui/ServicePolicyPage.tsx
@@ -4,7 +4,7 @@ import { PolicyDetailItem } from '@/entities/policy/ui/PolicyDetailItem';
 
 export default function ServicePolicyPage() {
   return (
-    <div className="flex h-full pb-[3.31rem]">
+    <div className="flex h-full">
       <PolicyDetailItem policyId="ServicePolicy" />
     </div>
   );

--- a/src/app-pages/mypage/settings/scraps/ui/ScrapsPage.tsx
+++ b/src/app-pages/mypage/settings/scraps/ui/ScrapsPage.tsx
@@ -4,5 +4,9 @@ import { useInfiniteScraps } from '@/features/post/model/useScraps';
 import { PostListPage } from '@/widgets/post-list/ui/PostListPage';
 
 export default function ScrapsPage() {
-  return <PostListPage useInfiniteQueryHook={useInfiniteScraps} />;
+  return (
+    <div className="flex h-full">
+      <PostListPage useInfiniteQueryHook={useInfiniteScraps} />
+    </div>
+  );
 }

--- a/src/entities/policy/ui/PolicyDetailItem.tsx
+++ b/src/entities/policy/ui/PolicyDetailItem.tsx
@@ -15,7 +15,7 @@ export const PolicyDetailItem = ({ policyId }: PolicyDetailItemProps) => {
   const md = preprocessToMarkdown(policyItem.text, policyId ?? policyItem.id);
 
   return (
-    <div className="flex flex-1 flex-col overflow-y-auto px-[1rem] py-[0.62rem]">
+    <div className="flex flex-1 flex-col overflow-y-auto px-[1rem] py-[0.62rem] pb-[3.5rem]">
       <div className="text-body-12-400--2 text-[#000]">
         <Markdown>{md}</Markdown>
       </div>

--- a/src/widgets/post-list/ui/PostList.tsx
+++ b/src/widgets/post-list/ui/PostList.tsx
@@ -39,7 +39,7 @@ export const PostList = ({
   }
 
   return (
-    <div className="flex flex-col gap-4 px-[1rem]">
+    <div className="flex flex-1 flex-col gap-4 overflow-y-auto px-[1rem]">
       {posts.map((post) => (
         <PostCard key={post.id} post={post} onClick={() => onPostClick?.(post)} />
       ))}


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 any가 사용되지 않았습니다
- [x] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈
- close #127 

## 📌 작업 목적
- 게시글 목록 조회 화면 스크롤 버그 수정

## ⚠️ 기존 문제
- 게시글 목록 조회 화면 스크롤이 되지 않는 버그가 존재했음

## ☑️ 해결 방법
- PostList 컴포넌트의 부모 컴포넌트에 flex h-full 추가 후 PostList 컴포넌트에 flex-1 overflow-y-auto 추가

## 🧪 테스트 방법
1. pnpm run dev
2. http://localhost:3000/mypage/settings 접속
3. 내가 스크랩한 게시글 / 내가 작성한 게시글 목록 클릭 후 스크롤이 되는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - 마이페이지 설정 내 게시글·스크랩 페이지를 전체 높이 활용하는 플렉스 컨테이너로 래핑해 레이아웃 일관성과 정렬을 개선했습니다.
  - 하위 레이아웃 섹션에 오버플로우 숨김을 적용해 레이아웃의 스크롤 동작을 안정화했습니다.

- Style
  - 게시글 목록 영역에 세로 스크롤과 유연한 높이를 적용해 긴 목록에서의 공간 활용성과 탐색성을 향상했습니다.
  - 정책 페이지들에서 불필요한 하단 여백을 제거하고, 상세 항목에 하단 패딩을 추가해 화면 여백을 정리했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->