### PR TITLE
[CHORE] 메뉴 드롭다운 정렬 props 추가 및 열림 상태 리프트업

### DIFF
--- a/src/shared/ui/menu/Menu.stories.tsx
+++ b/src/shared/ui/menu/Menu.stories.tsx
@@ -15,22 +15,26 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
+// 1. 기본 스토리 (단순 UI 확인용)
 export const Default: Story = {
   args: {
-    label: 'Options',
+    label: '기수',
+    isOpen: false,
+    onToggle: () => {},
+    onClose: () => {},
     itemList: [
-      { id: 1, label: 'Option 1', onClick: () => alert('Option 1 selected') },
-      { id: 2, label: 'Option 2', onClick: () => alert('Option 2 selected'), isSelected: true },
-      { id: 3, label: 'Option 3', onClick: () => alert('Option 3 selected') },
-      { id: 4, label: 'Option 4', onClick: () => alert('Option 4 selected') },
-      { id: 5, label: 'Option 5', onClick: () => alert('Option 5 selected') },
-      { id: 6, label: 'Option 6', onClick: () => alert('Option 6 selected') },
+      { id: 1, label: '1기', onClick: () => {} },
+      { id: 2, label: '2기', onClick: () => {}, isSelected: true },
     ],
   },
 };
 
