### PR TITLE
[CHORE] Features 계층 디자인 토큰 업데이트

### DIFF
--- a/src/features/onboarding/ui/ProfileStep.tsx
+++ b/src/features/onboarding/ui/ProfileStep.tsx
@@ -10,7 +10,7 @@ export function ProfileStep() {
   return (
     <>
       {/* 프로필 이미지 업로더 */}
-      <div className="flex items-center justify-center gap-[0.62rem] self-stretch pt-[2.5rem] pb-[0.62rem]">
+      <div className="flex items-center justify-center gap-10 self-stretch pt-19 pb-10">
         <Controller
           name="profileImageUrl"
           control={control}
@@ -21,7 +21,7 @@ export function ProfileStep() {
       </div>
 
       {/* 이름 입력 */}
-      <div className="flex w-full flex-col items-start gap-[0.62rem] self-stretch">
+      <div className="flex w-full flex-col items-start gap-10 self-stretch">
         <FieldGroup title="이름" isRequired className="w-full">
           <Controller
             name="name"

--- a/src/features/onboarding/ui/TrackUnivStep.tsx
+++ b/src/features/onboarding/ui/TrackUnivStep.tsx
@@ -50,7 +50,7 @@ export function TrackUnivStep() {
       <div>
         <FieldGroup title="기수 및 파트" isRequired>
           {fields.map((field, idx) => (
-            <div key={field.id} className="flex items-center gap-[0.25rem]">
+            <div key={field.id} className="flex items-center gap-5">
               <SelectField
                 size="l"
                 placeholder="기수 및 파트를 선택해주세요"
@@ -66,7 +66,7 @@ export function TrackUnivStep() {
               />
 
               {fields.length > 1 && (
-                <button onClick={() => remove(idx)} className="p-[0.6rem]">
+                <button onClick={() => remove(idx)} className="p-8">
                   <SurfIcon size="l" name="TrashOne" />
                 </button>
               )}
@@ -79,7 +79,7 @@ export function TrackUnivStep() {
             size="s"
             variant="secondary"
             onClick={() => append({ generation: null, part: null })}
-            className="my-[0.625rem]"
+            className="my-10"
           >
             추가하기
           </SolidButton>
@@ -87,7 +87,7 @@ export function TrackUnivStep() {
       </div>
 
       {/* 대학교 및 대학원 */}
-      <div className="flex flex-col gap-[0.5rem]">
+      <div className="flex flex-col gap-3">
         <FieldGroup title="대학교" isRequired>
           <Controller
             name="university"

--- a/src/features/onboarding/ui/TrackUnivStep.tsx
+++ b/src/features/onboarding/ui/TrackUnivStep.tsx
@@ -66,7 +66,10 @@ export function TrackUnivStep() {
               />
 
               {fields.length > 1 && (
-                <button onClick={() => remove(idx)} className="p-8">
+                <button
+                  onClick={() => remove(idx)}
+                  className="flex h-[2.5rem] w-[2.5rem] items-center justify-center"
+                >
                   <SurfIcon size="l" name="TrashOne" />
                 </button>
               )}


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 코드에 any가 사용되지 않았습니다
- [ ] 스토리북에 추가했습니다 (해당 시)
- [ ] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈
- close #279

## 📌 작업 목적
- Features 계층 디자인 토큰 업데이트 (onboarding~post)

## 🔨 주요 작업 내용
- onboarding 피처
  - ProfileStep
  - TrackUnivStep
- post 피처 ui 없음

## 🧪 테스트 방법
- 온보딩으로 접속하기 위한 절차 (온보딩 했어도 홈으로 가지 않게 하기)
- 1. `AuthProvider` 컴포넌트에서 37번째 줄을 다음과 같이 수정 `APPROVED: (path: string) => (path === '/' ? '/home' : null),`
- 2. `OnboardingForm` 컴포넌트에서 21번째 줄에 `useState(0)`. `useState(1)`, `useState(2)`를 넣어보며 온보딩 화면 확인 가능

## 💬 논의할 점
- 이름 입력해도 "다음" 버튼 활성화 안됨
- 기수 선택 피커 UI 이상
- 일단 토큰 업데이트 하느라 뜯어보진 못했는데, 테스트 해보다 발견한 오류들입니다.

## 🙋🏻 참고 자료
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style

* **UI 스타일 표준화**
  * 온보딩 화면의 컴포넌트 간격 및 정렬을 표준 디자인 스케일로 업데이트했습니다.
  * 프로필 이미지 업로더, 이름 필드, 대학원 추적 필드의 스타일 토큰을 일관성 있게 정규화했습니다.
  * 버튼과 레이아웃의 시각적 표현이 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->