### PR TITLE
[CHORE] 커밋 메시지 컨벤션 수정

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -6,7 +6,7 @@ echo "🔍 커밋 메시지 규칙 검사"
 # 일반적으로 $1 로 전달되지만, 혹시 없으면 .git/COMMIT_EDITMSG 로 대체
 MSG_FILE="${1:-.git/COMMIT_EDITMSG}"
 
-# ⚠️ GitHub Desktop (Windows)에서는 줄바꿈이 CRLF(\r\n)로 저장돼서
+# GitHub Desktop (Windows)에서는 줄바꿈이 CRLF(\r\n)로 저장돼서
 # 정규식 검사 시 줄 끝에 \r 이 남아 규칙이 깨질 수 있음
 # → \r 제거해서 LF만 남긴 임시 파일 생성
 TMP_FILE="$(mktemp)"                 # 임시 파일 생성
@@ -17,10 +17,7 @@ tr -d '\r' < "$MSG_FILE" > "$TMP_FILE"  # \r 제거 후 TMP_FILE 에 저장
 if ! pnpm exec commitlint --edit "$TMP_FILE"; then
   echo ""
   echo "❌ 커밋 메시지 규칙 위반"
-  echo "👉 규칙 예시:"
-  echo "   [feat][nickname]: 새로운 기능 추가 (#123)"
-  echo "   [fix][nickname]: 버그 수정 (#99)"
-  echo ""
+  echo "👉 규칙 예시: feat: 새로운 기능 추가 (#123)"
   echo "📖 허용된 타입: feat, fix, refactor, style, format, docs, chore, add, del, test"
   rm -f "$TMP_FILE"   # 임시 파일 정리
   exit 1              # 검사 실패 → 커밋 중단

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,19 +1,12 @@
 export default {
-  parserPreset: {
-    parserOpts: {
-      headerPattern:
-        /^\[(?<type>feat|fix|refactor|style|format|docs|chore|add|del|test)\]\[(?<nickname>[a-z0-9_-]+)\]: (?<subject>.+)$/,
-      headerCorrespondence: ['type', 'nickname', 'subject'],
-    },
-  },
   rules: {
     'type-enum': [
       2,
       'always',
       ['feat', 'fix', 'refactor', 'style', 'format', 'docs', 'chore', 'add', 'del', 'test'],
     ],
-    'subject-empty': [2, 'never'],
     'type-empty': [2, 'never'],
+    'subject-empty': [2, 'never'],
     'header-max-length': [2, 'always', 100],
   },
 };

--- a/docs/code-convention.md
+++ b/docs/code-convention.md
@@ -41,11 +41,10 @@ fix/navbar-overlap-210
 ## 📩 Commit Convention
 
 ### 1. Commit Message Rules
-- 기본 규칙: **[기능 Type][GitHub 닉네임]: 작업 내용 (#이슈번호 선택)**
+- 기본 규칙: **기능 Type: 작업 내용 (#이슈번호 선택)**
 
 #### Examples
-[feat][rngrhn4114]: 로그인 API 연동 (#39)
-[fix][chaejy]: 비밀번호 유효성 검사 버그 수정 (#52)
+feat: 로그인 API 연동 (#39)
 
 
 ### 2. Commit Types


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 any가 사용되지 않았습니다
- [x] 스토리북에 추가했습니다 (해당 시)
- [x] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈
- close #218

## 📌 작업 목적
- 커밋 컨벤션 간편화

## 🔨 주요 작업 내용
`type: subject` 방식으로 변경

## ⚠️ 기존 문제
- 괄호와 닉네임까지 커밋 메시지에 들어가는 게 불필요하다는 의견이 있어 수정

## ☑️ 해결 방법
- cimmitlint 컨벤션 양식과 husky pre-commit 안내 메시지를 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores
* 커밋 메시지 검증 실패 시 안내 문구 예시를 간결한 단일 형식("feat: ... (#123)")으로 변경
* 가이드 문서의 커밋 메시지 예시 및 표기법을 대괄호 닉네임 없는 형식으로 업데이트
* 커밋 형식 검증 설정에서 커스텀 헤더 파싱을 제거해 규칙 구성이 간소화됨

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->