+// 2. 상호작용 스토리 (실제 열림/닫힘 및 선택 동작 확인)
 export const Interactive: Story = {
   render: (args) => {
+    // 메뉴 열림 상태 관리
+    const [isOpen, setIsOpen] = useState(false);
+    // 선택된 아이템 관리
     const [selectedId, setSelectedId] = useState<number | null>(null);
 
     const interactiveItemList = args.itemList?.map((item) => ({
@@ -39,21 +43,30 @@ export const Interactive: Story = {
       onClick: () => {
         setSelectedId(item.id);
         item.onClick?.();
+        setIsOpen(false); // 선택 시 닫기
       },
     }));
 
-    return <Menu {...args} itemList={interactiveItemList} />;
+    return (
+      <Menu
+        {...args}
+        isOpen={isOpen}
+        onToggle={() => setIsOpen(!isOpen)}
+        onClose={() => setIsOpen(false)}
+        itemList={interactiveItemList}
+        label={interactiveItemList?.find((i) => i.id === selectedId)?.label || args.label}
+      />
+    );
   },
   args: {
-    label: 'Options',
+    label: '선택하세요',
+    isOpen: false,
+    onToggle: () => {},
+    onClose: () => {},
     itemList: [
       { id: 1, label: 'Option 1', onClick: () => console.log('1 clicked') },
       { id: 2, label: 'Option 2', onClick: () => console.log('2 clicked') },
       { id: 3, label: 'Option 3', onClick: () => console.log('3 clicked') },
-      { id: 4, label: 'Option 4', onClick: () => console.log('4 clicked') },
-      { id: 5, label: 'Option 5', onClick: () => console.log('5 clicked') },
-      { id: 6, label: 'Option 6', onClick: () => console.log('6 clicked') },
-      { id: 7, label: 'Option 7', onClick: () => console.log('7 clicked') },
     ],
   },
 };

--- a/src/shared/ui/menu/Menu.tsx
+++ b/src/shared/ui/menu/Menu.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { MenuTrigger } from './menu-trigger/MenuTrigger';
 import { MenuDropDown } from './menu-dropdown/MenuDropDown';
 import { MenuItem } from './menu-item/MenuItem';
@@ -7,31 +6,41 @@ import type { MenuItemProps } from '@/shared/ui/menu/menu-item/MenuItem';
 /**
  * @param label - 메뉴 트리거에 표시될 라벨 텍스트
  * @param itemList - 메뉴 아이템 리스트
+ * @param align - 정렬 방향
+ * @param isOpen - 메뉴 열림 여부
+ * @param onToggle - 메뉴 열림 상태 변경
+ * @param onClose - 메뉴를 닫을 때 호출
  */
 
 export interface MenuProps {
   label: string;
   itemList?: MenuItemProps[];
+  align?: 'left' | 'right'; // 정렬 방향
+  isOpen: boolean;
+  onToggle: () => void;
+  onClose: () => void;
 }
 
-export const Menu = ({ label, itemList = [] }: MenuProps) => {
-  const [menuLabel, setMenuLabel] = useState(label);
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
-
-  const toggleMenu = () => setIsMenuOpen((prev) => !prev);
-  const closeMenu = () => setIsMenuOpen(false);
-
+export const Menu = ({
+  label,
+  itemList = [],
+  align = 'left',
+  isOpen,
+  onToggle,
+  onClose,
+}: MenuProps) => {
   return (
     <div className="relative w-fit">
-      <MenuTrigger label={menuLabel} isOpen={isMenuOpen} onClick={toggleMenu} />
-      {isMenuOpen && (
-        <div className="absolute top-full left-0 z-10 mt-2 w-full min-w-max">
+      <MenuTrigger label={label} isOpen={isOpen} onClick={onToggle} />
+      {isOpen && (
+        <div
+          className={`absolute top-full z-10 mt-2 w-full min-w-max ${align === 'right' ? 'right-0' : 'left-0'}`}
+        >
           <MenuDropDown
             items={itemList}
             onItemClick={(item) => {
-              setMenuLabel(item.label); // 메뉴 라벨 사용자 선택 라벨로 업데이트
               item.onClick(); // 아이템 자체 액션 실행
-              closeMenu(); // 클릭 시 메뉴 닫기
+              onClose(); // 클릭 시 메뉴 닫기
             }}
             renderItem={(item, onClick) => (
               <MenuItem

--- a/src/widgets/member-search/ui/MemberSearchWidget.tsx
+++ b/src/widgets/member-search/ui/MemberSearchWidget.tsx
@@ -18,7 +18,7 @@ export const MemberSearchWidget = ({ filters, totalCount }: MemberSearchWidgetPr
 
   // 1. 기수 메뉴 아이템 (id를 generation 숫자 그대로 사용)
   const generationItems = [
-    { id: 0, label: '기수', isSelected: !generation, onClick: () => setGeneration(undefined) },
+    { id: 0, label: '전체', isSelected: !generation, onClick: () => setGeneration(undefined) },
     ...Array.from({ length: TOTAL_GENERATION }, (_, i) => {
       const genValue = TOTAL_GENERATION - i;
       return {
@@ -32,7 +32,7 @@ export const MemberSearchWidget = ({ filters, totalCount }: MemberSearchWidgetPr
 
   // 2. 파트 메뉴 아이템 (id를 인덱스로 부여)
   const partItems = [
-    { id: 100, label: '파트', isSelected: !part, onClick: () => setPart(undefined) },
+    { id: 100, label: '전체', isSelected: !part, onClick: () => setPart(undefined) },
     ...Object.entries(toEnumPartMap).map(([label, value], index) => ({
       id: index + 101, // 101부터 시작하는 number 타입 id
       label: label,

--- a/src/widgets/member-search/ui/MemberSearchWidget.tsx
+++ b/src/widgets/member-search/ui/MemberSearchWidget.tsx
@@ -3,13 +3,17 @@ import { toEnumPartMap, toLabelPartMap } from '@/features/onboarding/lib/trackMa
 import { TOTAL_GENERATION } from '@/shared/constants';
 import { Menu } from '@/shared/ui/menu';
 import { TextInput } from '@/shared/ui/text-input/TextInput';
+import { useState } from 'react';
 
 interface MemberSearchWidgetProps {
   filters: ReturnType<typeof useMemberFilters>;
   totalCount: number;
 }
 
+type OpenMenuType = 'generation' | 'part' | null;
+
 export const MemberSearchWidget = ({ filters, totalCount }: MemberSearchWidgetProps) => {
+  const [openMenu, setOpenMenu] = useState<OpenMenuType>(null);
   const { keyword, generation, part, setKeyword, setGeneration, setPart } = filters;
 
   // 1. 기수 메뉴 아이템 (id를 generation 숫자 그대로 사용)
@@ -40,6 +44,11 @@ export const MemberSearchWidget = ({ filters, totalCount }: MemberSearchWidgetPr
   // 3. 현재 선택된 파트의 한글 라벨 (버튼 표시용)
   const currentPartLabel = part ? toLabelPartMap[part] : '파트';
 
+  // 메뉴 토글 함수
+  const handleToggle = (menuName: OpenMenuType) => {
+    setOpenMenu((prev) => (prev === menuName ? null : menuName));
+  };
+
   return (
     <div className="flex flex-col">
       <div className="px-13 py-10">
@@ -55,8 +64,22 @@ export const MemberSearchWidget = ({ filters, totalCount }: MemberSearchWidgetPr
       <div className="flex justify-between px-13 pt-10">
         <span>전체 {totalCount}명</span>
         <div className="flex flex-row">
-          <Menu label={generation ? `${generation}기` : '기수'} itemList={generationItems} />
-          <Menu label={currentPartLabel} itemList={partItems} />
+          <Menu
+            label={generation ? `${generation}기` : '기수'}
+            itemList={generationItems}
+            align="right"
+            isOpen={openMenu === 'generation'}
+            onToggle={() => handleToggle('generation')}
+            onClose={() => setOpenMenu(null)}
+          />
+          <Menu
+            label={currentPartLabel}
+            itemList={partItems}
+            align="right"
+            isOpen={openMenu === 'part'}
+            onToggle={() => handleToggle('part')}
+            onClose={() => setOpenMenu(null)}
+          />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 any가 사용되지 않았습니다
- [x] 스토리북에 추가했습니다 (해당 시)
- [x] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈
- close #343

## 📌 작업 목적
- 메뉴 드롭다운의 위치에 따라 메뉴 컨테이너가 잘리지 않을 수 있도록 정렬 방향을 바꿉니다.
- 메뉴 드롭다운이 한 번에 하나만 열릴 수 있도록 합니다.

## 🔨 주요 작업 내용
- 메뉴 드롭다운 오른쪽 위치시 컨테이너가 absolute right-0, 왼쪽 위치시 컨테이너가 absolute left-0 이 되도록 수정
- 오픈 상태 관리를 리프트업하여 페이지 단에서 관리하도록 수정

## 🧪 테스트 방법
`http://localhost:3000/member-search` 접속
- 메뉴 드롭다운이 잘리지 않는지 확인
- 한 번에 하나의 메뉴만 열리는지 확인

## 📷 실행 영상 또는 스크린샷
https://github.com/user-attachments/assets/f1dccc5e-b3e0-4f81-b7a3-0c10692acc62


## 💬 논의할 점
- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경사항

* **새로운 기능**
  * 드롭다운 메뉴의 정렬 옵션(좌측/우측) 추가

* **개선사항**
  * 여러 드롭다운 메뉴의 상태 관리 개선으로 메뉴 열림/닫힘 처리 최적화
  * 멤버 검색 필터(기수/파트) 드롭다운 동작 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->