### PR TITLE
[FIX] AnnouncementBar, Shortcut, Carousel 컴포넌트 수정

### DIFF
--- a/src/entities/schedule/ui/announcement-bar/AnnouncementBar.stories.tsx
+++ b/src/entities/schedule/ui/announcement-bar/AnnouncementBar.stories.tsx
@@ -14,21 +14,9 @@ const meta: Meta<typeof AnnouncementBar> = {
       control: 'select',
       options: CATEGORY_OPTIONS,
     },
-    date: { control: 'date' },
+    date: { control: 'text' },
     title: { control: 'text' },
   },
-
-  decorators: [
-    (Story, context) => {
-      const dateArg = context.args.date;
-
-      if (!(dateArg instanceof Date)) {
-        context.args.date = new Date(dateArg);
-      }
-
-      return <Story {...context} />;
-    },
-  ],
 };
 
 export default meta;
@@ -37,7 +25,7 @@ type Story = StoryObj<typeof AnnouncementBar>;
 export const Default: Story = {
   args: {
     title: '후반기 만남의 장 공지',
-    date: new Date(),
+    date: '12.31',
     category: 'official',
   },
 };

--- a/src/entities/schedule/ui/announcement-bar/AnnouncementBar.tsx
+++ b/src/entities/schedule/ui/announcement-bar/AnnouncementBar.tsx
@@ -1,10 +1,9 @@
 import { ActivityCategory } from '@/entities/calendar/model/types';
-import { formatMonthDay } from '@/shared/utils/date';
 import { CalendarBadge } from '@/entities/calendar/ui/CalendarBadge/CalendarBadge';
 
 interface AnnouncementBarProps {
   title: string;
-  date: Date;
+  date: string;
   category: ActivityCategory;
   onClick?: () => void;
 }
