### PR TITLE
[FEAT] 온보딩 앰플리튜드 로그

### DIFF
--- a/src/features/onboarding/lib/trackOnBoardingEvent.ts
+++ b/src/features/onboarding/lib/trackOnBoardingEvent.ts
@@ -1,0 +1,4 @@
+import { createDomainTracker } from '@/shared/lib/createDomainTracker';
+import { OnBoardingEventPropsMap } from '../model/types';
+
+export const trackOnBoardingEvent = createDomainTracker<OnBoardingEventPropsMap>();

--- a/src/features/onboarding/model/types.ts
+++ b/src/features/onboarding/model/types.ts
@@ -48,16 +48,16 @@ export type OnBoardingResponse = {
  *  온보딩 이벤트 이름
  */
 export const ONBOARDING_EVENTS = {
-  SIGNUP_PAGE_VIEW: 'signup_page_view',
-  SIGNUP_INPUT: 'signup_input',
-  SIGNUP_SUBMIT: 'signup_submit',
+  VIEW_SIGNUP_PAGE: 'view_signup_page',
+  INPUT_SIGNUP_FIELD: 'input_signup_field',
+  SUBMIT_SIGNUP_FORM: 'submit_signup_form',
 } as const;
 
 /**
  * 이벤트별 속성 타입 매핑
  */
 export type OnBoardingEventPropsMap = {
-  [ONBOARDING_EVENTS.SIGNUP_PAGE_VIEW]: { step: string };
-  [ONBOARDING_EVENTS.SIGNUP_INPUT]: { field_name: string };
-  [ONBOARDING_EVENTS.SIGNUP_SUBMIT]: { input_count: number };
+  [ONBOARDING_EVENTS.VIEW_SIGNUP_PAGE]: { step: string };
+  [ONBOARDING_EVENTS.INPUT_SIGNUP_FIELD]: { field_name: string };
+  [ONBOARDING_EVENTS.SUBMIT_SIGNUP_FORM]: { input_count: number };
 };

--- a/src/features/onboarding/model/types.ts
+++ b/src/features/onboarding/model/types.ts
@@ -43,3 +43,21 @@ export type OnBoardingResponse = {
     phoneNumber: string;
   };
 };
+
+/**
+ *  온보딩 이벤트 이름
+ */
+export const ONBOARDING_EVENTS = {
+  SIGNUP_PAGE_VIEW: 'signup_page_view',
+  SIGNUP_INPUT: 'signup_input',
+  SIGNUP_SUBMIT: 'signup_submit',
+} as const;
+
+/**
+ * 이벤트별 속성 타입 매핑
+ */
+export type OnBoardingEventPropsMap = {
+  [ONBOARDING_EVENTS.SIGNUP_PAGE_VIEW]: { step: string };
+  [ONBOARDING_EVENTS.SIGNUP_INPUT]: { field_name: string };
+  [ONBOARDING_EVENTS.SIGNUP_SUBMIT]: { input_count: number };
+};

--- a/src/features/onboarding/ui/EmailPhoneStep.tsx
+++ b/src/features/onboarding/ui/EmailPhoneStep.tsx
@@ -1,8 +1,9 @@
 // features/onboarding/ui/EmailPhoneStep.tsx
 import { Controller, useFormContext } from 'react-hook-form';
-import { OnBoardingFormData } from '@/features/onboarding/model/types';
+import { ONBOARDING_EVENTS, OnBoardingFormData } from '@/features/onboarding/model/types';
 import { FieldGroup } from '@/shared/ui/field-group/FieldGroup';
 import { TextArea } from '@/shared/ui/text-area/TextArea';
