### PR TITLE
[CHORE] 게시판 페이지에서 게시글 작성 페이지로 이동하는 버튼 추가

### DIFF
--- a/src/app-pages/board/ui/BoardPage.tsx
+++ b/src/app-pages/board/ui/BoardPage.tsx
@@ -8,6 +8,7 @@ import { TAB_CATEGORIES, TAB_CATEGORY_LIST } from '@/entities/post/model/tab';
 import { AppHeader } from '@/widgets/header/ui/AppHeader';
 import { HeaderMode } from '@/shared/ui/header/Header';
 import { POST_BOARDS } from '@/entities/post/model/board';
+import { PostFab } from '@/entities/post/ui/post-fab/PostFab';
 
 const BoardPage = ({ boardId: boardIdProp }: { boardId: string }) => {
   const router = useRouter();
@@ -57,6 +58,15 @@ const BoardPage = ({ boardId: boardIdProp }: { boardId: string }) => {
           <PostListContainer boardId={boardId} category={categoryKey} userLevel={userLevel} />
         </div>
       </div>
+      {userLevel !== 'member' && (
+        <div className="pointer-events-none fixed inset-0 z-50">
+          <div className="relative mx-auto h-full sm:max-w-[360px]">
+            <div className="pointer-events-auto absolute right-15 bottom-15">
+              <PostFab onClick={() => router.push(`/board/${boardId}/post/create`)} />
+            </div>
+          </div>
+        </div>
+      )}
     </>
   );
 };


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 코드에 any가 사용되지 않았습니다
- [ ] 스토리북에 추가했습니다 (해당 시)
- [ ] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈
- close #323

## 📌 작업 목적
- 게시판 페이지에서 게시글 작성 페이지로 이동하는 버튼 추가

## 🔨 주요 작업 내용
- PostFab 추가했습니다

## 🧪 테스트 방법
- `http://localhost:3000/board/1` 에서 글쓰기 버튼 누르면 `http://localhost:3000/board/1/post/create`로 이동하는지 확인
- 자신의 권한이 'member'가 아니어야 보입니다!

## 💬 논의할 점
- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 비회원 사용자를 위한 포스트 작성 버튼이 추가되었습니다.
  * 포스트 작성 페이지로 쉽게 이동할 수 있는 빠른 액션 버튼이 전면에 표시됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->