### PR TITLE
[FIX] 게시글 작성 시 게시글 예약 기능 오류 수정

### DIFF
--- a/src/app-pages/post/write/ui/PostPage.tsx
+++ b/src/app-pages/post/write/ui/PostPage.tsx
@@ -58,6 +58,7 @@ export default function PostPage(props: PostPageProps) {
 
   // 예약 시간 임시 저장용 state (취소 시 롤백 위함)
   const [tempDate, setTempDate] = useState<Date>(new Date());
+  const [showRemoveReservationAlert, setShowRemoveReservationAlert] = useState(false);
 
   // 모달 열릴 때 현재 예약 시간으로 초기화
   useEffect(() => {
@@ -70,6 +71,18 @@ export default function PostPage(props: PostPageProps) {
     setReservedAt(tempDate);
     setReserved(true);
     closeReservationModal();
+  };
+
+  const handleRemoveReservation = () => {
+    closeReservationModal();
+    setTimeout(() => setShowRemoveReservationAlert(true), 100);
+  };
+
+  // 실제 예약 취소
+  const handleConfirmRemove = () => {
+    setReserved(false);
+    setReservedAt(null);
+    setShowRemoveReservationAlert(false);
   };
 
   const board = POST_BOARDS.find((b) => b.id === Number(boardId));
@@ -170,7 +183,6 @@ export default function PostPage(props: PostPageProps) {
       </div>
 
       {/* 6. 예약 설정 모달 */}
-      {/* TODO: 리팩토링 필요 */}
       <ModalSheet
         isOpen={isReservationModalOpen}
         onClose={closeReservationModal}
@@ -181,11 +193,32 @@ export default function PostPage(props: PostPageProps) {
             <Sheet
               title="게시글 예약 설정"
               description="해당 시간에 맞춰 게시글이 예약됩니다"
-              primaryBtn={{ label: '예약하기', onClick: handleSaveReservation }}
-              secondaryBtn={{ label: '취소하기', onClick: closeReservationModal }}
+              primaryBtn={
+                reserved
+                  ? {
+                      label: '수정하기',
+                      onClick: handleSaveReservation,
+                    }
+                  : {
+                      label: '예약하기',
+                      onClick: handleSaveReservation,
+                    }
+              }
+              secondaryBtn={
+                reserved
+                  ? {
+                      label: '예약 취소하기',
+                      onClick: handleRemoveReservation,
+                      variant: 'warning',
+                    }
+                  : {
+                      label: '취소하기',
+                      onClick: closeReservationModal,
+                    }
+              }
             >
               <div className="py-15">
-                <DateTimePicker mode="all" value={tempDate} onChange={setTempDate} />
+                <DateTimePicker mode="future" value={tempDate} onChange={setTempDate} />
               </div>
             </Sheet>
           </ModalSheet.Content>
@@ -193,7 +226,30 @@ export default function PostPage(props: PostPageProps) {
         <ModalSheet.Backdrop onTap={closeReservationModal} />
       </ModalSheet>
 
-      {/* 7. 뒤로가기 경고 모달 */}
+      {/* 7. 실제 예약 취소 확인 모달 */}
+      <Alert
+        state="default"
+        title="설정한 예약이 취소됩니다"
+        infoText="예약 취소하기를 누를 경우 게시글 내 설정된 예약이 삭제됩니다."
+        isOpen={showRemoveReservationAlert}
+        onClose={() => setShowRemoveReservationAlert(false)}
+        actions={[
+          {
+            type: 'solid',
+            label: '취소',
+            variant: 'secondary',
+            onClick: () => setShowRemoveReservationAlert(false),
+          },
+          {
+            type: 'solid',
+            label: '삭제하기',
+            variant: 'danger',
+            onClick: handleConfirmRemove,
+          },
+        ]}
+      />
+
+      {/* 8. 뒤로가기 경고 모달 */}
       <Alert
         state="default"
         title="변경 내용을 저장하지 않고 나가시겠습니까?"

--- a/src/app-pages/post/write/ui/PostPage.tsx
+++ b/src/app-pages/post/write/ui/PostPage.tsx
@@ -68,9 +68,13 @@ export default function PostPage(props: PostPageProps) {
   }, [isReservationModalOpen, reservedAt]);
 
   const handleSaveReservation = () => {
-    setReservedAt(tempDate);
-    setReserved(true);
-    closeReservationModal();
+    if (tempDate > new Date()) {
+      setReservedAt(tempDate);
+      setReserved(true);
+      closeReservationModal();
+    } else {
+      alert('현재 시간 이후로만 예약할 수 있습니다.');
+    }
   };
 
   const handleRemoveReservation = () => {

--- a/src/app-pages/post/write/ui/PostPage.tsx
+++ b/src/app-pages/post/write/ui/PostPage.tsx
@@ -177,7 +177,6 @@ export default function PostPage(props: PostPageProps) {
         className="mx-auto flex w-full sm:w-[360px]"
       >
         <ModalSheet.Container>
-          <ModalSheet.Header />
           <ModalSheet.Content>
             <Sheet
               title="게시글 예약 설정"
@@ -185,8 +184,8 @@ export default function PostPage(props: PostPageProps) {
               primaryBtn={{ label: '예약하기', onClick: handleSaveReservation }}
               secondaryBtn={{ label: '취소하기', onClick: closeReservationModal }}
             >
-              <div>
-                <DateTimePicker value={tempDate} onChange={setTempDate} />
+              <div className="py-15">
+                <DateTimePicker mode="all" value={tempDate} onChange={setTempDate} />
               </div>
             </Sheet>
           </ModalSheet.Content>

--- a/src/entities/schedule/ui/DateTimePicker/DateTimePicker.stories.tsx
+++ b/src/entities/schedule/ui/DateTimePicker/DateTimePicker.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { DateTimePicker } from './DateTimePicker';
+import { useState } from 'react';
+
+const meta: Meta<typeof DateTimePicker> = {
+  title: 'Entities/UI/Schedule/DateTimePicker',
+  component: DateTimePicker,
+  tags: ['autodocs'],
+  argTypes: {
+    value: {
+      control: 'date',
+      description: '선택된 날짜 객체 (Date)',
+    },
+    onChange: { action: 'changed' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof DateTimePicker>;
+
+export const Default: Story = {
+  args: {
+    value: new Date(),
+  },
+};
+
+// 실제 동작 확인용
+export const Interactive: Story = {
+  render: (args) => {
+    const [date, setDate] = useState<Date>(args.value ? new Date(args.value) : new Date());
+
+    const handleChange = (newDate: Date) => {
+      setDate(newDate);
+      args.onChange?.(newDate);
+    };
+
+    return (
+      <div className="mx-auto max-w-md rounded-lg p-4 sm:w-[360px]">
+        <div className="mb-4 text-center text-lg font-bold">
+          선택된 날짜: {date.toLocaleString('ko-KR')}
+        </div>
+        <div className="border">
+          <DateTimePicker value={date} onChange={handleChange} />
+        </div>
+      </div>
+    );
+  },
+  args: {
+    value: new Date(),
+  },
+};

--- a/src/entities/schedule/ui/DateTimePicker/DateTimePicker.tsx
+++ b/src/entities/schedule/ui/DateTimePicker/DateTimePicker.tsx
@@ -68,8 +68,6 @@ export function DateTimePicker({ value, onChange, mode = 'all' }: DateTimePicker
 
   const getInitialRoundedDate = useCallback(() => {
     return roundToNearestMinutes(value, { nearestTo: 30, roundingMethod: 'ceil' });
-
-    return value;
   }, [value]);
 
   // 초기값 설정

--- a/src/entities/schedule/ui/DateTimePicker/DateTimePicker.tsx
+++ b/src/entities/schedule/ui/DateTimePicker/DateTimePicker.tsx
@@ -10,6 +10,7 @@ import {
   startOfDay,
   subYears,
   addYears,
+  roundToNearestMinutes,
 } from 'date-fns';
 import { ko } from 'date-fns/locale';
 
@@ -24,7 +25,7 @@ export type DateTimePickerProps = {
 const MINUTES = [0, 30];
 const AM_PM_OPTIONS = ['오전', '오후'];
 
-export function DateTimePicker({ value, onChange, mode = 'future' }: DateTimePickerProps) {
+export function DateTimePicker({ value, onChange, mode = 'all' }: DateTimePickerProps) {
   // index 0 => 오늘
   const { BASE_DATE, TOTAL_DAYS } = useMemo(() => {
     const today = startOfDay(new Date());
@@ -65,8 +66,14 @@ export function DateTimePicker({ value, onChange, mode = 'future' }: DateTimePic
     [BASE_DATE],
   );
 
+  const getInitialRoundedDate = useCallback(() => {
+    return roundToNearestMinutes(value, { nearestTo: 30, roundingMethod: 'ceil' });
+
+    return value;
+  }, [value]);
+
   // 초기값 설정
-  const [indices, setIndices] = useState(() => getIndicesFromDate(value));
+  const [indices, setIndices] = useState(() => getIndicesFromDate(getInitialRoundedDate()));
 
   // --- 이벤트 핸들러 ---
   const handleWheelChange = useCallback(

--- a/src/entities/schedule/ui/DateTimePicker/DateTimePicker.tsx
+++ b/src/entities/schedule/ui/DateTimePicker/DateTimePicker.tsx
@@ -2,20 +2,52 @@
 
 import { useState, useCallback, useMemo } from 'react';
 import { Wheel } from '@/shared/ui/wheel-picker/Wheel';
-import { isToday, addDays, differenceInCalendarDays, format, startOfDay } from 'date-fns';
+import {
+  isToday,
+  addDays,
+  differenceInCalendarDays,
+  format,
+  startOfDay,
+  subYears,
+  addYears,
+} from 'date-fns';
 import { ko } from 'date-fns/locale';
 
-type DateTimePickerProps = {
+export type DatePickerMode = 'future' | 'all';
+
+export type DateTimePickerProps = {
   value: Date;
   onChange: (date: Date) => void;
+  mode?: DatePickerMode;
 };
 
 const MINUTES = [0, 30];
 const AM_PM_OPTIONS = ['오전', '오후'];
 
-export function DateTimePicker({ value, onChange }: DateTimePickerProps) {
+export function DateTimePicker({ value, onChange, mode = 'future' }: DateTimePickerProps) {
   // index 0 => 오늘
-  const BASE_DATE = useMemo(() => startOfDay(new Date()), []);
+  const { BASE_DATE, TOTAL_DAYS } = useMemo(() => {
+    const today = startOfDay(new Date());
+
+    if (mode === 'future') {
+      // 미래 모드: 오늘부터 ~ 3년 뒤까지
+      // Index 0 = 오늘
+      return {
+        BASE_DATE: today,
+        TOTAL_DAYS: 365 * 3,
+      };
+    } else {
+      // 전체 모드: 과거 50년 ~ 미래 50년 (총 100년 범위)
+      // Index 0 = 50년 전
+      const pastDate = subYears(today, 50);
+      const futureDate = addYears(today, 50);
+
+      return {
+        BASE_DATE: pastDate,
+        TOTAL_DAYS: differenceInCalendarDays(futureDate, pastDate),
+      };
+    }
+  }, [mode]);
 
   const getIndicesFromDate = useCallback(
     (date: Date) => {
@@ -108,7 +140,7 @@ export function DateTimePicker({ value, onChange }: DateTimePickerProps) {
       <div className="z-20 flex h-full w-full">
         <Wheel
           value={indices.dateIdx}
-          length={365} // 1년치만 보여줌
+          length={TOTAL_DAYS}
           width={140}
           loop={false}
           setValue={formatDateLabel}

--- a/src/entities/schedule/ui/DateTimePicker/DateTimePicker.tsx
+++ b/src/entities/schedule/ui/DateTimePicker/DateTimePicker.tsx
@@ -38,10 +38,10 @@ export function DateTimePicker({ value, onChange, mode = 'all' }: DateTimePicker
         TOTAL_DAYS: 365 * 3,
       };
     } else {
-      // 전체 모드: 과거 50년 ~ 미래 50년 (총 100년 범위)
-      // Index 0 = 50년 전
-      const pastDate = subYears(today, 50);
-      const futureDate = addYears(today, 50);
+      // 전체 모드: 과거 3년 ~ 미래 3년 (총 6년 범위)
+      // Index 0 = 3년 전
+      const pastDate = subYears(today, 3);
+      const futureDate = addYears(today, 3);
 
       return {
         BASE_DATE: pastDate,

--- a/src/entities/schedule/ui/DateTimePicker/DateTimePicker.tsx
+++ b/src/entities/schedule/ui/DateTimePicker/DateTimePicker.tsx
@@ -1,9 +1,9 @@
 'use client';
-// TODO: 리팩토링에 참고 필요
-import { useState, useEffect, useCallback } from 'react';
+
+import { useState, useCallback, useMemo } from 'react';
 import { Wheel } from '@/shared/ui/wheel-picker/Wheel';
-import { isToday, addDays, differenceInCalendarDays, format } from 'date-fns';
-import { ko } from 'date-fns/locale'; // 요일 한글 처리를 위해
+import { isToday, addDays, differenceInCalendarDays, format, startOfDay } from 'date-fns';
+import { ko } from 'date-fns/locale';
 
 type DateTimePickerProps = {
   value: Date;
@@ -13,100 +13,91 @@ type DateTimePickerProps = {
 const MINUTES = [0, 30];
 const AM_PM_OPTIONS = ['오전', '오후'];
 
-// 기준일 설정 (예: 1900년 1월 1일, 혹은 올해 1월 1일)
-// 이 날짜가 인덱스 0이 됩니다. 충분히 과거로 잡아두면 과거 날짜도 선택 가능합니다.
-// 여기서는 편의상 "올해 1월 1일"을 기준으로 잡겠습니다.
-const BASE_DATE = new Date(new Date().getFullYear(), 0, 1);
-
 export function DateTimePicker({ value, onChange }: DateTimePickerProps) {
-  // --- 1. 날짜(Date) Wheel 인덱스 계산 ---
-  // value가 BASE_DATE로부터 며칠 떨어져 있는지 계산합니다.
-  const getInitialDateIndex = useCallback((targetDate: Date) => {
-    return differenceInCalendarDays(targetDate, BASE_DATE);
-  }, []);
+  // index 0 => 오늘
+  const BASE_DATE = useMemo(() => startOfDay(new Date()), []);
 
-  // --- 2. 시간/분 인덱스 계산 ---
-  const getInitialHourIndex = (date: Date) => {
-    const hour = date.getHours();
-    // 12시간제 (1~12) 인덱스 (0~11)
-    const hour12 = hour % 12 === 0 ? 12 : hour % 12;
-    return hour12 === 12 ? 11 : hour12 - 1;
-  };
+  const getIndicesFromDate = useCallback(
+    (date: Date) => {
+      const diff = differenceInCalendarDays(date, BASE_DATE);
+      const hour = date.getHours();
+      const minute = date.getMinutes();
 
-  const getInitialAmPmIndex = (date: Date) => (date.getHours() < 12 ? 0 : 1);
-  const getInitialMinuteIndex = (date: Date) => (date.getMinutes() >= 30 ? 1 : 0);
+      return {
+        dateIdx: Math.max(0, diff),
+        amPmIdx: hour < 12 ? 0 : 1,
+        hourIdx: (hour % 12 === 0 ? 12 : hour % 12) === 12 ? 11 : (hour % 12) - 1,
+        minuteIdx: minute >= 30 ? 1 : 0,
+      };
+    },
+    [BASE_DATE],
+  );
 
-  // --- 상태 관리 ---
-  const [dateWheelIdx, setDateWheelIdx] = useState(() => getInitialDateIndex(value));
-  const [amPmIdx, setAmPmIdx] = useState(() => getInitialAmPmIndex(value));
-  const [hour12Idx, setHour12Idx] = useState(() => getInitialHourIndex(value));
-  const [minuteIdx, setMinuteIdx] = useState(() => getInitialMinuteIndex(value));
+  // 초기값 설정
+  const [indices, setIndices] = useState(() => getIndicesFromDate(value));
 
-  // --- 외부 value 변경 시 내부 상태 동기화 ---
-  useEffect(() => {
-    setDateWheelIdx(getInitialDateIndex(value));
-    setAmPmIdx(getInitialAmPmIndex(value));
-    setHour12Idx(getInitialHourIndex(value));
-    setMinuteIdx(getInitialMinuteIndex(value));
-  }, [value, getInitialDateIndex]);
+  // --- 이벤트 핸들러 ---
+  const handleWheelChange = useCallback(
+    (type: 'date' | 'ampm' | 'hour' | 'minute', newIndex: number) => {
+      setIndices((prev) => ({
+        ...prev,
+        [type === 'date'
+          ? 'dateIdx'
+          : type === 'ampm'
+            ? 'amPmIdx'
+            : type === 'hour'
+              ? 'hourIdx'
+              : 'minuteIdx']: newIndex,
+      }));
 
-  // --- Wheel 변경 시 부모에게 알림 (onChange) ---
-  useEffect(() => {
-    // 1. 현재 선택된 날짜 계산 (기준일 + 인덱스일)
-    const selectedDate = addDays(BASE_DATE, dateWheelIdx);
+      const currentIndices = {
+        ...indices,
+        [type === 'date'
+          ? 'dateIdx'
+          : type === 'ampm'
+            ? 'amPmIdx'
+            : type === 'hour'
+              ? 'hourIdx'
+              : 'minuteIdx']: newIndex,
+      };
 
-    // 2. 시간 계산
-    // hour12Idx(0~11) -> 1~12시
-    const hour12 = hour12Idx + 1;
-    let hour24 = 0;
+      const { dateIdx, amPmIdx, hourIdx, minuteIdx } = currentIndices;
 
-    if (amPmIdx === 0) {
-      // 오전
-      hour24 = hour12 === 12 ? 0 : hour12;
-    } else {
-      // 오후
-      hour24 = hour12 === 12 ? 12 : hour12 + 12;
-    }
+      const selectedDate = addDays(BASE_DATE, dateIdx);
 
-    // 3. 분 계산
-    const minute = MINUTES[minuteIdx];
+      const hour12 = hourIdx + 1;
+      let hour24 = 0;
 
-    // 4. 최종 날짜 생성
-    const newDate = new Date(selectedDate);
-    newDate.setHours(hour24);
-    newDate.setMinutes(minute);
-    newDate.setSeconds(0);
-    newDate.setMilliseconds(0);
+      if (amPmIdx === 0) {
+        // 오전
+        hour24 = hour12 === 12 ? 0 : hour12;
+      } else {
+        // 오후
+        hour24 = hour12 === 12 ? 12 : hour12 + 12;
+      }
 
-    // 값이 다를 때만 onChange 호출
-    if (newDate.getTime() !== value.getTime()) {
+      const minute = MINUTES[minuteIdx];
+
+      const newDate = new Date(selectedDate);
+      newDate.setHours(hour24);
+      newDate.setMinutes(minute);
+      newDate.setSeconds(0);
+      newDate.setMilliseconds(0);
+
+      // 부모에게 전달
       onChange(newDate);
-    }
-  }, [dateWheelIdx, amPmIdx, hour12Idx, minuteIdx, onChange, value]);
+    },
+    [indices, BASE_DATE, onChange],
+  );
 
-  // --- 포매팅 함수들 (Wheel에 텍스트로 보여질 부분) ---
-
-  // [중요] 인덱스를 받아서 날짜 텍스트로 변환
-  const formatDateLabel = useCallback((_relative: number, absolute: number): string => {
-    // absolute 인덱스는 BASE_DATE로부터의 일수 차이입니다.
-    const targetDate = addDays(BASE_DATE, absolute);
-
-    if (isToday(targetDate)) {
-      return '오늘';
-    }
-
-    // date-fns format을 사용하면 연도가 넘어가도 알아서 처리됨 (12월 31일 -> 1월 1일)
-    // "M월 d일 EEE" 형식 (예: 1월 1일 수)
-    return format(targetDate, 'M월 d일 EEE', { locale: ko });
-  }, []);
-
-  const formatHourLabel = useCallback((_: number, absolute: number) => {
-    return `${(absolute % 12) + 1}`;
-  }, []);
-
-  const formatMinuteLabel = useCallback((_: number, absolute: number) => {
-    return MINUTES[absolute % 2].toString().padStart(2, '0');
-  }, []);
+  const formatDateLabel = useCallback(
+    (_: number, absolute: number) => {
+      const targetDate = addDays(BASE_DATE, absolute);
+      if (isToday(targetDate)) return '오늘';
+      return format(targetDate, 'M월 d일 (E)', { locale: ko });
+    },
+    [BASE_DATE],
+  );
 
   return (
     <div className="relative flex h-44 w-full items-center justify-center gap-2">
@@ -116,51 +107,51 @@ export function DateTimePicker({ value, onChange }: DateTimePickerProps) {
       {/* 날짜 Wheel */}
       <div className="z-20 flex h-full w-full">
         <Wheel
-          value={dateWheelIdx}
-          length={365 * 3} // [설정] 휠의 전체 길이 (예: 3년치).
+          value={indices.dateIdx}
+          length={365} // 1년치만 보여줌
           width={140}
           loop={false}
           setValue={formatDateLabel}
-          onChange={setDateWheelIdx}
+          onChange={(idx) => handleWheelChange('date', idx)}
           disableHighlight
         />
       </div>
 
-      {/* 오전/오후 Wheel */}
+      {/* 오전/오후 */}
       <div className="z-20 flex h-full w-full">
         <Wheel
-          value={amPmIdx}
+          value={indices.amPmIdx}
           length={2}
           width={50}
           loop={false}
           setValue={(_, abs) => AM_PM_OPTIONS[abs % 2]}
-          onChange={setAmPmIdx}
+          onChange={(idx) => handleWheelChange('ampm', idx)}
           disableHighlight
         />
       </div>
 
-      {/* 시간 Wheel */}
+      {/* 시간 */}
       <div className="z-20 flex h-full w-full">
         <Wheel
-          value={hour12Idx}
+          value={indices.hourIdx}
           length={12}
           width={35}
           loop={true}
-          setValue={formatHourLabel}
-          onChange={setHour12Idx}
+          setValue={(_, abs) => `${(abs % 12) + 1}`}
+          onChange={(idx) => handleWheelChange('hour', idx)}
           disableHighlight
         />
       </div>
 
-      {/* 분 Wheel */}
+      {/* 분 */}
       <div className="z-20 flex h-full w-full">
         <Wheel
-          value={minuteIdx}
+          value={indices.minuteIdx}
           length={2}
           width={35}
           loop={true}
-          setValue={formatMinuteLabel}
-          onChange={setMinuteIdx}
+          setValue={(_, abs) => MINUTES[abs % 2].toString().padStart(2, '0')}
+          onChange={(idx) => handleWheelChange('minute', idx)}
           disableHighlight
         />
       </div>

--- a/src/entities/schedule/ui/ScheduleSetting/ScheduleSetting.tsx
+++ b/src/entities/schedule/ui/ScheduleSetting/ScheduleSetting.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { format } from 'date-fns';
+import { format, roundToNearestMinutes } from 'date-fns';
 import { ko } from 'date-fns/locale';
 
 export type ScheduleTitle = '시작' | '종료';
@@ -12,6 +12,8 @@ export type ScheduleSettingProps = {
 };
 
 export function ScheduleSetting({ title, date, onClick }: ScheduleSettingProps) {
+  const roundedDate = roundToNearestMinutes(date, { nearestTo: 30 });
+
   return (
     <button
       type="button"
@@ -22,7 +24,7 @@ export function ScheduleSetting({ title, date, onClick }: ScheduleSettingProps) 
 
       <div className="text-foreground-quaternary text-caption-caption2 flex w-full flex-row justify-end gap-4">
         <div>{format(date, 'yyyy년 M월 d일 (E)', { locale: ko })}</div>
-        <div>{format(date, 'HH:mm', { locale: ko })}</div>
+        <div>{format(roundedDate, 'HH:mm', { locale: ko })}</div>
       </div>
     </button>
   );

--- a/src/shared/ui/sheet/Sheet.tsx
+++ b/src/shared/ui/sheet/Sheet.tsx
@@ -24,6 +24,7 @@ interface SheetButton {
   label: string;
   onClick?: () => void;
   disabled?: boolean;
+  variant?: 'primary' | 'secondary' | 'danger' | 'warning';
 }
 
 interface SheetProps {
@@ -66,7 +67,7 @@ export function Sheet({
               <SolidButton
                 type="button"
                 size="l"
-                variant="secondary"
+                variant={secondaryBtn.variant || 'secondary'}
                 isDisabled={secondaryBtn.disabled}
                 onClick={secondaryBtn.onClick}
               >
@@ -77,7 +78,7 @@ export function Sheet({
               <SolidButton
                 type="button"
                 size="l"
-                variant="primary"
+                variant={primaryBtn.variant || 'primary'}
                 isDisabled={primaryBtn.disabled}
                 onClick={primaryBtn.onClick}
               >

--- a/src/widgets/schedule/ui/ScheduleEditorContainer.tsx
+++ b/src/widgets/schedule/ui/ScheduleEditorContainer.tsx
@@ -113,7 +113,7 @@ export default function ScheduleEditorContainer({ entryPoint }: Props) {
       endDate: new Date(),
       location: '미정',
     },
-    values: activeInitialData ?? undefined, // 비동기 데이터 주입 (reset 대신 values 사용 권장)
+    values: activeInitialData ?? undefined,
     mode: 'onChange',
   });
 
@@ -139,7 +139,7 @@ export default function ScheduleEditorContainer({ entryPoint }: Props) {
     if (entryPoint === 'post') {
       setLinkedSchedule({
         ...data,
-        id: currentScheduleId, // 여기서 ID를 꼭 넣어줘야 합니다!
+        id: currentScheduleId,
       });
       if (process.env.NODE_ENV === 'development') console.log('Store 저장 완료');
       router.back();

--- a/src/widgets/schedule/ui/ScheduleForm.tsx
+++ b/src/widgets/schedule/ui/ScheduleForm.tsx
@@ -165,7 +165,7 @@ export default function ScheduleForm({ onSubmit, initialData }: ScheduleFormProp
                       }}
                     >
                       <div className="py-15">
-                        <DateTimePicker value={tempEndDate} onChange={setTempEndDate} />
+                        <DateTimePicker value={tempEndDate} onChange={setTempEndDate} mode="all" />
                       </div>
                     </Sheet>
                   </ModalSheet.Content>
@@ -214,7 +214,7 @@ export default function ScheduleForm({ onSubmit, initialData }: ScheduleFormProp
                       }}
                     >
                       <div className="py-15">
-                        <DateTimePicker value={tempEndDate} onChange={setTempEndDate} />
+                        <DateTimePicker value={tempEndDate} onChange={setTempEndDate} mode="all" />
                       </div>
                     </Sheet>
                   </ModalSheet.Content>

--- a/src/widgets/schedule/ui/ScheduleForm.tsx
+++ b/src/widgets/schedule/ui/ScheduleForm.tsx
@@ -83,27 +83,28 @@ export default function ScheduleForm({ onSubmit, initialData }: ScheduleFormProp
               className="mx-auto flex w-full sm:w-[360px]"
             >
               <ModalSheet.Container>
-                <ModalSheet.Header />
                 <ModalSheet.Content>
-                  <div className="rounded-4 flex flex-col gap-4 px-15 pt-16 pb-15">
-                    {SCHEDULE_CATEGORIES.map((option) => (
-                      <button
-                        key={option.value}
-                        type="button"
-                        onClick={() => {
-                          field.onChange(option.value);
-                          handleCloseModal();
-                        }}
-                        className={`text-foreground-normal text-body-body5 flex w-full flex-1 items-center px-12 py-10 ${
-                          field.value === option.value
-                            ? 'bg-background-secondary'
-                            : 'hover:bg-background-secondary'
-                        }`}
-                      >
-                        {option.label}
-                      </button>
-                    ))}
-                  </div>
+                  <Sheet>
+                    <div className="rounded-4 flex flex-col gap-4 px-15 pt-16 pb-15">
+                      {SCHEDULE_CATEGORIES.map((option) => (
+                        <button
+                          key={option.value}
+                          type="button"
+                          onClick={() => {
+                            field.onChange(option.value);
+                            handleCloseModal();
+                          }}
+                          className={`text-foreground-normal text-body-body5 flex w-full flex-1 items-center px-12 py-10 ${
+                            field.value === option.value
+                              ? 'bg-background-secondary'
+                              : 'hover:bg-background-secondary'
+                          }`}
+                        >
+                          {option.label}
+                        </button>
+                      ))}
+                    </div>
+                  </Sheet>
                 </ModalSheet.Content>
               </ModalSheet.Container>
               <ModalSheet.Backdrop
@@ -150,7 +151,6 @@ export default function ScheduleForm({ onSubmit, initialData }: ScheduleFormProp
                 className="mx-auto flex w-full sm:w-[360px]"
               >
                 <ModalSheet.Container>
-                  <ModalSheet.Header />
                   <ModalSheet.Content>
                     <Sheet
                       title="일정 시작 설정"
@@ -198,7 +198,6 @@ export default function ScheduleForm({ onSubmit, initialData }: ScheduleFormProp
                 className="mx-auto flex w-full sm:w-[360px]"
               >
                 <ModalSheet.Container>
-                  <ModalSheet.Header />
                   <ModalSheet.Content>
                     <Sheet
                       title="일정 종료 설정"

--- a/src/widgets/schedule/ui/ScheduleForm.tsx
+++ b/src/widgets/schedule/ui/ScheduleForm.tsx
@@ -165,7 +165,11 @@ export default function ScheduleForm({ onSubmit, initialData }: ScheduleFormProp
                       }}
                     >
                       <div className="py-15">
-                        <DateTimePicker value={tempEndDate} onChange={setTempEndDate} mode="all" />
+                        <DateTimePicker
+                          value={tempStartDate}
+                          onChange={setTempStartDate}
+                          mode="all"
+                        />
                       </div>
                     </Sheet>
                   </ModalSheet.Content>

--- a/src/widgets/schedule/ui/ScheduleForm.tsx
+++ b/src/widgets/schedule/ui/ScheduleForm.tsx
@@ -85,7 +85,7 @@ export default function ScheduleForm({ onSubmit, initialData }: ScheduleFormProp
               <ModalSheet.Container>
                 <ModalSheet.Content>
                   <Sheet>
-                    <div className="rounded-4 flex flex-col gap-4 px-15 pt-16 pb-15">
+                    <div className="rounded-4 flex flex-col gap-4 pt-16 pb-15">
                       {SCHEDULE_CATEGORIES.map((option) => (
                         <button
                           key={option.value}
@@ -94,7 +94,7 @@ export default function ScheduleForm({ onSubmit, initialData }: ScheduleFormProp
                             field.onChange(option.value);
                             handleCloseModal();
                           }}
-                          className={`text-foreground-normal text-body-body5 flex w-full flex-1 items-center px-12 py-10 ${
+                          className={`text-foreground-normal text-body-body6 flex w-full flex-1 items-center px-12 py-10 ${
                             field.value === option.value
                               ? 'bg-background-secondary'
                               : 'hover:bg-background-secondary'
@@ -164,7 +164,9 @@ export default function ScheduleForm({ onSubmit, initialData }: ScheduleFormProp
                         onClick: handleCloseModal,
                       }}
                     >
-                      <DateTimePicker value={tempStartDate} onChange={setTempStartDate} />
+                      <div className="py-15">
+                        <DateTimePicker value={tempEndDate} onChange={setTempEndDate} />
+                      </div>
                     </Sheet>
                   </ModalSheet.Content>
                 </ModalSheet.Container>
@@ -211,7 +213,9 @@ export default function ScheduleForm({ onSubmit, initialData }: ScheduleFormProp
                         onClick: handleCloseModal,
                       }}
                     >
-                      <DateTimePicker value={tempEndDate} onChange={setTempEndDate} />
+                      <div className="py-15">
+                        <DateTimePicker value={tempEndDate} onChange={setTempEndDate} />
+                      </div>
                     </Sheet>
                   </ModalSheet.Content>
                 </ModalSheet.Container>


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 any가 사용되지 않았습니다
- [x] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈
- close #292 
- close #294 
- close #295 

## ⚠️ 기존 문제
- 게시글 작성 시 게시글 예약 기능 오류 수정

## ☑️ 해결 방법
- DateTimePicker 컴포넌트의 props에 mode(future, all)를 추가하였습니다.
   -> future는 게시글 예약 시 사용되는 타입이고, all은 일정 생성/수정 시 사용되는 타입입니다.
- 00분/30분 단위로 나오도록 date-fns의 roundToNearestMinutes 를 사용하였습니다.

## 🧪 테스트 방법
1. pnpm run dev 후 로그인
2. http://localhost:3000/board/1/post/84/edit 접속하여 하단 툴바 '예약' 버튼 클릭하여 아무 시간으로 예약
    -> 다시 '예약' 버튼 클릭하여 예약 취소하기/수정하기 버튼이 나오는지 확인
    -> 현재 시간 이전으로 예약 시 현재 시간 이후로만 예약 가능합니다 알림이 나오는지 확인
3. 하단 툴바 '일정' 버튼 클릭하여 시작일/종료일 기본값의 분 기본값이 00분 또는 30분으로 나오는지 확인
    -> 시작일/종료일을 클릭하여 과거의 시간도 예약이 가능한지 확인

## ✔️ 설치 라이브러리
- 없음

## 📷 실행 영상 또는 스크린샷
https://github.com/user-attachments/assets/0ccd1212-26bd-418c-b25e-404cffb18719

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 예약 취소 확인 알림 추가
  * 시간 선택기(DateTimePicker)에 mode 옵션(미래/전체) 추가 및 Storybook 예제 추가
  * 버튼 스타일 옵션(primary, secondary, danger, warning) 추가

* **개선사항**
  * 예약 저장 시 미래 날짜 검증 추가
  * 시간 선택기에서 30분 단위 반올림 적용 및 인터페이스 개선
  * 여러 모달의 레이아웃·패딩·버튼 라벨 동적 표시로 UI 최적화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->