+import { trackOnBoardingEvent } from '../lib/trackOnBoardingEvent';
 
 export function EmailPhoneStep() {
   const { control } = useFormContext<OnBoardingFormData>();
@@ -22,6 +23,12 @@ export function EmailPhoneStep() {
           render={({ field, fieldState }) => (
             <TextArea
               {...field}
+              onBlur={(_e) => {
+                trackOnBoardingEvent(ONBOARDING_EVENTS.SIGNUP_INPUT, {
+                  field_name: 'email',
+                });
+                field.onBlur();
+              }}
               value={field.value || ''}
               errorMessage={fieldState.error?.message}
               placeholder="이메일을 입력해주세요."
@@ -44,6 +51,12 @@ export function EmailPhoneStep() {
           render={({ field, fieldState }) => (
             <TextArea
               {...field}
+              onBlur={(_e) => {
+                trackOnBoardingEvent(ONBOARDING_EVENTS.SIGNUP_INPUT, {
+                  field_name: 'phone',
+                });
+                field.onBlur();
+              }}
               value={field.value || ''}
               errorMessage={fieldState.error?.message}
               placeholder="전화번호를 입력해주세요."

--- a/src/features/onboarding/ui/EmailPhoneStep.tsx
+++ b/src/features/onboarding/ui/EmailPhoneStep.tsx
@@ -24,7 +24,7 @@ export function EmailPhoneStep() {
             <TextArea
               {...field}
               onBlur={(_e) => {
-                trackOnBoardingEvent(ONBOARDING_EVENTS.SIGNUP_INPUT, {
+                trackOnBoardingEvent(ONBOARDING_EVENTS.INPUT_SIGNUP_FIELD, {
                   field_name: 'email',
                 });
                 field.onBlur();
@@ -52,7 +52,7 @@ export function EmailPhoneStep() {
             <TextArea
               {...field}
               onBlur={(_e) => {
-                trackOnBoardingEvent(ONBOARDING_EVENTS.SIGNUP_INPUT, {
+                trackOnBoardingEvent(ONBOARDING_EVENTS.INPUT_SIGNUP_FIELD, {
                   field_name: 'phone',
                 });
                 field.onBlur();

--- a/src/features/onboarding/ui/TrackUnivStep.tsx
+++ b/src/features/onboarding/ui/TrackUnivStep.tsx
@@ -97,7 +97,7 @@ export function TrackUnivStep() {
               <TextArea
                 {...field}
                 onBlur={(_e) => {
-                  trackOnBoardingEvent(ONBOARDING_EVENTS.SIGNUP_INPUT, {
+                  trackOnBoardingEvent(ONBOARDING_EVENTS.INPUT_SIGNUP_FIELD, {
                     field_name: 'university',
                   });
                   field.onBlur();

--- a/src/features/onboarding/ui/TrackUnivStep.tsx
+++ b/src/features/onboarding/ui/TrackUnivStep.tsx
@@ -11,8 +11,13 @@ import { TextArea } from '@/shared/ui/text-area/TextArea';
 import { FieldGroup } from '@/shared/ui/field-group/FieldGroup';
 import { SolidButton } from '@/shared/ui/solid-button/SolidButton';
 import { useState } from 'react';
-import { OnBoardingFormData, TrackPart } from '@/features/onboarding/model/types';
+import {
+  ONBOARDING_EVENTS,
+  OnBoardingFormData,
+  TrackPart,
+} from '@/features/onboarding/model/types';
 import { formatTrackLabel, mapToApiTrack } from '../lib/trackMapper';
+import { trackOnBoardingEvent } from '../lib/trackOnBoardingEvent';
 
 export function TrackUnivStep() {
   const { control, setValue } = useFormContext<OnBoardingFormData>();
@@ -91,6 +96,12 @@ export function TrackUnivStep() {
             render={({ field, fieldState }) => (
               <TextArea
                 {...field}
+                onBlur={(_e) => {
+                  trackOnBoardingEvent(ONBOARDING_EVENTS.SIGNUP_INPUT, {
+                    field_name: 'university',
+                  });
+                  field.onBlur();
+                }}
                 value={field.value || ''}
                 errorMessage={fieldState.error?.message}
                 placeholder="대학교를 입력해주세요."

--- a/src/shared/lib/trackEvent.ts
+++ b/src/shared/lib/trackEvent.ts
@@ -4,5 +4,9 @@ export function trackEvent<
   const M extends Record<string, Record<string, unknown>>,
   K extends keyof M,
 >(eventName: K, eventProps: M[K]) {
-  amplitude.logEvent(String(eventName), eventProps);
+  try {
+    amplitude.logEvent(String(eventName), eventProps);
+  } catch (error) {
+    console.error(`[Amplitude] ${String(eventName)} 이벤트 전송 실패:`, error);
+  }
 }

--- a/src/widgets/onboarding/ui/OnBoardingForm.tsx
+++ b/src/widgets/onboarding/ui/OnBoardingForm.tsx
@@ -1,7 +1,7 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import OnBoardingLayout from './OnBoardingLayout';
-import { OnBoardingFormData } from '@/features/onboarding/model/types';
+import { ONBOARDING_EVENTS, OnBoardingFormData } from '@/features/onboarding/model/types';
 import { ProfileStep } from '@/features/onboarding/ui/ProfileStep';
 import { TrackUnivStep } from '@/features/onboarding/ui/TrackUnivStep';
 import { EmailPhoneStep } from '@/features/onboarding/ui/EmailPhoneStep';
@@ -9,6 +9,7 @@ import { submitOnBoarding } from '@/features/onboarding/api/submitOnBoarding';
 import { useRouter } from 'next/navigation';
 import axios from 'axios';
 import { DefaultError } from '@/shared/lib/handleApiError';
+import { trackOnBoardingEvent } from '@/features/onboarding/lib/trackOnBoardingEvent';
 
 export default function OnBoardingForm() {
   const [step, setStep] = useState(0);
@@ -43,6 +44,19 @@ export default function OnBoardingForm() {
   ];
   const StepComponent = steps[step].component;
 
+  // step이 바뀔 때마다 signup_page_view 트래킹
+  useEffect(() => {
+    const stepNames: Record<number, 'nickname' | 'track' | 'contact'> = {
+      0: 'nickname',
+      1: 'track',
+      2: 'contact',
+    };
+
+    trackOnBoardingEvent(ONBOARDING_EVENTS.SIGNUP_PAGE_VIEW, {
+      step: stepNames[step],
+    });
+  }, [step]);
+
   async function handleNext() {
     const isValid = await methods.trigger(steps[step].fields);
     if (!isValid) return;
@@ -53,6 +67,17 @@ export default function OnBoardingForm() {
       // 전체 값 제출
       await methods.handleSubmit(async (data) => {
         try {
+          // 온보딩 제출 signup_submit 트래킹
+          const filledCount = Object.values(data).filter(
+            (v) =>
+              v !== '' && //  빈 문자열이 아닌 경우는 제외
+              v !== null && //  null이 아닌 경우는 제외
+              !(Array.isArray(v) && v.length === 0), // 빈 배열([])인 경우는 제외
+          ).length;
+
+          trackOnBoardingEvent(ONBOARDING_EVENTS.SIGNUP_SUBMIT, {
+            input_count: filledCount,
+          });
           await submitOnBoarding(data);
           router.push('/home');
         } catch (error) {

--- a/src/widgets/onboarding/ui/OnBoardingForm.tsx
+++ b/src/widgets/onboarding/ui/OnBoardingForm.tsx
@@ -11,6 +11,12 @@ import axios from 'axios';
 import { DefaultError } from '@/shared/lib/handleApiError';
 import { trackOnBoardingEvent } from '@/features/onboarding/lib/trackOnBoardingEvent';
 
+const STEP_ANALYTICS_NAMES: Record<number, 'nickname' | 'track' | 'contact'> = {
+  0: 'nickname',
+  1: 'track',
+  2: 'contact',
+};
+
 export default function OnBoardingForm() {
   const [step, setStep] = useState(0);
   const methods = useFormContext<OnBoardingFormData>();
@@ -46,14 +52,8 @@ export default function OnBoardingForm() {
 
   // step이 바뀔 때마다 signup_page_view 트래킹
   useEffect(() => {
-    const stepNames: Record<number, 'nickname' | 'track' | 'contact'> = {
-      0: 'nickname',
-      1: 'track',
-      2: 'contact',
-    };
-
     trackOnBoardingEvent(ONBOARDING_EVENTS.VIEW_SIGNUP_PAGE, {
-      step: stepNames[step],
+      step: STEP_ANALYTICS_NAMES[step],
     });
   }, [step]);
 

--- a/src/widgets/onboarding/ui/OnBoardingForm.tsx
+++ b/src/widgets/onboarding/ui/OnBoardingForm.tsx
@@ -52,7 +52,7 @@ export default function OnBoardingForm() {
       2: 'contact',
     };
 
-    trackOnBoardingEvent(ONBOARDING_EVENTS.SIGNUP_PAGE_VIEW, {
+    trackOnBoardingEvent(ONBOARDING_EVENTS.VIEW_SIGNUP_PAGE, {
       step: stepNames[step],
     });
   }, [step]);
@@ -75,7 +75,7 @@ export default function OnBoardingForm() {
               !(Array.isArray(v) && v.length === 0), // 빈 배열([])인 경우는 제외
           ).length;
 
-          trackOnBoardingEvent(ONBOARDING_EVENTS.SIGNUP_SUBMIT, {
+          trackOnBoardingEvent(ONBOARDING_EVENTS.SUBMIT_SIGNUP_FORM, {
             input_count: filledCount,
           });
           await submitOnBoarding(data);


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 any가 사용되지 않았습니다
- [x] 스토리북에 추가했습니다 (해당 시)
- [x] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈
- close #132 

## 📌 작업 목적
- 온보딩 앰플리튜드 로그 추가

## 🔨 주요 작업 내용
- `signup_page_view` 로그 추가  
  → 각 온보딩 단계 진입 시(`nickname`, `track`, `contact`) 이벤트 발생
- `signup_input` 로그 추가  
  → 입력 필드(`email`, `phone`, `university`)에서 `onBlur` 발생 시 이벤트 전송
- `signup_submit` 로그 추가  
  → 가입 완료 버튼 클릭 시 입력 필드 수(`input_count`)와 함께 이벤트 전송

## 🧪 테스트 방법
1. `pnpm dev` 실행  
2. 온보딩 단계별 진입 시 `signup_page_view`  이벤트 전송 확인 (`nickname`, `track`, `contact` 속성도 확인)
3. 각 입력 필드(`email`, `phone`, `university`) 포커스 아웃 시 `signup_input` 이벤트가 전송되는지 확인  
4. 가입 완료 버튼 클릭 시 `signup_submit` 이벤트가 전송되는지 확인 (속성은 입력한 input field의 개수)


## 📷 실행 영상 또는 스크린샷
-  `signup_page_view` 
<img width="1287" height="709" alt="image" src="https://github.com/user-attachments/assets/bbd1d003-db79-4f47-a255-b568a1f2546c" />

- `signup_input`
<img width="1266" height="593" alt="image" src="https://github.com/user-attachments/assets/9574657a-2645-4535-a6de-48b85ea2ce01" />

-  `signup_submit` 
<img width="1354" height="796" alt="image" src="https://github.com/user-attachments/assets/546fc37d-cb25-42a6-af18-352dc457c33d" />



## 💬 논의할 점
- Strict Mode로 인해 `signup_page_view`의 `nickname` 이벤트가 개발 모드에서 두 번 전송됩니다.
  배포 환경에서는 한 번만 전송됩니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신기능**
  - 온보딩 폼에 분석 추적이 추가되었습니다.
    - 각 단계 진입 시 페이지 조회 이벤트가 자동 기록됩니다.
    - 이메일, 전화번호, 대학 입력란에서 포커스 이탈(onBlur) 시 입력 필드 이벤트가 기록됩니다.
    - 최종 제출 시 입력한 항목 수를 포함한 제출 이벤트가 기록됩니다.
    - 사용 흐름과 검증 로직은 변경되지 않으며, 추적은 백그라운드에서 동작합니다
- **버그 수정**
  - 이벤트 전송 처리에서 발생 가능한 예외를 안전하게 처리하도록 개선되어 추적 실패 시 앱 안정성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->