### PR TITLE
[CHORE] 발행된 게시글일 시 예약 툴바 비활성화 및 이미 예약중인 글 수정 모드일시 예약 배지 설정

### DIFF
--- a/src/app-pages/post/write/ui/PostPage.tsx
+++ b/src/app-pages/post/write/ui/PostPage.tsx
@@ -54,6 +54,8 @@ export default function PostPage(props: PostPageProps) {
     handleBack,
     handleSubmit,
     resetPostState,
+    isPublished,
+    isReserved,
   } = usePostForm({ mode, boardId, postId });
 
   // 예약 시간 임시 저장용 state (취소 시 롤백 위함)
@@ -121,7 +123,7 @@ export default function PostPage(props: PostPageProps) {
       </div>
 
       {/* 예약중 태그 */}
-      {reserved && reservedAt && (
+      {isReserved && (
         <div className="px-13 pt-10">
           <PostBadge type="reservation" />
         </div>
@@ -183,6 +185,7 @@ export default function PostPage(props: PostPageProps) {
           onChange={handleEditorChange}
           onScheduleRemove={handleScheduleRemove}
           onReservationClick={openReservationModal}
+          isPublished={isPublished}
         />
       </div>
 

--- a/src/entities/post/api/types.ts
+++ b/src/entities/post/api/types.ts
@@ -71,6 +71,8 @@ export type PostDetailData = {
   hasSchedule: boolean;
   scheduleId: number | null;
   profileImageUrl?: string;
+  isReserved: boolean;
+  reservedAt: string;
 };
 
 // 상세 API 응답 타입

--- a/src/entities/post/api/types.ts
+++ b/src/entities/post/api/types.ts
@@ -72,7 +72,7 @@ export type PostDetailData = {
   scheduleId: number | null;
   profileImageUrl?: string;
   isReserved: boolean;
-  reservedAt: string;
+  reservedAt: string | null;
 };
 
 // 상세 API 응답 타입

--- a/src/entities/post/model/mappers.ts
+++ b/src/entities/post/model/mappers.ts
@@ -68,5 +68,7 @@ export const transformDetailToPost = (item: PostDetailData): PostDetail => {
     scheduleId: item.scheduleId,
     profileImageUrl: item.profileImageUrl,
     postedAt: item.postedAt,
+    isReserved: item.isReserved,
+    reservedAt: item.reservedAt,
   };
 };

--- a/src/entities/post/model/types.ts
+++ b/src/entities/post/model/types.ts
@@ -31,6 +31,8 @@ export type PostDetail = {
   scheduleId: number | null;
   profileImageUrl?: string;
   postedAt: string;
+  isReserved: boolean;
+  reservedAt: string;
 };
 
 // 게시판

--- a/src/entities/post/model/types.ts
+++ b/src/entities/post/model/types.ts
@@ -32,7 +32,7 @@ export type PostDetail = {
   profileImageUrl?: string;
   postedAt: string;
   isReserved: boolean;
-  reservedAt: string;
+  reservedAt: string | null;
 };
 
 // 게시판

--- a/src/features/post/post-editor/ui/PostEditorToolbar.tsx
+++ b/src/features/post/post-editor/ui/PostEditorToolbar.tsx
@@ -23,17 +23,23 @@ const baseItems: ToolBarItem<ToolbarKey>[] = [
 type Props = {
   editor: Editor; // 볼드체 버튼 클릭시 굵기를 조절하는 포스트 에디터
   onCameraClick: () => void; // 파일 탐색기 여는 콜백
-  onScheduleClick: () => void; // 예약 버튼 클릭 시 예약 DateTimePicker 모달 오픈 콜백
+  onReservationClick: () => void; // 예약 버튼 클릭 시 예약 DateTimePicker 모달 오픈 콜백
+  isReservationDisabled: boolean; // 예약 비활성화 여부
 };
 
-export const PostEditorToolbar = ({ editor, onCameraClick, onScheduleClick }: Props) => {
+export const PostEditorToolbar = ({
+  editor,
+  onCameraClick,
+  onReservationClick,
+  isReservationDisabled,
+}: Props) => {
   const router = useRouter();
 
   const actionMap: Record<ToolbarKey, () => void> = {
     [TOOLBAR_KEY.BOLD]: () => editor.chain().focus().toggleBold().run(),
     [TOOLBAR_KEY.CAMERA]: onCameraClick,
     [TOOLBAR_KEY.ALARM]: () => {
-      onScheduleClick();
+      onReservationClick();
     },
     [TOOLBAR_KEY.CALENDAR]: () => {
       router.push('/post/schedule');
@@ -41,13 +47,20 @@ export const PostEditorToolbar = ({ editor, onCameraClick, onScheduleClick }: Pr
   };
 
   const handleItemClick = (key: ToolbarKey) => {
+    if (key === TOOLBAR_KEY.ALARM && isReservationDisabled) return;
     actionMap[key]?.();
   };
 
-  // bold만 active 상태 추가
-  const items: ToolBarItem<ToolbarKey>[] = baseItems.map((item) =>
-    item.key === TOOLBAR_KEY.BOLD ? { ...item, active: editor.isActive('bold') } : item,
-  );
+  const items: ToolBarItem<ToolbarKey>[] = baseItems.map((item) => {
+    const isBold = item.key === TOOLBAR_KEY.BOLD;
+    const isAlarm = item.key === TOOLBAR_KEY.ALARM;
+
+    return {
+      ...item,
+      active: isBold ? editor.isActive('bold') : false,
+      disabled: isAlarm && isReservationDisabled,
+    };
+  });
 
   return <ToolBar items={items} onItemClick={handleItemClick} />;
 };

--- a/src/features/post/post-form/model/usePostForm.ts
+++ b/src/features/post/post-form/model/usePostForm.ts
@@ -123,6 +123,15 @@ export const usePostForm = ({ mode, boardId, postId }: Props) => {
     return !title.trim() || isEmpty;
   }, [title, checkHasChanges]);
 
+  // 이미 발행된 글인지 판단 (툴바 비활성화용)
+  // 수정 모드이고 서버 데이터상 예약 중이 아닌 경우
+  const isPublished = !!(mode === 'edit' && postDetail && !postDetail.isReserved);
+
+  // 현재 예약 중인지 판단 (배지 노출용)
+  // 클라이언트에서 새로 예약 설정을 했거나(reserved),
+  // 서버 데이터상 이미 예약 상태(postDetail.isReserved)인 경우
+  const isReserved = !!(reserved || (mode === 'edit' && postDetail?.isReserved));
+
   // 5. Event Handlers
   const handleEditorChange = useCallback(
     (updatedData: EditorState) => {
@@ -305,6 +314,8 @@ export const usePostForm = ({ mode, boardId, postId }: Props) => {
     isReservationModalOpen,
     isSubmitDisabled,
     isScheduleFetching,
+    isPublished,
+    isReserved,
 
     // Actions
     openCategory,

--- a/src/shared/ui/toolbar/ToolBar.tsx
+++ b/src/shared/ui/toolbar/ToolBar.tsx
@@ -8,6 +8,7 @@ export type ToolBarItem<K extends string> = {
   label: string;
   icon: IconName;
   active?: boolean;
+  disabled?: boolean;
 };
 
 type ToolBarProps<K extends string> = {
@@ -31,6 +32,7 @@ export function ToolBar<K extends string>({ items, onItemClick, className = '' }
           label={item.label}
           icon={item.icon}
           active={item.active}
+          disabled={item.disabled}
           onClick={() => {
             onItemClick?.(item.key);
           }}

--- a/src/shared/ui/toolbar/ToolBarItems.tsx
+++ b/src/shared/ui/toolbar/ToolBarItems.tsx
@@ -7,14 +7,23 @@ interface ToolBarItemsProps {
   label: string;
   icon: IconName;
   active?: boolean;
+  disabled?: boolean;
   onClick?: MouseEventHandler<HTMLButtonElement>;
 }
 
-const baseStyle = 'text-foreground-normal inline-flex items-center gap-5 focus:outline-none';
+export function ToolBarItems({ label, icon, onClick, active, disabled }: ToolBarItemsProps) {
+  const baseStyle = 'text-foreground-normal inline-flex items-center gap-5 focus:outline-none';
 
-export function ToolBarItems({ label, icon, onClick, active }: ToolBarItemsProps) {
+  const statusStyle = disabled ? 'opacity-30' : 'opacity-100';
+
   return (
-    <button type="button" aria-pressed={active} onClick={onClick} className={baseStyle}>
+    <button
+      type="button"
+      aria-pressed={active}
+      onClick={disabled ? undefined : onClick}
+      className={`${baseStyle} ${statusStyle}`}
+      disabled={disabled}
+    >
       <SurfIcon name={icon} size="m" />
       <span className="text-body-body10">{label}</span>
     </button>

--- a/src/widgets/post/post-editor/PostEditor.tsx
+++ b/src/widgets/post/post-editor/PostEditor.tsx
@@ -29,6 +29,7 @@ export type PostEditorProps = {
   onChange: (data: { content: string; images: UploadImage[] }) => void;
   onScheduleRemove: () => void;
   onReservationClick: () => void;
+  isPublished: boolean;
 };
 
 export const PostEditor = ({
@@ -39,6 +40,7 @@ export const PostEditor = ({
   onChange,
   onScheduleRemove,
   onReservationClick,
+  isPublished,
 }: PostEditorProps) => {
   // 1. Hooks & Refs
   const {
@@ -216,7 +218,8 @@ export const PostEditor = ({
         <PostEditorToolbar
           editor={editor}
           onCameraClick={openPicker}
-          onScheduleClick={onReservationClick}
+          onReservationClick={onReservationClick}
+          isReservationDisabled={isPublished}
         />
       </div>
 


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 코드에 any가 사용되지 않았습니다
- [ ] 스토리북에 추가했습니다 (해당 시)
- [ ] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈
- close #329

## 📌 작업 목적
- 발행된 게시글일 시 예약 툴바 비활성화
- 이미 예약중인 글의 수정 모드일시 예약 배지 설정

## 🔨 주요 작업 내용
- 백엔드에 게시글 상세 응답(조회, 생성, 수정 공통)에 예약 여부를 확인할 수 있는 필드 요청
  - isReserved, reservedAt 추가
- 발행된 게시글 조건 : 수정 모드이고 서버 데이터상 예약 중이 아닌 경우
- 예약중인 게시글 조건 :  클라이언트에서 새로 예약 설정을 했거나(reserved) or 서버 데이터상 이미 예약 상태(postDetail.isReserved)인 경우
- **작업 중 발견한 개선사항 및 에러가 있어 담당자 태그 함께 남깁니다. 확인 부탁드립니다!**
  - reservedAt은 이미 예약중인 글의 수정 모드일 시 피커에서 예약한 시간 데이터를 보여줘야 할 것 같아 요청드렸습니다. @rngrhn4114 
  - 게시판 페이지에서 예약 중인 글에 "예약중" 배지가 뜨지 않는 것 같습니다. @Chaejy

## 🧪 테스트 방법
- 게시글 수정 모드시 발행된 글이면 -> 예약중 뱃지 비노출 및 툴바에서 예약 비활성화 되는 것 확인
- 게시글 수정 모드시 발행된 글이 아니면 -> 예약중 뱃지 노출되는 것 확인

## 📷 실행 영상 또는 스크린샷
https://github.com/user-attachments/assets/4ee98536-f677-42a9-83da-0cf29a847306


## 💬 논의할 점
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **새로운 기능**
  * 게시물의 예약(isReserved) 및 발행(isPublished) 상태 추적 및 노출 추가
  * 에디터 툴바에 예약 동작(onReservationClick) 지원 추가

* **개선 사항**
  * 발행된 게시물에서 예약 관련 UI 자동 비활성화
  * 툴바 아이템의 비활성화(disabled) 상태 지원 추가로 UI 제어 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->