### PR TITLE
[FIX] 스토리북 스크롤 버그 이슈

### DIFF
--- a/.storybook/preview-body.css
+++ b/.storybook/preview-body.css
@@ -1,0 +1,3 @@
+body {
+  overflow-y: auto !important;
+}

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,4 +1,5 @@
 import '@/shared/styles/globals.css';
+import './preview-body.css';
 import type { Preview } from '@storybook/nextjs-vite';
 import 'keen-slider/keen-slider.min.css';
 


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 any가 사용되지 않았습니다
- [x] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈
- close #172 

## ⚠️ 기존 문제
- 프로젝트의 전역 CSS (index.css 등)에 포함된 body { overflow: hidden; } 스타일이 Storybook의 미리보기(Canvas) 영역에도 적용되어, 컴포넌트의 높이가 길어져도 스크롤이 발생하지 않는 문제가 있었습니다.

## ☑️ 해결 방법
- Storybook에서만 스크롤을 강제로 활성화하기 위해 .storybook/preview-body.css 파일을 생성하여 body { overflow-y: auto !important; } 스타일을 추가했습니다.
- .storybook/preview.js 파일에서 해당 CSS 파일을 import 하여, Storybook 미리보기 영역에 스타일이 적용되도록 수정했습니다.

## 🧪 테스트 방법
1. pnpm run storybook으로 Storybook 실행
2. EventDateCard 등 콘텐츠가 세로로 긴 컴포넌트 페이지로 이동
3. 미리보기(Canvas) 영역에서 세로 스크롤이 정상 작동 확인

## ✔️ 설치 라이브러리
- (없음)

## 📷 실행 영상 또는 스크린샷
https://github.com/user-attachments/assets/0a3e6d8c-6f53-4286-8246-31f3606c2cb6

## 💬 논의할 점
- 전역 CSS를 직접 수정하는 대신, Storybook 전용 CSS 파일을 만들어 !important로 덮어쓰는 방식을 사용했습니다.
## 🙋🏻 참고 자료
- (없음)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 페이지 스크롤 동작이 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->