### PR TITLE
[CHORE] 내가 작성한/스크랩한 게시글 클릭시 이동 로직 추가 및 쿼리키 통일

### DIFF
--- a/src/entities/post/api/queryKeys.ts
+++ b/src/entities/post/api/queryKeys.ts
@@ -25,8 +25,24 @@ export const postQueryKeys = {
    * -------------------- */
   myPosts: () => [...postQueryKeys.lists(), 'me'] as const,
 
+  // 내 게시글 일반 페이징용
+  myPostsPaging: (page: number, size: number, sort: string) =>
+    [...postQueryKeys.myPosts(), 'paging', { page, size, sort }] as const,
+
+  // 내 게시글 무한 스크롤용
+  myPostsInfinite: (size: number, sort: string) =>
+    [...postQueryKeys.myPosts(), 'infinite', { size, sort }] as const,
+
   /* --------------------
    * 스크랩한 게시글
    * -------------------- */
   scraps: () => [...postQueryKeys.lists(), 'scraps'] as const,
+
+  // 일반 페이징 목록용
+  scrapPaging: (page: number, size: number, sort: string) =>
+    [...postQueryKeys.scraps(), 'paging', { page, size, sort }] as const,
+
+  // 무한 스크롤용
+  scrapInfinite: (size: number, sort: string) =>
+    [...postQueryKeys.scraps(), 'infinite', { size, sort }] as const,
 };

--- a/src/features/post/model/useMyPosts.ts
+++ b/src/features/post/model/useMyPosts.ts
@@ -3,11 +3,12 @@
 import { useQuery, useInfiniteQuery } from '@tanstack/react-query';
 import { postApi } from '@/entities/post/api/postApi';
 import { PostListApiResponse } from '@/entities/post/api/types';
-// TODO: Post 엔티티로 변경 및 통합
+import { postQueryKeys } from '@/entities/post/api/queryKeys';
+
 /** 내가 작성한 게시글 단일 페이지 조회 */
 export const useMyPosts = (page: number = 0, size: number = 20, sort: string = '') => {
   return useQuery<PostListApiResponse>({
-    queryKey: ['posts', 'my-posts', page, size, sort],
+    queryKey: postQueryKeys.myPostsPaging(page, size, sort),
     queryFn: () => postApi.getMyPosts({ page, size, sort }),
   });
 };
@@ -15,7 +16,7 @@ export const useMyPosts = (page: number = 0, size: number = 20, sort: string = '
 /** 내가 작성한 게시글 무한 스크롤 조회 */
 export const useInfiniteMyPosts = (size: number = 20, sort: string = '') => {
   return useInfiniteQuery<PostListApiResponse>({
-    queryKey: ['posts', 'my-posts', 'infinite', size, sort],
+    queryKey: postQueryKeys.myPostsInfinite(size, sort),
     queryFn: ({ pageParam = 0 }) => {
       const page = pageParam as number;
       return postApi.getMyPosts({ page, size, sort });

--- a/src/features/post/model/useScraps.ts
+++ b/src/features/post/model/useScraps.ts
@@ -3,12 +3,12 @@
 import { useQuery, useInfiniteQuery } from '@tanstack/react-query';
 import { postApi } from '@/entities/post/api/postApi';
 import { PostListApiResponse } from '@/entities/post/api/types';
+import { postQueryKeys } from '@/entities/post/api/queryKeys';
 
-// TODO: Post 엔티티로 변경 및 통합
 /** 스크랩한 게시글 단일 페이지 조회 */
 export const useScraps = (page: number = 0, size: number = 20, sort: string = '') => {
   return useQuery<PostListApiResponse>({
-    queryKey: ['posts', 'scraps', page, size, sort],
+    queryKey: postQueryKeys.scrapPaging(page, size, sort),
     queryFn: () => postApi.getScraps({ page, size, sort }),
   });
 };
@@ -16,7 +16,7 @@ export const useScraps = (page: number = 0, size: number = 20, sort: string = ''
 /** 스크랩한 게시글 무한 스크롤 조회 */
 export const useInfiniteScraps = (size: number = 20, sort: string = '') => {
   return useInfiniteQuery<PostListApiResponse>({
-    queryKey: ['posts', 'scraps', 'infinite', size, sort],
+    queryKey: postQueryKeys.scrapInfinite(size, sort),
     queryFn: ({ pageParam = 0 }) => {
       const page = pageParam as number;
       return postApi.getScraps({ page, size, sort });

--- a/src/widgets/post-list/ui/PostListPage.tsx
+++ b/src/widgets/post-list/ui/PostListPage.tsx
@@ -7,6 +7,7 @@ import type { PostListItemResponse } from '@/entities/post/api/types';
 import { PostCardList } from '@/widgets/post-list/ui/PostCardList';
 import { Post } from '@/entities/post/model/types';
 import type { UserLevel } from '@/entities/user/model/types';
+import { useRouter } from 'next/navigation';
 
 // 서버 응답 data 페이지 당 타입
 type ApiPage = {
@@ -30,6 +31,8 @@ export function PostListPage({
   scrollRootRef,
   userLevel,
 }: PostListPageProps) {
+  const router = useRouter();
+
   // 화면 하단 DOM 요소 참조
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
   const size = 20;
@@ -66,8 +69,9 @@ export function PostListPage({
   const handlePostClick = useCallback(
     (post: Post) => {
       onPostClick?.(post);
+      router.push(`/board/${post.boardId}/post/${post.postId}`);
     },
-    [onPostClick],
+    [onPostClick, router],
   );
 
   // 에러 처리 화면


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 any가 사용되지 않았습니다
- [x] 스토리북에 추가했습니다 (해당 시)
- [x] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈
- close #347

## 📌 작업 목적
- 내가 스크랩한 게시글, 내가 작성한 게시글 페이지에서 포스트 카드를 클릭하면 상세 조회 페이지로 이동하도록 합니다.
- 포스트 엔터티에서 정의한 쿼리키와 형식을 통일합니다.

## 🔨 주요 작업 내용
- 공통으로 사용되는 PostListPage의 handlePostClick에 경로 이동 로직을 추가하였습니다.
- 훅 자체 쿼리키를 포스트 엔터티의 쿼리키 파일에서 정의한 쿼리키로 수정하였습니다.
- **경로 상수화 PR이 머지되면 상수화된 경로로 변경 후 머지할 예정입니다.**

## 🧪 테스트 방법
`http://localhost:3000/settings`
- 내가 스크랩한 게시글, 내가 작성한 게시글에서 포스트 카드를 클릭하면 상세 조회 경로로 이동되는지 확인해주세요.

## 📷 실행 영상 또는 스크린샷

https://github.com/user-attachments/assets/a52616e1-759c-4115-9799-71d31ed5f3ca



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 게시물 목록에서 게시물을 클릭하면 해당 게시물의 상세 페이지로 자동 이동합니다.

* **리팩터**
  * 게시물 관련 데이터 조회의 내부 키 관리가 통합되어 일관성이 개선되었습니다(내부 동작 개선, 사용자 기능에는 변경 없음).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->