### PR TITLE
[FEAT] MemberItem 및 MemberList 컴포넌트 제작

### DIFF
--- a/src/entities/search/model/types.ts
+++ b/src/entities/search/model/types.ts
@@ -1,3 +1,6 @@
 import { UserProfile } from '@/entities/user/model/types';
 
-export type MemberItemUser = Pick<UserProfile, 'name' | 'bio' | 'level' | 'chips' | 'avatarUrl'>;
+export type MemberItemUser = Pick<
+  UserProfile,
+  'userId' | 'name' | 'bio' | 'level' | 'chips' | 'avatarUrl'
+>;

--- a/src/entities/search/model/types.ts
+++ b/src/entities/search/model/types.ts
@@ -1,0 +1,3 @@
+import { UserProfile } from '@/entities/user/model/types';
+
+export type MemberItemUser = Pick<UserProfile, 'name' | 'bio' | 'level' | 'chips' | 'avatarUrl'>;

--- a/src/entities/search/model/useDynamicVisibleCount.ts
+++ b/src/entities/search/model/useDynamicVisibleCount.ts
@@ -70,7 +70,7 @@ export const useDynamicVisibleCount = <T>({
     }
 
     return () => observer.disconnect();
-  }, [items, gap, moreBadgeWidth]);
+  }, [items.length, gap, moreBadgeWidth]);
 
   return {
     visibleCount,

--- a/src/entities/search/model/useDynamicVisibleCount.ts
+++ b/src/entities/search/model/useDynamicVisibleCount.ts
@@ -8,8 +8,8 @@ interface UseDynamicVisibleCountProps<T> {
 
 export const useDynamicVisibleCount = <T>({
   items,
-  gap = 20,
-  moreBadgeWidth = 40,
+  gap = 4,
+  moreBadgeWidth = 28,
 }: UseDynamicVisibleCountProps<T>) => {
   // 실제 보여줄 개수 상태
   const [visibleCount, setVisibleCount] = useState(items.length);

--- a/src/entities/search/model/useDynamicVisibleCount.ts
+++ b/src/entities/search/model/useDynamicVisibleCount.ts
@@ -1,0 +1,80 @@
+import { useState, useRef, useLayoutEffect } from 'react';
+
+interface UseDynamicVisibleCountProps<T> {
+  items: T[]; // 측정할 아이템 배열
+  gap?: number; // 아이템 사이의 간격 (px)
+  moreBadgeWidth?: number; // '+N' 배지가 차지할 예상 너비 (px)
+}
+
+export const useDynamicVisibleCount = <T>({
+  items,
+  gap = 20,
+  moreBadgeWidth = 40,
+}: UseDynamicVisibleCountProps<T>) => {
+  // 실제 보여줄 개수 상태
+  const [visibleCount, setVisibleCount] = useState(items.length);
+
+  // 컨테이너와 Ghost 요소를 연결할 Ref
+  const containerRef = useRef<HTMLUListElement>(null);
+  const ghostContainerRef = useRef<HTMLUListElement>(null);
+
+  useLayoutEffect(() => {
+    const calculate = () => {
+      if (!containerRef.current || !ghostContainerRef.current) return;
+
+      const containerWidth = containerRef.current.offsetWidth;
+      // Ghost 컨테이너의 자식들(칩)의 DOM 요소 가져오기
+      const chipNodes = Array.from(ghostContainerRef.current.children) as HTMLElement[];
+
+      let currentWidth = 0;
+      let count = 0;
+
+      for (let i = 0; i < chipNodes.length; i++) {
+        const chipWidth = chipNodes[i].offsetWidth;
+        const isLastItem = i === chipNodes.length - 1;
+
+        // 아이템이 추가될 때마다 너비 누적 (첫 아이템이 아니면 gap 추가)
+        const itemWidthWithGap = chipWidth + (i > 0 ? gap : 0);
+        const nextTotalWidth = currentWidth + itemWidthWithGap;
+
+        // 로직:
+        // 1. 마지막 아이템인 경우: 그냥 컨테이너 안에 들어가는지만 확인
+        // 2. 중간 아이템인 경우: 이 아이템 + (+N 배지 너비)가 들어갈 공간이 있는지 확인
+
+        if (isLastItem) {
+          if (nextTotalWidth <= containerWidth) {
+            count++;
+          }
+        } else {
+          // 다음 아이템이 더 있으므로, '+N' 배지 공간도 확보해야 함 (gap 포함)
+          if (nextTotalWidth + gap + moreBadgeWidth <= containerWidth) {
+            currentWidth = nextTotalWidth;
+            count++;
+          } else {
+            // 공간 부족하면 여기서 카운팅 멈춤
+            break;
+          }
+        }
+      }
+
+      setVisibleCount(count);
+    };
+
+    // 초기 계산
+    calculate();
+
+    // 리사이즈 감지
+    const observer = new ResizeObserver(calculate);
+    if (containerRef.current) {
+      observer.observe(containerRef.current);
+    }
+
+    return () => observer.disconnect();
+  }, [items, gap, moreBadgeWidth]);
+
+  return {
+    visibleCount,
+    containerRef,
+    ghostContainerRef,
+  };
+};

--- a/src/entities/search/ui/MemberItem.stories.tsx
+++ b/src/entities/search/ui/MemberItem.stories.tsx
@@ -16,6 +16,7 @@ export default meta;
 type Story = StoryObj<typeof MemberItem>;
 
 const mockUser: MemberItemUser = {
+  userId: 1,
   name: '테이브',
   bio: '프론트엔드와 블록체인을 좋아합니다',
   level: 'superManager',

--- a/src/entities/search/ui/MemberItem.stories.tsx
+++ b/src/entities/search/ui/MemberItem.stories.tsx
@@ -4,7 +4,7 @@ import { MemberItem } from './MemberItem';
 import type { MemberItemUser } from '../model/types';
 
 const meta: Meta<typeof MemberItem> = {
-  title: 'Entities/UI/Notification/MemberItem',
+  title: 'Entities/UI/Search/MemberItem',
   component: MemberItem,
   parameters: {
     layout: 'padded',
@@ -57,7 +57,7 @@ export const SuperManagerLevel: Story = {
   },
 };
 
-export const ExcecutiveManagerLevel: Story = {
+export const ExecutiveManagerLevel: Story = {
   args: {
     user: {
       ...mockUser,

--- a/src/entities/search/ui/MemberItem.stories.tsx
+++ b/src/entities/search/ui/MemberItem.stories.tsx
@@ -1,0 +1,93 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+
+import { MemberItem } from './MemberItem';
+import type { MemberItemUser } from '../model/types';
+
+const meta: Meta<typeof MemberItem> = {
+  title: 'Entities/UI/Notification/MemberItem',
+  component: MemberItem,
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof MemberItem>;
+
+const mockUser: MemberItemUser = {
+  name: '테이브',
+  bio: '프론트엔드와 블록체인을 좋아합니다',
+  level: 'superManager',
+  chips: ['15기 프론트엔드', '15기 디자인'],
+  avatarUrl: null,
+};
+
+export const Default: Story = {
+  args: {
+    user: mockUser,
+  },
+};
+
+export const NoBio: Story = {
+  args: {
+    user: {
+      ...mockUser,
+      bio: null,
+    },
+  },
+};
+
+export const ManyChips: Story = {
+  args: {
+    user: {
+      ...mockUser,
+      chips: ['15기 프론트엔드', '15기 디자인', '15기 백엔드', '15기 데이터분석', '15기 딥러닝'],
+    },
+  },
+};
+
+export const SuperManagerLevel: Story = {
+  args: {
+    user: {
+      ...mockUser,
+      level: 'superManager',
+    },
+  },
+};
+
+export const ExcecutiveManagerLevel: Story = {
+  args: {
+    user: {
+      ...mockUser,
+      level: 'executiveManager',
+    },
+  },
+};
+
+export const ManagerLevel: Story = {
+  args: {
+    user: {
+      ...mockUser,
+      level: 'manager',
+    },
+  },
+};
+
+export const MemberLevel: Story = {
+  args: {
+    user: {
+      ...mockUser,
+      level: 'member',
+    },
+  },
+};
+
+export const NoChips: Story = {
+  args: {
+    user: {
+      ...mockUser,
+      chips: [],
+    },
+  },
+};

--- a/src/entities/search/ui/MemberItem.tsx
+++ b/src/entities/search/ui/MemberItem.tsx
@@ -26,9 +26,9 @@ export const MemberItem = ({ user, onClick }: MemberItemProps) => {
   return (
     <button onClick={onClick} className="flex w-full gap-11 overflow-hidden p-12">
       {/* 프로필 이미지 */}
-      <Avatar size="m" />
+      <Avatar size="m" src={user.avatarUrl ?? undefined} />
 
-      <div className="flex w-full flex-col gap-7 overflow-hidden">
+      <div className="flex w-full flex-col items-start gap-7 overflow-hidden">
         {/* 헤더: 이름 + 레벨 + 칩 */}
         <header className="flex w-full items-center gap-8">
           {/* 이름 + 권한 아이콘 */}
@@ -38,16 +38,16 @@ export const MemberItem = ({ user, onClick }: MemberItemProps) => {
           </h3>
 
           {/* 기수 (칩 목록) */}
-          <ul ref={containerRef} className="flex min-w-0 flex-1 items-center gap-5 overflow-hidden">
+          <ul ref={containerRef} className="flex min-w-0 flex-1 gap-5 overflow-hidden">
             {visibleChips.map((chip) => (
-              <li key={chip} className="shrink-0">
+              <li key={chip} className="flex shrink-0 items-center">
                 <InfoBadge text={chip} />
               </li>
             ))}
 
             {/* +N개 UI 처리 */}
             {remainingCount > 0 && (
-              <li className="shrink-0">
+              <li className="flex shrink-0 items-center">
                 <InfoBadge text={`+${remainingCount}`} />
               </li>
             )}

--- a/src/entities/search/ui/MemberItem.tsx
+++ b/src/entities/search/ui/MemberItem.tsx
@@ -12,7 +12,7 @@ export const MemberItem = ({ user }: MemberItemProps) => {
   const BadgeIcon = USER_LEVEL_BADGE[level];
 
   return (
-    <article className="flex w-full gap-11">
+    <article className="flex w-full gap-11 p-12">
       {/* 프로필 이미지 */}
       <Avatar size="m" />
 

--- a/src/entities/search/ui/MemberItem.tsx
+++ b/src/entities/search/ui/MemberItem.tsx
@@ -4,9 +4,9 @@ import { InfoBadge } from '@/shared/ui/info-badge/InfoBadge';
 import { MemberItemUser } from '../model/types';
 import { useDynamicVisibleCount } from '../model/useDynamicVisibleCount';
 
-export type MemberItemProps = {
+interface MemberItemProps {
   user: MemberItemUser;
-};
+}
 
 export const MemberItem = ({ user }: MemberItemProps) => {
   const { name, bio, level, chips } = user;

--- a/src/entities/search/ui/MemberItem.tsx
+++ b/src/entities/search/ui/MemberItem.tsx
@@ -2,6 +2,7 @@ import { USER_LEVEL_BADGE } from '@/entities/user/ui/user-level/UserLevelBadges'
 import { Avatar } from '@/shared/ui/avatar/Avatar';
 import { InfoBadge } from '@/shared/ui/info-badge/InfoBadge';
 import { MemberItemUser } from '../model/types';
+import { useDynamicVisibleCount } from '../model/useDynamicVisibleCount';
 
 export type MemberItemProps = {
   user: MemberItemUser;
@@ -11,34 +12,67 @@ export const MemberItem = ({ user }: MemberItemProps) => {
   const { name, bio, level, chips } = user;
   const BadgeIcon = USER_LEVEL_BADGE[level];
 
+  // 1. 커스텀 훅 사용
+  const { visibleCount, containerRef, ghostContainerRef } = useDynamicVisibleCount({
+    items: chips,
+    gap: 4, // 칩 간격
+    moreBadgeWidth: 28, // '+N' 배지 너비
+  });
+
+  const visibleChips = chips.slice(0, visibleCount);
+  const remainingCount = chips.length - visibleCount;
+
   return (
-    <article className="flex w-full gap-11 p-12">
+    <article className="flex w-full gap-11 overflow-hidden p-12">
       {/* 프로필 이미지 */}
       <Avatar size="m" />
 
-      <div className="flex flex-col gap-7">
+      <div className="flex w-full flex-col gap-7 overflow-hidden">
         {/* 헤더: 이름 + 레벨 + 칩 */}
-        <header className="flex gap-8">
+        <header className="flex w-full items-center gap-8">
           {/* 이름 + 권한 아이콘 */}
-          <h3 className="text-foreground-normal text-body-body6 flex items-center gap-5">
+          <h3 className="text-foreground-normal text-body-body6 flex shrink-0 items-center gap-5">
             <span>{name}</span>
             <BadgeIcon className="h-[1.125rem] w-[1.125rem] shrink-0" />
           </h3>
 
-          {/* 기수
-          TODO: chip 여러 개일 시 마지막 칩 +N개 UI 처리 필요 */}
-          <ul className="flex items-center gap-5">
-            {chips.map((chip) => (
-              <li key={chip}>
+          {/* 기수 (칩 목록) */}
+          <ul ref={containerRef} className="flex min-w-0 flex-1 items-center gap-5 overflow-hidden">
+            {visibleChips.map((chip) => (
+              <li key={chip} className="shrink-0">
                 <InfoBadge text={chip} />
               </li>
             ))}
+
+            {/* +N개 UI 처리 */}
+            {remainingCount > 0 && (
+              <li className="shrink-0">
+                <InfoBadge text={`+${remainingCount}`} />
+              </li>
+            )}
           </ul>
         </header>
 
         {/* 한 줄 소개 */}
-        <p className="text-foreground-normal text-caption-caption4">{bio ?? ''}</p>
+        <p className="text-foreground-normal text-caption-caption4 truncate">{bio ?? ''}</p>
       </div>
+
+      {/* [Ghost Container]
+        화면에 보이지 않지만 너비 계산을 위해 존재. 
+        실제 ul과 동일한 구조(gap, padding 등)여야 함.
+      */}
+      <ul
+        ref={ghostContainerRef}
+        aria-hidden="true"
+        className="pointer-events-none invisible absolute flex items-center gap-5 opacity-0"
+        style={{ top: 0, left: 0, width: 'max-content' }}
+      >
+        {chips.map((chip) => (
+          <li key={`ghost-${chip}`}>
+            <InfoBadge text={chip} />
+          </li>
+        ))}
+      </ul>
     </article>
   );
 };

--- a/src/entities/search/ui/MemberItem.tsx
+++ b/src/entities/search/ui/MemberItem.tsx
@@ -6,9 +6,10 @@ import { useDynamicVisibleCount } from '../model/useDynamicVisibleCount';
 
 interface MemberItemProps {
   user: MemberItemUser;
+  onClick?: () => void;
 }
 
-export const MemberItem = ({ user }: MemberItemProps) => {
+export const MemberItem = ({ user, onClick }: MemberItemProps) => {
   const { name, bio, level, chips } = user;
   const BadgeIcon = USER_LEVEL_BADGE[level];
 
@@ -23,7 +24,7 @@ export const MemberItem = ({ user }: MemberItemProps) => {
   const remainingCount = chips.length - visibleCount;
 
   return (
-    <article className="flex w-full gap-11 overflow-hidden p-12">
+    <button onClick={onClick} className="flex w-full gap-11 overflow-hidden p-12">
       {/* 프로필 이미지 */}
       <Avatar size="m" />
 
@@ -73,6 +74,6 @@ export const MemberItem = ({ user }: MemberItemProps) => {
           </li>
         ))}
       </ul>
-    </article>
+    </button>
   );
 };

--- a/src/entities/search/ui/MemberItem.tsx
+++ b/src/entities/search/ui/MemberItem.tsx
@@ -1,0 +1,44 @@
+import { USER_LEVEL_BADGE } from '@/entities/user/ui/user-level/UserLevelBadges';
+import { Avatar } from '@/shared/ui/avatar/Avatar';
+import { InfoBadge } from '@/shared/ui/info-badge/InfoBadge';
+import { MemberItemUser } from '../model/types';
+
+export type MemberItemProps = {
+  user: MemberItemUser;
+};
+
+export const MemberItem = ({ user }: MemberItemProps) => {
+  const { name, bio, level, chips } = user;
+  const BadgeIcon = USER_LEVEL_BADGE[level];
+
+  return (
+    <article className="flex w-full gap-11">
+      {/* 프로필 이미지 */}
+      <Avatar size="m" />
+
+      <div className="flex flex-col gap-7">
+        {/* 헤더: 이름 + 레벨 + 칩 */}
+        <header className="flex gap-8">
+          {/* 이름 + 권한 아이콘 */}
+          <h3 className="text-foreground-normal text-body-body6 flex items-center gap-5">
+            <span>{name}</span>
+            <BadgeIcon className="h-[1.125rem] w-[1.125rem] shrink-0" />
+          </h3>
+
+          {/* 기수
+          TODO: chip 여러 개일 시 마지막 칩 +N개 UI 처리 필요 */}
+          <ul className="flex items-center gap-5">
+            {chips.map((chip) => (
+              <li key={chip}>
+                <InfoBadge text={chip} />
+              </li>
+            ))}
+          </ul>
+        </header>
+
+        {/* 한 줄 소개 */}
+        <p className="text-foreground-normal text-caption-caption4">{bio ?? ''}</p>
+      </div>
+    </article>
+  );
+};

--- a/src/entities/search/ui/MemberList.stories.tsx
+++ b/src/entities/search/ui/MemberList.stories.tsx
@@ -1,0 +1,85 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+
+import { MemberList } from './MemberList';
+import type { MemberItemUser } from '../model/types';
+
+const meta: Meta<typeof MemberList> = {
+  title: 'Entities/UI/Notification/MemberList',
+  component: MemberList,
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof MemberList>;
+
+const mockMembers: MemberItemUser[] = [
+  {
+    name: '테이브',
+    bio: '프론트엔드와 블록체인을 좋아합니다',
+    level: 'superManager',
+    chips: ['15기 디자인', '15기 프론트엔드'],
+    avatarUrl: null,
+  },
+  {
+    name: '짱구',
+    bio: '디자인 시스템에 관심이 많아요',
+    level: 'executiveManager',
+    chips: ['15기 디자인', '15기 백엔드'],
+    avatarUrl: null,
+  },
+  {
+    name: '도라에몽',
+    bio: null,
+    level: 'manager',
+    chips: ['15기 프론트엔드', '15기 백엔드'],
+    avatarUrl: null,
+  },
+  {
+    name: '스펀지밥',
+    bio: null,
+    level: 'member',
+    chips: ['15기 딥러닝', '15기 데이터분석'],
+    avatarUrl: null,
+  },
+];
+
+export const Default: Story = {
+  args: {
+    members: mockMembers,
+  },
+};
+
+export const SingleMember: Story = {
+  args: {
+    members: [mockMembers[0]],
+  },
+};
+
+export const NoBioMembers: Story = {
+  args: {
+    members: mockMembers.map((m) => ({
+      ...m,
+      bio: null,
+    })),
+  },
+};
+
+export const ManyChips: Story = {
+  args: {
+    members: [
+      {
+        ...mockMembers[0],
+        chips: ['15기 프론트엔드', '15기 백엔드', '15기 디자인', '15기 데이터분석', '15기 딥러닝'],
+      },
+    ],
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    members: [],
+  },
+};

--- a/src/entities/search/ui/MemberList.stories.tsx
+++ b/src/entities/search/ui/MemberList.stories.tsx
@@ -4,7 +4,7 @@ import { MemberList } from './MemberList';
 import type { MemberItemUser } from '../model/types';
 
 const meta: Meta<typeof MemberList> = {
-  title: 'Entities/UI/Notification/MemberList',
+  title: 'Entities/UI/Search/MemberList',
   component: MemberList,
   parameters: {
     layout: 'padded',

--- a/src/entities/search/ui/MemberList.stories.tsx
+++ b/src/entities/search/ui/MemberList.stories.tsx
@@ -17,6 +17,7 @@ type Story = StoryObj<typeof MemberList>;
 
 const mockMembers: MemberItemUser[] = [
   {
+    userId: 1,
     name: '테이브',
     bio: '프론트엔드와 블록체인을 좋아합니다',
     level: 'superManager',
@@ -24,6 +25,7 @@ const mockMembers: MemberItemUser[] = [
     avatarUrl: null,
   },
   {
+    userId: 2,
     name: '짱구',
     bio: '디자인 시스템에 관심이 많아요',
     level: 'executiveManager',
@@ -31,6 +33,7 @@ const mockMembers: MemberItemUser[] = [
     avatarUrl: null,
   },
   {
+    userId: 3,
     name: '도라에몽',
     bio: null,
     level: 'manager',
@@ -38,6 +41,7 @@ const mockMembers: MemberItemUser[] = [
     avatarUrl: null,
   },
   {
+    userId: 4,
     name: '스펀지밥',
     bio: null,
     level: 'member',

--- a/src/entities/search/ui/MemberList.tsx
+++ b/src/entities/search/ui/MemberList.tsx
@@ -1,0 +1,18 @@
+import { MemberItemUser } from '../model/types';
+import { MemberItem } from './MemberItem';
+
+export type MemberListProps = {
+  members: MemberItemUser[];
+};
+
+export const MemberList = ({ members }: MemberListProps) => {
+  return (
+    <ul className="flex flex-col">
+      {members.map((member) => (
+        <li key={member.name}>
+          <MemberItem user={member} />
+        </li>
+      ))}
+    </ul>
+  );
+};

--- a/src/entities/search/ui/MemberList.tsx
+++ b/src/entities/search/ui/MemberList.tsx
@@ -1,9 +1,9 @@
 import { MemberItemUser } from '../model/types';
 import { MemberItem } from './MemberItem';
 
-export type MemberListProps = {
+interface MemberListProps {
   members: MemberItemUser[];
-};
+}
 
 export const MemberList = ({ members }: MemberListProps) => {
   return (

--- a/src/entities/search/ui/MemberList.tsx
+++ b/src/entities/search/ui/MemberList.tsx
@@ -9,7 +9,7 @@ export const MemberList = ({ members }: MemberListProps) => {
   return (
     <ul className="flex flex-col">
       {members.map((member) => (
-        <li key={member.name}>
+        <li key={member.userId}>
           <MemberItem user={member} />
         </li>
       ))}

--- a/src/entities/user/model/mappers.ts
+++ b/src/entities/user/model/mappers.ts
@@ -47,6 +47,8 @@ export function mapUserProfile(dto: UserProfileApiResponse['data']): UserProfile
 
   return {
     name: dto.username,
+    bio: null, // TODO: API에서 bio 받아오도록 수정 필요
+    avatarUrl: null, // TODO: API에서 avatarUrl 받아오도록 수정 필요
     phoneNumber: dto.phoneNumber,
     email: dto.email,
     university: dto.university,

--- a/src/entities/user/model/mappers.ts
+++ b/src/entities/user/model/mappers.ts
@@ -46,6 +46,7 @@ export function mapUserProfile(dto: UserProfileApiResponse['data']): UserProfile
   }));
 
   return {
+    userId: 1, // TODO: API에서 userId 받아오도록 수정 필요
     name: dto.username,
     bio: null, // TODO: API에서 bio 받아오도록 수정 필요
     avatarUrl: null, // TODO: API에서 avatarUrl 받아오도록 수정 필요

--- a/src/entities/user/model/types.ts
+++ b/src/entities/user/model/types.ts
@@ -34,6 +34,9 @@ export type CareerUpdateDTO = Partial<CareerBase> & { careerId: number };
 
 export type UserProfile = {
   name: string;
+  // TODO: bio와 avatarUrl 받아와도 될지 확인 필요
+  bio: string | null;
+  avatarUrl: string | null;
   phoneNumber: string;
   email: string;
   university: string | null;

--- a/src/entities/user/model/types.ts
+++ b/src/entities/user/model/types.ts
@@ -33,8 +33,8 @@ export type CareerCreateDTO = CareerBase;
 export type CareerUpdateDTO = Partial<CareerBase> & { careerId: number };
 
 export type UserProfile = {
+  userId: number;
   name: string;
-  // TODO: bio와 avatarUrl 받아와도 될지 확인 필요
   bio: string | null;
   avatarUrl: string | null;
   phoneNumber: string;

--- a/src/shared/assets/icons/profile/manager-badge.svg
+++ b/src/shared/assets/icons/profile/manager-badge.svg
@@ -1,4 +1,4 @@
-<svg width="20" height="21" viewBox="0 0 20 21" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 20 21" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M0 10.5C0 4.97715 4.47715 0.5 10 0.5C15.5228 0.5 20 4.97715 20 10.5C20 16.0228 15.5228 20.5 10 20.5C4.47715 20.5 0 16.0228 0 10.5Z" fill="#15A4EC"/>
 <path d="M14 8.5C14 10.7091 12.2091 12.5 10 12.5C7.79086 12.5 6 10.7091 6 8.5C6 6.29086 7.79086 4.5 10 4.5C12.2091 4.5 14 6.29086 14 8.5Z" stroke="white" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M7.33329 11.4814L6.66663 15.7741C6.66663 16.3141 7.85483 16.6653 8.2981 16.4238L9.70182 15.6591C9.8895 15.5569 10.1104 15.5569 10.2981 15.6591L11.7018 16.4238C12.1451 16.6653 13.3333 16.3141 13.3333 15.7741L12.6666 11.4814" stroke="white" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 코드에 any가 사용되지 않았습니다
- [ ] 스토리북에 추가했습니다 (해당 시)
- [ ] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈
- close #234

## 📌 작업 목적
- MemberItem 및 MemberList 컴포넌트 제작

## 🔨 주요 작업 내용
- UserProfile 타입에 userId, bio (한 줄 소개), avatarUrl 추가
- mapUserProfile 매퍼 속성에 useId, bio, avatarUrl 추가 (백엔드 데이터 필요 주석 남김)
- InfoBadge (칩) 컨테이너 너비에 따라 보여질 칩의 개수와 +N개로 처리할 칩의 개수를 계산하는 훅 제작

## 🧪 테스트 방법
- 스토리북 Entities/UI/Notification/MemberItem, MemberList
- 뷰포트 너비 조절하며 반응형 테스트

## 📷 실행 영상 또는 스크린샷
https://github.com/user-attachments/assets/ac8483d0-8798-4ae6-94cb-a948b41b13ed

## 💬 논의할 점
- 

## 🙋🏻 참고 자료
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 멤버 프로필 카드 추가 — 아바타, 이름, 레벨 배지, 소개 표시
  * 멤버 목록을 세로로 나열해 개별 프로필 확인 가능
  * 칩(배지) 표시가 컨테이너 크기에 따라 동적으로 조정되며 초과분은 "+N"으로 표시

* **Documentation**
  * 다양한 상태(기본, 바이오 없음, 칩 다수 등)를 보여주는 스토리북 예제 추가

* **Types**
  * 프로필 타입에 ID, 소개(bio), 아바타 URL 필드 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->