@@ -15,7 +14,7 @@ export const AnnouncementBar = ({ title, date, category, onClick }: Announcement
       className="text-body-body9 text-foreground-normal bg-background-normal-lighter rounded-5 border-border-secondary flex h-[3.125rem] w-full items-center gap-10 border px-13 shadow-[0_0_20px_3px_rgba(0,0,0,0.04)]"
       onClick={onClick}
     >
-      <div>{formatMonthDay(date)}</div>
+      <div>{date}</div>
       <CalendarBadge variation={category} />
       <div>{title}</div>
     </button>

--- a/src/entities/schedule/ui/announcement-bar/AnnouncementBar.tsx
+++ b/src/entities/schedule/ui/announcement-bar/AnnouncementBar.tsx
@@ -12,7 +12,7 @@ interface AnnouncementBarProps {
 export const AnnouncementBar = ({ title, date, category, onClick }: AnnouncementBarProps) => {
   return (
     <button
-      className="text-body-body9 text-foreground-normal bg-background-normal-lighter rounded-5 flex h-[3.125rem] w-full items-center gap-10 px-13"
+      className="text-body-body9 text-foreground-normal bg-background-normal-lighter rounded-5 border-border-secondary flex h-[3.125rem] w-full items-center gap-10 border px-13 shadow-[0_0_20px_3px_rgba(0,0,0,0.04)]"
       onClick={onClick}
     >
       <div>{formatMonthDay(date)}</div>

--- a/src/shared/ui/carousel/Carousel.stories.tsx
+++ b/src/shared/ui/carousel/Carousel.stories.tsx
@@ -48,3 +48,30 @@ export const Single: Story = {
     className: 'w-[300px] h-[150px]',
   },
 };
+
+export const WithOrderAndLink: Story = {
+  name: 'With Order & Link',
+  args: {
+    images: [
+      {
+        src: 'https://public.mujikorea.co.kr/images/products/categories/mjPpw4Qa3Ds4faXJOmFhHIhD83YQqC88jPFYxbFZ.jpg',
+        alt: '1번 이미지 (order 1)',
+        displayOrder: 1,
+        linkUrl: 'https://www.google.com/',
+      },
+      {
+        src: 'https://public.mujikorea.co.kr/images/plans/2510_men_bn_pc.jpg',
+        alt: '2번 이미지 (order 2)',
+        displayOrder: 2,
+        linkUrl: 'https://www.naver.com/',
+      },
+      {
+        src: 'https://public.mujikorea.co.kr/images/products/categories/kPekPdSyST6wgk6RqUVZz0JnquFG6rhmTmEjJL5H.jpg',
+        alt: '3번 이미지 (order 3)',
+        displayOrder: 3,
+        linkUrl: 'https://www.mujikorea.co.kr/product',
+      },
+    ],
+    className: 'w-[300px] h-[150px]',
+  },
+};

--- a/src/shared/ui/carousel/Carousel.tsx
+++ b/src/shared/ui/carousel/Carousel.tsx
@@ -1,12 +1,14 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Pagenation } from '../pagenation/Pagenation';
 import { Control } from './Control';
 
 interface CarouselImage {
   src: string;
   alt: string;
+  linkUrl?: string;
+  displayOrder?: number;
 }
 
 interface CarouselProps {
@@ -21,7 +23,16 @@ export const Carousel = ({ images, className = '' }: CarouselProps) => {
   const [current, setCurrent] = useState(0);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const length = images.length;
+  const sortedImages = useMemo(() => {
+    return [...images].sort((a, b) => {
+      // displayOrder 없는 경우는 뒤로
+      if (a.displayOrder == null && b.displayOrder == null) return 0;
+      if (a.displayOrder == null) return 1;
+      if (b.displayOrder == null) return -1;
+      return a.displayOrder - b.displayOrder;
+    });
+  }, [images]);
+  const length = sortedImages.length;
 
   const resetTimer = useCallback(() => {
     // 이전 타미어 존재하면 제거
@@ -47,12 +58,12 @@ export const Carousel = ({ images, className = '' }: CarouselProps) => {
   // 좌측 버튼
   const handlePrev = () => {
     // 음수 인덱스 방지하여 이동
-    setCurrent((prev) => (prev - 1 + images.length) % images.length);
+    setCurrent((prev) => (prev - 1 + length) % length);
   };
 
   // 우측 버튼
   const handleNext = () => {
-    setCurrent((prev) => (prev + 1) % images.length);
+    setCurrent((prev) => (prev + 1) % length);
   };
 
   if (length === 0) {
@@ -65,13 +76,17 @@ export const Carousel = ({ images, className = '' }: CarouselProps) => {
         className="flex h-full transition-transform duration-500 ease-in-out"
         style={{ transform: `translateX(-${current * 100}%)` }}
       >
-        {images.map((img, idx) => (
-          <img
+        {sortedImages.map((img, idx) => (
+          <button
             key={idx}
-            src={img.src}
-            alt={img.alt}
-            className="h-full w-full flex-shrink-0 object-cover"
-          />
+            onClick={() => {
+              if (!img.linkUrl) return;
+              window.open(img.linkUrl, '_blank');
+            }}
+            className="h-full w-full flex-shrink-0 cursor-pointer"
+          >
+            <img src={img.src} alt={img.alt} className="h-full w-full object-cover" />
+          </button>
         ))}
       </div>
 
@@ -96,7 +111,7 @@ export const Carousel = ({ images, className = '' }: CarouselProps) => {
       {/* 페이지네이션 */}
       <Pagenation
         currentPage={current + 1}
-        totalPages={images.length}
+        totalPages={length}
         className="absolute right-[10px] bottom-[10px]"
       />
     </div>

--- a/src/shared/ui/carousel/Carousel.tsx
+++ b/src/shared/ui/carousel/Carousel.tsx
@@ -83,7 +83,7 @@ export const Carousel = ({ images, className = '' }: CarouselProps) => {
               if (!img.linkUrl) return;
               window.open(img.linkUrl, '_blank');
             }}
-            className="h-full w-full flex-shrink-0 cursor-pointer"
+            className="h-full w-full flex-shrink-0"
           >
             <img src={img.src} alt={img.alt} className="h-full w-full object-cover" />
           </button>

--- a/src/shared/ui/shortcut/Shortcut.stories.tsx
+++ b/src/shared/ui/shortcut/Shortcut.stories.tsx
@@ -35,6 +35,7 @@ export const Circle: Story = {
     label: 'Label',
     imageSrc:
       'https://product.mujikorea.co.kr/images/products/8809191730770/NEW/8809191730770.jpg?w=960&f=webp',
+    onClick: () => alert('Circle shortcut 클릭됨'),
   },
 };
 
@@ -44,5 +45,6 @@ export const Rectangle: Story = {
     label: 'Label',
     imageSrc:
       'https://product.mujikorea.co.kr/images/products/8809191730770/NEW/8809191730770.jpg?w=960&f=webp',
+    onClick: () => alert('Rectangle shortcut 클릭됨'),
   },
 };

--- a/src/shared/ui/shortcut/Shortcut.tsx
+++ b/src/shared/ui/shortcut/Shortcut.tsx
@@ -4,25 +4,29 @@ interface ShortcutProps {
   type: 'circle' | 'rectangle';
   label: string;
   imageSrc?: string;
+  onClick?: () => void;
 }
 
-export const Shortcut = ({ type, label, imageSrc }: ShortcutProps) => {
+export const Shortcut = ({ type, label, imageSrc, onClick }: ShortcutProps) => {
   if (type === 'circle') {
     return (
-      <div className="flex flex-col items-center gap-7">
+      <button className="flex cursor-pointer flex-col items-center gap-7" onClick={onClick}>
         <div className="h-[2.5rem] w-[2.5rem] overflow-hidden rounded-full bg-gray-200">
           {imageSrc && (
             <Image src={imageSrc} alt={label} width={40} height={40} className="object-cover" />
           )}
         </div>
         <span className="text-caption-caption6">{label}</span>
-      </div>
+      </button>
     );
   }
 
   // rectangle
   return (
-    <div className="bg-background-normal-lighter rounded-5 border-border-secondary flex h-[9.375rem] w-[6.5625rem] flex-col overflow-hidden border">
+    <button
+      className="bg-background-normal-lighter rounded-5 border-border-secondary flex h-[9.375rem] w-[6.5625rem] cursor-pointer flex-col items-start overflow-hidden border shadow-[0_0_20px_3px_rgba(0,0,0,0.04)]"
+      onClick={onClick}
+    >
       {/* Label 영역 */}
       <div className="text-foreground-normal text-body-body5 px-13 pt-13">{label}</div>
 
@@ -38,6 +42,6 @@ export const Shortcut = ({ type, label, imageSrc }: ShortcutProps) => {
           />
         )}
       </div>
-    </div>
+    </button>
   );
 };

--- a/src/shared/ui/shortcut/Shortcut.tsx
+++ b/src/shared/ui/shortcut/Shortcut.tsx
@@ -10,7 +10,7 @@ interface ShortcutProps {
 export const Shortcut = ({ type, label, imageSrc, onClick }: ShortcutProps) => {
   if (type === 'circle') {
     return (
-      <button className="flex cursor-pointer flex-col items-center gap-7" onClick={onClick}>
+      <button className="flex flex-col items-center gap-7" onClick={onClick}>
         <div className="h-[2.5rem] w-[2.5rem] overflow-hidden rounded-full bg-gray-200">
           {imageSrc && (
             <Image src={imageSrc} alt={label} width={40} height={40} className="object-cover" />
@@ -24,7 +24,7 @@ export const Shortcut = ({ type, label, imageSrc, onClick }: ShortcutProps) => {
   // rectangle
   return (
     <button
-      className="bg-background-normal-lighter rounded-5 border-border-secondary flex h-[9.375rem] w-[6.5625rem] cursor-pointer flex-col items-start overflow-hidden border shadow-[0_0_20px_3px_rgba(0,0,0,0.04)]"
+      className="bg-background-normal-lighter rounded-5 border-border-secondary flex h-[9.375rem] w-[6.5625rem] flex-col items-start overflow-hidden border shadow-[0_0_20px_3px_rgba(0,0,0,0.04)]"
       onClick={onClick}
     >
       {/* Label 영역 */}


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 any가 사용되지 않았습니다
- [x] 스토리북에 추가했습니다 (해당 시)
- [x] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈
- close #305 

## 📌 작업 목적
- AnnouncementBar, Shortcut, Carousel 컴포넌트 수정

## 🔨 주요 작업 내용
- AnnouncementBar
  - shadow 적용
  - border 적용
  - date prop 타입 string으로 변경
- Shortcut
  - type='rectangle'일 경우 shadow 적용
  - onClick prop 추가
- Carousel
  - linkUrl, displayOrder props 추가
  - 컴포넌트 내부에서 이미지 순서 displayOrder 기반 정렬
  - 클릭 시 해당 linkUrl 오픈

## 🧪 테스트 방법
1. `pnpm storybook`
2. 각 컴포넌트 스토리북 확인
- `Shared/UI/Carousel`
- `Shared/UI/Shortcut`
- `Entities/UI/Schedule/AnnouncementBar`




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 캐러셀: 이미지별 정렬 순서와 링크 지원 추가(정렬에 따라 표시되며 링크는 새 탭으로 열림).
  * 단축키 요소: 클릭 상호작용(onClick) 추가.

* **스타일**
  * 알림 바에 테두리 및 그림자 추가.
  * 클릭 가능한 요소의 포인터/커서 스타일 개선.

* **호환성 변경**
  * 알림 바의 날짜 표현 방식이 문자열로 변경되어 입력값 그대로 화면에 표시됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->