### PR TITLE
[HOTFIX] 카카오 http 이미지 허용 함수 Avatar 적용

### DIFF
--- a/src/entities/post/ui/post-profile/PostProfile.tsx
+++ b/src/entities/post/ui/post-profile/PostProfile.tsx
@@ -1,5 +1,4 @@
 import { Avatar } from '@/shared/ui/avatar/Avatar';
-import { kakaoImgNormalize } from '@/shared/lib/kakaoImgNormalize';
 
 type PostProfileProps = {
   profileImgUrl?: string;
@@ -12,7 +11,7 @@ type PostProfileProps = {
 export function PostProfile({ profileImgUrl, nickname, date, time, viewCount }: PostProfileProps) {
   return (
     <section className="flex items-center gap-10" aria-label={`${nickname}님의 작성 게시글 정보`}>
-      <Avatar src={kakaoImgNormalize(profileImgUrl)} size="m" alt={`${nickname}의 프로필 이미지`} />
+      <Avatar src={profileImgUrl} size="m" alt={`${nickname}의 프로필 이미지`} />
       <div className="flex flex-col items-start justify-center py-3">
         <strong className="text-body-body6 text-foreground-normal">{nickname}</strong>
 

--- a/src/shared/ui/avatar/Avatar.tsx
+++ b/src/shared/ui/avatar/Avatar.tsx
@@ -14,6 +14,7 @@ import DEFAULT_PROFILE_IMAGE from '@/shared/assets/icons/profile/profile-default
  * @param onClick - 클릭 핸들러. 제공 시 button 요소로 렌더링되어 접근성 향상
  *
  */
+import { kakaoImgNormalize } from '@/shared/lib/kakaoImgNormalize';
 
 export type AvatarSize = 'xs' | 's' | 'm' | 'l' | 'xl';
 
@@ -46,7 +47,8 @@ export function Avatar({
 
   const base = `relative flex items-center justify-center flex-shrink-0 aspect-square ${sizesStyle[size].rounded} overflow-hidden ${sizesStyle[size].cls}`;
 
-  const imageSrc = !error && src ? src : DEFAULT_PROFILE_IMAGE;
+  const normalizedSrc = kakaoImgNormalize(src);
+  const imageSrc = !error && normalizedSrc ? normalizedSrc : DEFAULT_PROFILE_IMAGE;
 
   // interactive 여부에 따라 wrapper element 결정
   const Wrapper = onClick ? 'button' : 'div';


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 코드에 any가 사용되지 않았습니다
- [ ] 스토리북에 추가했습니다 (해당 시)
- [ ] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈
- close #320

## 📌 작업 목적
- 카카오 http 이미지 허용 함수 Avatar 적용

## ⚠️ 기존 문제 (선택)
- 기존에는 Avatar을 사용하는 곳에서 모두 src에 kakaoImgNormalize 함수를 적용했어야 함

## ☑️ 해결 방법 (선택)
- Avatar 컴포넌트에서 함수를 적용하여 기존 구조 유지

## 💬 논의할 점
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 프로필 이미지 처리 로직을 개선하여 아바타 컴포넌트의 이미지 정규화 방식을 최적화했습니다. 이미지 로딩 및 표시 동작이 더욱 일관되게 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->