### PR TITLE
[HOTFIX] ActivityBadge 중복 문제

### DIFF
--- a/src/entities/calendar/ui/CalendarActivityBadge/CalendarActivityBadge.stories.tsx
+++ b/src/entities/calendar/ui/CalendarActivityBadge/CalendarActivityBadge.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/nextjs';
-import { ActivityBadge } from './ActivityBadge';
+import { CalendarActivityBadge } from './CalendarActivityBadge';
 import type { DailyActivity } from '@/entities/calendar/model/types';
 
 const createDummyItem = (
@@ -13,9 +13,9 @@ const createDummyItem = (
   endDate: new Date(),
 });
 
-const meta: Meta<typeof ActivityBadge> = {
+const meta: Meta<typeof CalendarActivityBadge> = {
   title: 'Entities/UI/Calendar/ActivityBadge',
-  component: ActivityBadge,
+  component: CalendarActivityBadge,
   parameters: {
     layout: 'centered',
   },
@@ -44,7 +44,7 @@ const meta: Meta<typeof ActivityBadge> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof ActivityBadge>;
+type Story = StoryObj<typeof CalendarActivityBadge>;
 
 // ───────────────────────────────
 // 기본 상태들 (타입별)
@@ -97,14 +97,26 @@ export const AllVariations: Story = {
   render: () => (
     <div className="flex w-[150px] flex-col gap-4">
       <div className="text-sm font-bold">Current Month</div>
-      <ActivityBadge item={createDummyItem('official', '공식 일정')} isCurrentMonth={true} />
-      <ActivityBadge item={createDummyItem('operation', '운영 일정')} isCurrentMonth={true} />
-      <ActivityBadge item={createDummyItem('other', '기타 일정')} isCurrentMonth={true} />
+      <CalendarActivityBadge
+        item={createDummyItem('official', '공식 일정')}
+        isCurrentMonth={true}
+      />
+      <CalendarActivityBadge
+        item={createDummyItem('operation', '운영 일정')}
+        isCurrentMonth={true}
+      />
+      <CalendarActivityBadge item={createDummyItem('other', '기타 일정')} isCurrentMonth={true} />
 
       <div className="mt-4 text-sm font-bold">Other Month (Opacity 50%)</div>
-      <ActivityBadge item={createDummyItem('official', '공식 일정')} isCurrentMonth={false} />
-      <ActivityBadge item={createDummyItem('operation', '운영 일정')} isCurrentMonth={false} />
-      <ActivityBadge item={createDummyItem('other', '기타 일정')} isCurrentMonth={false} />
+      <CalendarActivityBadge
+        item={createDummyItem('official', '공식 일정')}
+        isCurrentMonth={false}
+      />
+      <CalendarActivityBadge
+        item={createDummyItem('operation', '운영 일정')}
+        isCurrentMonth={false}
+      />
+      <CalendarActivityBadge item={createDummyItem('other', '기타 일정')} isCurrentMonth={false} />
     </div>
   ),
 };

--- a/src/entities/calendar/ui/CalendarActivityBadge/CalendarActivityBadge.tsx
+++ b/src/entities/calendar/ui/CalendarActivityBadge/CalendarActivityBadge.tsx
@@ -3,9 +3,9 @@ import type { DailyActivity } from '@/entities/calendar/model/types';
 type Props = { item: DailyActivity; isCurrentMonth?: boolean };
 
 const labelByType: Record<DailyActivity['category'], string> = {
-  official: '공식 일정',
-  operation: '운영 일정',
-  other: '기타 일정',
+  official: '정규행사',
+  operation: '운영회의',
+  other: '기타일정',
 };
 
 const colorByType: Record<DailyActivity['category'], string> = {
@@ -14,7 +14,7 @@ const colorByType: Record<DailyActivity['category'], string> = {
   other: 'bg-background-tag-green text-foreground-tag-green-darker',
 };
 
-export function ActivityBadge({ item, isCurrentMonth = true }: Props) {
+export function CalendarActivityBadge({ item, isCurrentMonth = true }: Props) {
   const baseClasses =
     'flex w-full min-w-0 items-center inline-flex rounded-2 px-2 py-3 text-caption-caption5 flex-shrink-0';
   const opacityClass = isCurrentMonth ? '' : 'opacity-50';

--- a/src/entities/calendar/ui/DailyActivityBadgeList/DailyActivityBadgeList.tsx
+++ b/src/entities/calendar/ui/DailyActivityBadgeList/DailyActivityBadgeList.tsx
@@ -1,5 +1,5 @@
 import type { DailyActivity } from '@/entities/calendar/model/types';
-import { ActivityBadge } from '@/entities/calendar/ui/ActivityBadge/ActivityBadge';
+import { CalendarActivityBadge } from '@/entities/calendar/ui/CalendarActivityBadge/CalendarActivityBadge';
 
 type Props = {
   items: DailyActivity[];
@@ -16,7 +16,7 @@ export function DailyActivityBadgeList({ items, maxVisible = 2, isCurrentMonth =
   return (
     <div className="flex h-full w-full min-w-0 flex-col items-start justify-center gap-3">
       {visible.map((it) => (
-        <ActivityBadge key={it.id} item={it} isCurrentMonth={isCurrentMonth} />
+        <CalendarActivityBadge key={it.id} item={it} isCurrentMonth={isCurrentMonth} />
       ))}
       {remain > 0 && (
         <div


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 코드에 any가 사용되지 않았습니다
- [ ] 스토리북에 추가했습니다 (해당 시)
- [ ] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈
- close #

## ⚠️ 기존 문제 / ☑️ 해결 방법
- ActivityBadge 명칭이 중복 사용 되어 캘린더에 사용되는 ActivityBadge 컴포넌트 명칭을 CalendarActivityBadge로 변경하였습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **버그 수정**
  * 캘린더의 활동 배지 라벨 텍스트가 업데이트되었습니다.
    - '공식 일정' → '정규행사'
    - '운영 일정' → '운영회의'
    - '기타 일정' → '기타일정'

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->