### PR TITLE
[CHORE] Entites 계층 디자인 토큰 업데이트

### DIFF
--- a/src/entities/policy/ui/Markdown.tsx
+++ b/src/entities/policy/ui/Markdown.tsx
@@ -29,7 +29,13 @@ export function Markdown({ children }: { children: string }) {
           const hasNoMt = /\[no-mt\]\s*$/.test(raw);
           const label = raw.replace(/\s*\[(my-0|mb-0|no-mt)\]\s*$/, '');
 
-          const cls = hasMy0 ? 'my-0' : hasMb0 ? 'mt-6 mb-0' : hasNoMt ? 'mt-0 mb-6' : 'mt-6 mb-6';
+          const cls = hasMy0
+            ? 'my-0'
+            : hasMb0
+              ? 'mt-15 mb-0'
+              : hasNoMt
+                ? 'mt-0 mb-15'
+                : 'mt-15 mb-15';
 
           return (
             <h2 {...rest} className={`${className ?? ''} ${cls}`}>
@@ -38,22 +44,22 @@ export function Markdown({ children }: { children: string }) {
           );
         },
         h3: ({ children: c, className, ...rest }) => (
-          <h3 {...rest} className={`${className ?? ''} mt-6`}>
+          <h3 {...rest} className={`${className ?? ''} mt-15`}>
             {c}
           </h3>
         ),
         p: ({ children: c, className, ...rest }) => (
-          <p {...rest} className={`mb-2 leading-[1.65] break-keep ${className ?? ''}`}>
+          <p {...rest} className={`mb-2 leading-[2] break-keep ${className ?? ''}`}>
             {c}
           </p>
         ),
         ul: ({ children: c, className, ...rest }) => (
-          <ul {...rest} className={`mb-2 list-disc pl-5 ${className ?? ''}`}>
+          <ul {...rest} className={`mb-2 list-disc pl-13 ${className ?? ''}`}>
             {c}
           </ul>
         ),
         ol: ({ children: c, className, ...rest }) => (
-          <ol {...rest} className={`mb-2 list-decimal pl-5 ${className ?? ''}`}>
+          <ol {...rest} className={`mb-2 list-decimal pl-13 ${className ?? ''}`}>
             {c}
           </ol>
         ),

--- a/src/entities/policy/ui/Markdown.tsx
+++ b/src/entities/policy/ui/Markdown.tsx
@@ -49,7 +49,7 @@ export function Markdown({ children }: { children: string }) {
           </h3>
         ),
         p: ({ children: c, className, ...rest }) => (
-          <p {...rest} className={`mb-2 leading-[2] break-keep ${className ?? ''}`}>
+          <p {...rest} className={`mb-2 break-keep ${className ?? ''}`}>
             {c}
           </p>
         ),

--- a/src/entities/policy/ui/PolicyDetailItem.tsx
+++ b/src/entities/policy/ui/PolicyDetailItem.tsx
@@ -15,7 +15,7 @@ export const PolicyDetailItem = ({ policyId }: PolicyDetailItemProps) => {
   const md = preprocessToMarkdown(policyItem.text, policyId ?? policyItem.id);
 
   return (
-    <div className="flex flex-1 flex-col overflow-y-auto px-13 py-10 pb-[3.5rem]">
+    <div className="flex flex-1 flex-col overflow-y-auto px-13 pt-10 pb-[3.5rem]">
       <div className="text-xs leading-16 font-normal text-[#000]">
         <Markdown>{md}</Markdown>
       </div>

--- a/src/entities/policy/ui/PolicyDetailItem.tsx
+++ b/src/entities/policy/ui/PolicyDetailItem.tsx
@@ -15,8 +15,8 @@ export const PolicyDetailItem = ({ policyId }: PolicyDetailItemProps) => {
   const md = preprocessToMarkdown(policyItem.text, policyId ?? policyItem.id);
 
   return (
-    <div className="flex flex-1 flex-col overflow-y-auto px-13 pt-10 pb-[3.5rem]">
-      <div className="text-xs leading-16 font-normal text-[#000]">
+    <div className="flex flex-1 flex-col overflow-y-auto px-13 pt-11 pb-[3.5rem]">
+      <div className="text-body-body7 text-foreground-normal">
         <Markdown>{md}</Markdown>
       </div>
     </div>

--- a/src/entities/post/ui/post-card/PostCard.stories.tsx
+++ b/src/entities/post/ui/post-card/PostCard.stories.tsx
@@ -29,7 +29,7 @@ const mockPost: Post = {
   scrapCount: 0,
   commentCount: 8,
   categoryName: '행사',
-  thumbnailUrl: 'https://images.unsplash.com/photo-1522204507765-4b9e8f69e4f1?w=200&h=200&fit=crop',
+  thumbnailUrl: 'https://picsum.photos/200/300',
 };
 
 export const Default: Story = {

--- a/src/entities/post/ui/post-card/PostCard.tsx
+++ b/src/entities/post/ui/post-card/PostCard.tsx
@@ -6,6 +6,7 @@ import { PostBadge } from '@/entities/post/ui/post-badge/PostBadge';
 import { Post } from '../../model/types';
 import { stripHtml } from '@/shared/lib/stripHtml';
 import { toDate, toKST, timeAgo } from '@/shared/utils/date';
+import Image from 'next/image';
 
 type PostCardProps = {
   post: Post;
@@ -64,8 +65,8 @@ function PostCardComponent({
 
         {/* 본문 */}
         <div className="flex flex-col items-start gap-5 self-stretch">
-          <h3 className="text-body-body5 text-foreground-normal line-clamp-2">{title}</h3>
-          <p className="text-body-body6 text-foreground-normal-lighter line-clamp-1">
+          <h3 className="text-body-body6 text-foreground-normal line-clamp-2">{title}</h3>
+          <p className="text-body-body7 text-foreground-normal-lighter line-clamp-1">
             {stripHtml(content)}
           </p>
 
@@ -105,11 +106,13 @@ function PostCardComponent({
       {/* 썸네일 */}
       {thumbnailUrl && (
         <div className="aspect-square h-[4.375rem] w-[4.375rem] overflow-hidden">
-          <img
+          <Image
             src={thumbnailUrl}
             alt={`${title} 관련 이미지`}
-            className="h-full w-full object-cover"
+            className="object-cover"
             loading="lazy"
+            width={70}
+            height={70}
           />
         </div>
       )}

--- a/src/entities/post/ui/post-profile/PostProfile.tsx
+++ b/src/entities/post/ui/post-profile/PostProfile.tsx
@@ -13,7 +13,7 @@ export function PostProfile({ profileImgUrl, nickname, date, time, viewCount }: 
     <section className="flex items-center gap-10" aria-label={`${nickname}님의 작성 정보`}>
       <Avatar src={profileImgUrl} size="m" alt={`${nickname}의 프로필 이미지`} />
       <div className="flex flex-col items-start justify-center py-3">
-        <strong className="text-body-body7 text-foreground-normal">{nickname}</strong>
+        <strong className="text-body-body6 text-foreground-normal">{nickname}</strong>
 
         <div className="text-foreground-normal-lighter text-caption-caption4 flex items-center gap-7 pt-3">
           <time dateTime={date} aria-label={`작성일 ${date}`}>


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 코드에 any가 사용되지 않았습니다
- [ ] 스토리북에 추가했습니다 (해당 시)
- [ ] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈
- close #277

## 📌 작업 목적
- Entites 계층 디자인 토큰 업데이트 (policy, post)

## 🔨 주요 작업 내용
- policy 엔터티
  - PolicyDetailItem (외관 변화 x)
  - Markdown
- post 엔터티
  - PostCard
  - PostProfile

## 🧪 테스트 방법
- Markdown : `http://localhost:3000/mypage/settings/policy` 각 정책들 클릭하여 글자 간격 달라진 것 확인
- Postcard, PostProfile은 Post 엔터티 스토리북에서 확인

## 💬 논의할 점
- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 마크다운 제목(h2/h3), 단락, 목록의 여백과 줄간격 조정으로 가독성 개선
  * 게시물 카드 이미지 렌더링 최적화 및 본문 타이포그래피 세부 조정
  * 정책 상세 항목의 패딩 조정
  * 게시물 프로필 닉네임 텍스트 스타일 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->