### PR TITLE
[FEAT] 히어로카드 API 연결

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "convert-tokens": "pnpm run convert-typo && pnpm run convert-color && pnpm run convert-scheme && pnpm run convert-shadow",
     "test": "vitest",
     "test:ui": "vitest --ui",
-    "test:run": "vitest run"
+    "test:run": "vitest run",
+    "update-theme": "node scripts/update-theme.ts"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:run": "vitest run",
-    "update-theme": "node scripts/update-theme.ts"
+    "update-theme": "node --loader ts-node/esm scripts/update-theme.ts"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [

--- a/scripts/update-theme.ts
+++ b/scripts/update-theme.ts
@@ -1,0 +1,23 @@
+import fs from 'node:fs';
+import 'dotenv/config';
+
+const theme = JSON.parse(fs.readFileSync('./raw-data/image.json', 'utf8'));
+
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const SUPABASE_URL = process.env.SUPABASE_URL;
+
+async function main() {
+  const res = await fetch(`${SUPABASE_URL}/functions/v1/update-theme`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(theme, null, 2),
+  });
+
+  const data = await res.text();
+  console.log('✅ Result:', data);
+}
+
+void main();

--- a/scripts/update-theme.ts
+++ b/scripts/update-theme.ts
@@ -1,13 +1,111 @@
 import fs from 'node:fs';
-import 'dotenv/config';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import 'dotenv/config';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const themePath = path.resolve(__dirname, '../raw-data/image.json');
-const theme = JSON.parse(fs.readFileSync(themePath, 'utf8'));
+
+/**
+ * Theme Types
+ */
+type ThemeItem = {
+  feCharacter: string;
+  beCharacter: string;
+  dsCharacter: string;
+  daCharacter: string;
+  dlCharacter: string;
+  background: string;
+  isBgDark: boolean;
+  [key: string]: unknown;
+};
+
+type ThemeConfig = {
+  currentSeason: string;
+  base: ThemeItem;
+  seasons: Record<string, ThemeItem>;
+};
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null;
+}
+
+function assertThemeItem(v: unknown, label = 'theme'): asserts v is ThemeItem {
+  if (!isRecord(v)) throw new Error(`${label} must be an object`);
+
+  const required = [
+    'feCharacter',
+    'beCharacter',
+    'dsCharacter',
+    'daCharacter',
+    'dlCharacter',
+    'background',
+    'isBgDark',
+  ] as const;
+
+  for (const k of required) {
+    if (!(k in v)) throw new Error(`${label} missing key: ${k}`);
+  }
+
+  // 문자열 필드 기본 검증
+  for (const k of required.slice(0, 6)) {
+    const val = v[k];
+    if (typeof val !== 'string' || val.trim() === '') {
+      throw new Error(`${label}.${k} must be a non-empty string`);
+    }
+  }
+
+  // 불리언 검증
+  if (typeof v.isBgDark !== 'boolean') {
+    throw new Error(`${label}.isBgDark must be boolean`);
+  }
+
+  // URL 형태 최소 검증
+  for (const k of required.slice(0, 6)) {
+    const s = v[k] as string;
+    if (!/^https?:\/\/.+/i.test(s)) {
+      throw new Error(`${label}.${k} must look like a URL (http/https)`);
+    }
+  }
+}
+
+function assertThemeConfig(v: unknown): asserts v is ThemeConfig {
+  if (!isRecord(v)) throw new Error('ThemeConfig must be an object');
+
+  if (typeof v.currentSeason !== 'string' || v.currentSeason.trim() === '') {
+    throw new Error('ThemeConfig.currentSeason must be a non-empty string');
+  }
+
+  if (!('base' in v)) throw new Error('ThemeConfig.base is required');
+  assertThemeItem(v.base, 'base');
+
+  if (!('seasons' in v)) throw new Error('ThemeConfig.seasons is required');
+  if (!isRecord(v.seasons)) throw new Error('ThemeConfig.seasons must be an object');
+
+  for (const [seasonKey, item] of Object.entries(v.seasons)) {
+    assertThemeItem(item, `seasons["${seasonKey}"]`);
+  }
+
+  // 정책: currentSeason은 seasons에 반드시 존재해야 업로드 허용
+  const seasonKey = v.currentSeason.trim();
+  if (!(seasonKey in v.seasons)) {
+    throw new Error(
+      `currentSeason "${seasonKey}" not found in seasons. Add it to seasons or change currentSeason.`,
+    );
+  }
+}
+
+function readJsonFile(filePath: string): unknown {
+  try {
+    const raw = fs.readFileSync(filePath, 'utf8');
+    return JSON.parse(raw);
+  } catch (e) {
+    console.error(`❌ Failed to read/parse JSON: ${filePath}`);
+    throw e;
+  }
+}
 
 const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
 const SUPABASE_URL = process.env.SUPABASE_URL;
@@ -16,6 +114,19 @@ if (!SUPABASE_SERVICE_ROLE_KEY || !SUPABASE_URL) {
   console.error('❌ Error: SUPABASE_SERVICE_ROLE_KEY and SUPABASE_URL must be set');
   process.exit(1);
 }
+
+// 파일 로드
+const themeUnknown = readJsonFile(themePath);
+
+// 기본 검증
+try {
+  assertThemeConfig(themeUnknown);
+} catch (e) {
+  console.error('❌ Theme JSON validation failed:', e);
+  process.exit(1);
+}
+
+const theme: ThemeConfig = themeUnknown;
 
 async function main() {
   try {

--- a/scripts/update-theme.ts
+++ b/scripts/update-theme.ts
@@ -1,23 +1,45 @@
 import fs from 'node:fs';
 import 'dotenv/config';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const theme = JSON.parse(fs.readFileSync('./raw-data/image.json', 'utf8'));
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const themePath = path.resolve(__dirname, '../raw-data/image.json');
+const theme = JSON.parse(fs.readFileSync(themePath, 'utf8'));
 
 const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
 const SUPABASE_URL = process.env.SUPABASE_URL;
 
-async function main() {
-  const res = await fetch(`${SUPABASE_URL}/functions/v1/update-theme`, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(theme, null, 2),
-  });
+if (!SUPABASE_SERVICE_ROLE_KEY || !SUPABASE_URL) {
+  console.error('❌ Error: SUPABASE_SERVICE_ROLE_KEY and SUPABASE_URL must be set');
+  process.exit(1);
+}
 
-  const data = await res.text();
-  console.log('✅ Result:', data);
+async function main() {
+  try {
+    const res = await fetch(`${SUPABASE_URL}/functions/v1/update-theme`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(theme),
+    });
+
+    if (!res.ok) {
+      const errorText = await res.text();
+      console.error(`❌ Error: HTTP ${res.status} - ${errorText}`);
+      process.exit(1);
+    }
+
+    const data = await res.text();
+    console.log('✅ Result:', data);
+  } catch (error) {
+    console.error('❌ Network or fetch error:', error);
+    process.exit(1);
+  }
 }
 
 void main();

--- a/src/app-pages/home/ui/HomePageClient.tsx
+++ b/src/app-pages/home/ui/HomePageClient.tsx
@@ -8,18 +8,30 @@ import { Shortcut } from '@/shared/ui/shortcut/Shortcut';
 import { AppHeader } from '@/widgets/header/ui/AppHeader';
 import { LawBottomSheet } from '@/features/laws/ui/LawBottomSheet';
 import { useLawAgreement } from '@/features/laws/model/useLawAgreement';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { TAVE_CHANNEL_LINKS, SPONSOR_LINKS, SHORTCUT_LINKS } from '@/entities/home/model/constants';
 import { useRouter } from 'next/navigation';
 import { PAGE_ROUTES } from '@/shared/config/path';
+import { useAuthStore } from '@/features/auth/model/useAuthStore';
+import { HeroCard } from '@/features/home-theme/ui/hero-card/HeroCard';
+import type { HeroCardProps } from '@/features/home-theme/ui/hero-card/HeroCard';
 
-export const HomePage = () => {
+export const HomePageClient = ({ heroProps }: { heroProps: HeroCardProps }) => {
   const router = useRouter();
   const { agreements, handleCheck, isAllRequiredChecked, onClickLawDetail } = useLawAgreement();
   const [isOpen, setIsOpen] = useState(!agreements.laws1 || !agreements.laws2 || !agreements.laws3);
 
   const { data: homeData } = useGetHome();
   const deepLink = homeData?.announcementDeepLink ?? '';
+
+  const { memberId, memberRole } = useAuthStore();
+
+  // TODO: 리뷰 반영 후 제거
+  useEffect(() => {
+    console.log('AuthStore 상태 확인');
+    console.log('memberId:', memberId);
+    console.log('memberRole:', memberRole);
+  }, [memberId, memberRole]);
 
   const handleShortcutClick = (link: string, label: string) => {
     if (process.env.NODE_ENV === 'development') {
@@ -29,7 +41,7 @@ export const HomePage = () => {
   };
 
   return (
-    <div className="overflow-y-auto pb-[1.61rem]">
+    <div className="flex flex-col overflow-y-auto pb-[1.61rem]">
       <div className="absolute z-10 w-full sm:w-[360px]">
         {/* AppHeader */}
         <AppHeader
@@ -51,19 +63,8 @@ export const HomePage = () => {
 
       <div>
         {/* Hero Card */}
-        <div className="bg-foreground-badge-pink h-85 w-full">
-          {/* <HeroCard
-            userData={{
-              name: homeData?.userName,
-              batch: homeData?.userBatch,
-              part: homeData?.userPart,
-            }}
-            noticeData={{
-              title: homeData?.noticeDataMainText,
-              // sender: homeData?.noticeDataSender,
-            }}
-            imgData={[]} // 프론트엔드에서 결정할 부분
-          /> */}
+        <div className="flex w-full flex-col">
+          <HeroCard {...heroProps} />
         </div>
 
         <div className="flex flex-col gap-16 px-13 pt-15">
@@ -84,7 +85,14 @@ export const HomePage = () => {
           />
 
           {/* Carousel */}
-          <Carousel images={homeData?.carouselImages ?? []} />
+          <Carousel
+            images={
+              homeData?.carouselImages?.map((img) => ({
+                ...img,
+                linkUrl: img.linkUrl === null ? undefined : img.linkUrl,
+              })) ?? []
+            }
+          />
 
           {/* 앱 내 바로가기 링크 */}
           {/* 기획 측 정리 문서 필요 */}

--- a/src/app-pages/home/ui/HomePageServer.tsx
+++ b/src/app-pages/home/ui/HomePageServer.tsx
@@ -1,0 +1,10 @@
+import { getHome } from '@/entities/home/api/getHome.server';
+import { buildHeroCardViewModel } from '@/features/home-theme/api/buildHeroCardViewModel.server';
+import { HomePageClient } from './HomePageClient';
+
+export async function HomePage() {
+  const home = await getHome();
+  const heroProps = await buildHeroCardViewModel(home);
+
+  return <HomePageClient heroProps={heroProps} />;
+}

--- a/src/app-pages/home/ui/HomePageServer.tsx
+++ b/src/app-pages/home/ui/HomePageServer.tsx
@@ -4,8 +4,13 @@ import { buildHeroCardViewModel } from '@/features/home-theme/api/buildHeroCardV
 import { HomePageClient } from './HomePageClient';
 
 export async function HomePageServer() {
-  const home = await getHome();
-  const heroProps = await buildHeroCardViewModel(home);
+  try {
+    const home = await getHome();
+    const heroProps = await buildHeroCardViewModel(home);
 
-  return <HomePageClient heroProps={heroProps} />;
+    return <HomePageClient heroProps={heroProps} />;
+  } catch (error) {
+    console.error('[HomePageServer] Failed to load home data:', error);
+    throw error;
+  }
 }

--- a/src/app-pages/home/ui/HomePageServer.tsx
+++ b/src/app-pages/home/ui/HomePageServer.tsx
@@ -2,7 +2,7 @@ import { getHome } from '@/entities/home/api/getHome.server';
 import { buildHeroCardViewModel } from '@/features/home-theme/api/buildHeroCardViewModel.server';
 import { HomePageClient } from './HomePageClient';
 
-export async function HomePage() {
+export async function HomePageServer() {
   const home = await getHome();
   const heroProps = await buildHeroCardViewModel(home);
 

--- a/src/app-pages/home/ui/HomePageServer.tsx
+++ b/src/app-pages/home/ui/HomePageServer.tsx
@@ -1,3 +1,4 @@
+import 'server-only';
 import { getHome } from '@/entities/home/api/getHome.server';
 import { buildHeroCardViewModel } from '@/features/home-theme/api/buildHeroCardViewModel.server';
 import { HomePageClient } from './HomePageClient';

--- a/src/app/(protected)/(main)/page.tsx
+++ b/src/app/(protected)/(main)/page.tsx
@@ -1,4 +1,4 @@
-import { HomePage } from '@/app-pages/home/ui/HomePageServer';
+import { HomePageServer } from '@/app-pages/home/ui/HomePageServer';
 export default function Page() {
-  return <HomePage />;
+  return <HomePageServer />;
 }

--- a/src/app/(protected)/(main)/page.tsx
+++ b/src/app/(protected)/(main)/page.tsx
@@ -1,4 +1,4 @@
-import { HomePage } from '@/app-pages/home/ui/HomePage';
+import { HomePage } from '@/app-pages/home/ui/HomePageServer';
 export default function Page() {
   return <HomePage />;
 }

--- a/src/entities/home/api/getHome.server.ts
+++ b/src/entities/home/api/getHome.server.ts
@@ -1,3 +1,4 @@
+import 'server-only';
 import type { HomeApiResponse, HomeApiResponseData } from './types';
 import { serverFetchJsonGuarded } from '@/shared/api/serverFetchJsonGuarded';
 import { homeResponseGuard } from './guards';

--- a/src/entities/home/api/getHome.server.ts
+++ b/src/entities/home/api/getHome.server.ts
@@ -1,0 +1,13 @@
+import type { HomeApiResponse, HomeApiResponseData } from './types';
+import { serverFetchJsonGuarded } from '@/shared/api/serverFetchJsonGuarded';
+import { homeResponseGuard } from './guards';
+
+export async function getHome(): Promise<HomeApiResponseData> {
+  const res = await serverFetchJsonGuarded<HomeApiResponse>('/v1/user/home', homeResponseGuard);
+
+  if (res.code !== 200) {
+    throw new Error(`Home API returned error code: ${res.code} (${res.message})`);
+  }
+
+  return res.data;
+}

--- a/src/entities/home/api/guards.ts
+++ b/src/entities/home/api/guards.ts
@@ -1,0 +1,48 @@
+import type { Guard } from '@/shared/api/types';
+import { commonResponseGuard } from '@/shared/api/types';
+import type { HomeApiResponseData, HomeBanner } from './types';
+
+const isNumber: Guard<number> = (x): x is number => typeof x === 'number';
+const isString: Guard<string> = (x): x is string => typeof x === 'string';
+
+const isNullable =
+  <T>(g: Guard<T>): Guard<T | null> =>
+  (x): x is T | null =>
+    x === null || g(x);
+
+const isOptionalNullable =
+  <T>(g: Guard<T>): Guard<T | null | undefined> =>
+  (x): x is T | null | undefined =>
+    x === undefined || x === null || g(x);
+
+const isHomeBanner: Guard<HomeBanner> = (x): x is HomeBanner => {
+  if (typeof x !== 'object' || x === null) return false;
+  const o = x as Record<string, unknown>;
+
+  return (
+    isNumber(o.id) &&
+    isString(o.imageUrl) &&
+    isNullable(isString)(o.linkUrl) &&
+    isNumber(o.displayOrder)
+  );
+};
+
+const isHomeApiResponseData: Guard<HomeApiResponseData> = (x): x is HomeApiResponseData => {
+  if (typeof x !== 'object' || x === null) return false;
+  const o = x as Record<string, unknown>;
+
+  return (
+    isString(o.mainText) &&
+    isOptionalNullable(isString)(o.sender) &&
+    Array.isArray(o.banners) &&
+    o.banners.every(isHomeBanner) &&
+    isString(o.memberName) &&
+    isNumber(o.memberGeneration) &&
+    isString(o.memberPart) &&
+    isNullable(isString)(o.nextScheduleTitle) &&
+    isNullable(isString)(o.nextScheduleDate) &&
+    isNullable(isString)(o.nextScheduleDeepLink)
+  );
+};
+
+export const homeResponseGuard = commonResponseGuard(isHomeApiResponseData);

--- a/src/entities/home/api/guards.ts
+++ b/src/entities/home/api/guards.ts
@@ -1,9 +1,7 @@
 import type { Guard } from '@/shared/api/types';
 import { commonResponseGuard } from '@/shared/api/types';
 import type { HomeApiResponseData, HomeBanner } from './types';
-
-const isNumber: Guard<number> = (x): x is number => typeof x === 'number';
-const isString: Guard<string> = (x): x is string => typeof x === 'string';
+import { isNumber, isString } from '@/shared/api/primitives';
 
 const isNullable =
   <T>(g: Guard<T>): Guard<T | null> =>

--- a/src/entities/home/api/types.ts
+++ b/src/entities/home/api/types.ts
@@ -1,21 +1,22 @@
-import { CommonResponse } from '@/shared/api/types';
+import type { CommonResponse } from '@/shared/api/types';
 
 export interface HomeBanner {
   id: number;
   imageUrl: string;
-  linkUrl: string;
+  linkUrl: string | null;
   displayOrder: number;
 }
 
 export interface HomeApiResponseData {
   mainText: string;
+  sender?: string | null;
   banners: HomeBanner[];
   memberName: string;
   memberGeneration: number;
   memberPart: string;
-  nextScheduleTitle?: string;
-  nextScheduleDate?: string;
-  nextScheduleDeepLink?: string;
+  nextScheduleTitle: string | null;
+  nextScheduleDate: string | null;
+  nextScheduleDeepLink: string | null;
 }
 
 export type HomeApiResponse = CommonResponse<HomeApiResponseData>;

--- a/src/entities/home/model/constants.ts
+++ b/src/entities/home/model/constants.ts
@@ -11,7 +11,7 @@ export interface ShortcutItem {
 export const SHORTCUT_LINKS: ShortcutItem[] = [
   { id: 1, label: '공지사항', imageSrc: '/icons/notice.png', link: PAGE_ROUTES.BOARD.MAIN },
   { id: 2, label: '일정', imageSrc: '/icons/notice.png', link: PAGE_ROUTES.CALENDAR.MAIN },
-  { id: 3, label: '주소록', imageSrc: '/icons/job.png', link: '/job' },
+  { id: 3, label: '주소록', imageSrc: '/icons/job.png', link: PAGE_ROUTES.MEMBER_SEARCH },
 ];
 
 // 2. TAVE 채널 데이터

--- a/src/entities/user/api/getMyProfile.server.ts
+++ b/src/entities/user/api/getMyProfile.server.ts
@@ -1,3 +1,4 @@
+import 'server-only';
 import type { UserProfileApiResponse } from '@/entities/user/api/types';
 import { serverFetchWithCookies } from '@/shared/api/serverFetchWithCookies';
 

--- a/src/features/home-theme/api/buildHeroCardViewModel.server.ts
+++ b/src/features/home-theme/api/buildHeroCardViewModel.server.ts
@@ -3,9 +3,9 @@ import type { ThemeItem } from './types';
 import type { HomeApiResponseData } from '@/entities/home/api/types';
 import type { HeroCardProps } from '@/features/home-theme/ui/hero-card/HeroCard';
 import { getCharacterKeyByPart, PART_LABEL } from '@/features/home-theme/model/mappers';
+import { getTheme } from './getTheme.server';
 
 export async function buildHeroCardViewModel(home: HomeApiResponseData): Promise<HeroCardProps> {
-  const { getTheme } = await import('./getTheme.server');
   const theme: ThemeItem = await getTheme();
 
   const characterKey = getCharacterKeyByPart(home.memberPart);

--- a/src/features/home-theme/api/buildHeroCardViewModel.server.ts
+++ b/src/features/home-theme/api/buildHeroCardViewModel.server.ts
@@ -1,0 +1,39 @@
+import 'server-only';
+import type { ThemeItem } from './types';
+import type { HomeApiResponseData } from '@/entities/home/api/types';
+import type { HeroCardProps } from '@/features/home-theme/ui/hero-card/HeroCard';
+import { getCharacterKeyByPart, PART_LABEL } from '@/features/home-theme/model/mappers';
+
+export async function buildHeroCardViewModel(home: HomeApiResponseData): Promise<HeroCardProps> {
+  const { getTheme } = await import('./getTheme.server');
+  const theme: ThemeItem = await getTheme();
+
+  const characterKey = getCharacterKeyByPart(home.memberPart);
+
+  const charImgUrl = theme[characterKey] as string | null;
+  if (!charImgUrl) {
+    throw new Error(`Character image not found: ${characterKey}`);
+  }
+
+  const bgImgUrl = theme.background as string | null;
+  if (!bgImgUrl) {
+    throw new Error('Theme background not found');
+  }
+
+  return {
+    noticeData: {
+      title: home.mainText,
+      sender: home.sender ?? 'TAVE 운영진',
+    },
+    userData: {
+      name: home.memberName,
+      batch: home.memberGeneration,
+      part: PART_LABEL[home.memberPart] ?? home.memberPart,
+    },
+    imgData: {
+      bgImgUrl,
+      charImgUrl,
+      isDark: !!theme.isBgDark,
+    },
+  };
+}

--- a/src/features/home-theme/api/buildHeroCardViewModel.server.ts
+++ b/src/features/home-theme/api/buildHeroCardViewModel.server.ts
@@ -10,13 +10,13 @@ export async function buildHeroCardViewModel(home: HomeApiResponseData): Promise
 
   const characterKey = getCharacterKeyByPart(home.memberPart);
 
-  const charImgUrl = theme[characterKey] as string | null;
-  if (!charImgUrl) {
+  const charImgUrl = theme[characterKey];
+  if (typeof charImgUrl !== 'string' || !charImgUrl) {
     throw new Error(`Character image not found: ${characterKey}`);
   }
 
-  const bgImgUrl = theme.background as string | null;
-  if (!bgImgUrl) {
+  const bgImgUrl = theme.background;
+  if (typeof bgImgUrl !== 'string' || !bgImgUrl) {
     throw new Error('Theme background not found');
   }
 

--- a/src/features/home-theme/api/getTheme.server.ts
+++ b/src/features/home-theme/api/getTheme.server.ts
@@ -10,7 +10,7 @@ if (!SUPABASE_URL) {
 export async function getTheme(): Promise<ThemeItem> {
   const url = `${SUPABASE_URL}/storage/v1/object/public/assets/config/image.json`;
 
-  const res = await fetch(url, { cache: 'no-store' });
+  const res = await fetch(url, { next: { revalidate: 3600 } });
   if (!res.ok) {
     throw new Error(`Failed to fetch theme: ${res.status} ${res.statusText}`);
   }

--- a/src/features/home-theme/api/getTheme.server.ts
+++ b/src/features/home-theme/api/getTheme.server.ts
@@ -1,5 +1,6 @@
 import 'server-only';
 import type { ThemeConfig, ThemeItem } from './types';
+import { assertThemeItem } from './guards';
 
 const SUPABASE_URL = process.env.SUPABASE_URL;
 
@@ -23,6 +24,6 @@ export async function getTheme(): Promise<ThemeItem> {
   if (!theme) {
     throw new Error(`Theme not found for season: ${seasonKey}`);
   }
-
+  assertThemeItem(theme);
   return theme;
 }

--- a/src/features/home-theme/api/getTheme.server.ts
+++ b/src/features/home-theme/api/getTheme.server.ts
@@ -18,5 +18,11 @@ export async function getTheme(): Promise<ThemeItem> {
   const config = (await res.json()) as ThemeConfig;
 
   const seasonKey = (config.currentSeason ?? '').trim();
-  return config.seasons?.[seasonKey] ?? config.base ?? {};
+  const theme = config.seasons?.[seasonKey] ?? config.base;
+
+  if (!theme) {
+    throw new Error(`Theme not found for season: ${seasonKey}`);
+  }
+
+  return theme;
 }

--- a/src/features/home-theme/api/getTheme.server.ts
+++ b/src/features/home-theme/api/getTheme.server.ts
@@ -1,0 +1,22 @@
+import 'server-only';
+import type { ThemeConfig, ThemeItem } from './types';
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+
+if (!SUPABASE_URL) {
+  throw new Error('SUPABASE_URL is not set');
+}
+
+export async function getTheme(): Promise<ThemeItem> {
+  const url = `${SUPABASE_URL}/storage/v1/object/public/assets/config/image.json`;
+
+  const res = await fetch(url, { cache: 'no-store' });
+  if (!res.ok) {
+    throw new Error(`Failed to fetch theme: ${res.status} ${res.statusText}`);
+  }
+
+  const config = (await res.json()) as ThemeConfig;
+
+  const seasonKey = (config.currentSeason ?? '').trim();
+  return config.seasons?.[seasonKey] ?? config.base ?? {};
+}

--- a/src/features/home-theme/api/guards.ts
+++ b/src/features/home-theme/api/guards.ts
@@ -1,0 +1,31 @@
+import { ThemeItem } from './types';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+export function assertThemeItem(theme: unknown): asserts theme is ThemeItem {
+  if (!isRecord(theme)) {
+    throw new Error('Theme must be an object');
+  }
+
+  const required = [
+    'feCharacter',
+    'beCharacter',
+    'dsCharacter',
+    'daCharacter',
+    'dlCharacter',
+    'background',
+    'isBgDark',
+  ] as const;
+
+  for (const key of required) {
+    if (!(key in theme)) {
+      throw new Error(`ThemeItem missing key: ${key}`);
+    }
+  }
+
+  if (typeof theme.isBgDark !== 'boolean') {
+    throw new Error('isBgDark must be boolean');
+  }
+}

--- a/src/features/home-theme/api/types.ts
+++ b/src/features/home-theme/api/types.ts
@@ -1,3 +1,14 @@
+/**
+ * 히어로카드 스타일에 필요한 항목
+ *
+ * @property background - 배경 이미지 URL
+ * @property isBgDark - 배경이 어두운 테마인지 여부 (텍스트 색상 결정에 사용)
+ * @property feCharacter - 프론트엔드 파트 캐릭터 이미지 URL
+ * @property beCharacter - 백엔드 파트 캐릭터 이미지 URL
+ * @property dsCharacter - 디자인 파트 캐릭터 이미지 URL
+ * @property daCharacter - 데이터 분석 파트 캐릭터 이미지 URL
+ * @property dlCharacter - 딥러닝 파트 캐릭터 이미지 URL
+ */
 export type ThemeItem = {
   background?: string;
   isBgDark?: boolean;
@@ -12,6 +23,13 @@ export type ThemeItem = {
   [key: string]: unknown;
 };
 
+/**
+ * Supabase에서 로드되는 테마 설정 전체 구조
+ *
+ * @property currentSeason - 현재 활성화된 시즌 키 (예: "2024-winter")
+ * @property base - 기본 테마 (시즌 테마가 없을 때 폴백)
+ * @property seasons - 시즌별 캐릭터/배경
+ */
 export type ThemeConfig = {
   currentSeason: string;
   base: ThemeItem;

--- a/src/features/home-theme/api/types.ts
+++ b/src/features/home-theme/api/types.ts
@@ -10,14 +10,14 @@
  * @property dlCharacter - 딥러닝 파트 캐릭터 이미지 URL
  */
 export type ThemeItem = {
-  background?: string;
-  isBgDark?: boolean;
+  background: string;
+  isBgDark: boolean;
 
-  feCharacter?: string;
-  beCharacter?: string;
-  dsCharacter?: string;
-  daCharacter?: string;
-  dlCharacter?: string;
+  feCharacter: string;
+  beCharacter: string;
+  dsCharacter: string;
+  daCharacter: string;
+  dlCharacter: string;
 
   // 필요하면 확장
   [key: string]: unknown;

--- a/src/features/home-theme/api/types.ts
+++ b/src/features/home-theme/api/types.ts
@@ -1,0 +1,19 @@
+export type ThemeItem = {
+  background?: string;
+  isBgDark?: boolean;
+
+  feCharacter?: string;
+  beCharacter?: string;
+  dsCharacter?: string;
+  daCharacter?: string;
+  dlCharacter?: string;
+
+  // 필요하면 확장
+  [key: string]: unknown;
+};
+
+export type ThemeConfig = {
+  currentSeason: string;
+  base: ThemeItem;
+  seasons: Record<string, ThemeItem>;
+};

--- a/src/features/home-theme/model/mappers.ts
+++ b/src/features/home-theme/model/mappers.ts
@@ -17,7 +17,12 @@ const PART_TO_CHARACTER_KEY: Record<TrackPart, ThemeCharacterKey> = {
 };
 
 export function getCharacterKeyByPart(part: string): ThemeCharacterKey {
-  return PART_TO_CHARACTER_KEY[part as TrackPart] ?? 'feCharacter';
+  const characterKey = PART_TO_CHARACTER_KEY[part as TrackPart];
+  if (!characterKey) {
+    console.error(`Unknown part: ${part}, falling back to feCharacter`);
+    return 'feCharacter';
+  }
+  return characterKey;
 }
 
 export const PART_LABEL: Record<string, string> = {

--- a/src/features/home-theme/model/mappers.ts
+++ b/src/features/home-theme/model/mappers.ts
@@ -1,0 +1,30 @@
+import { TrackPart } from '@/entities/user/model/types';
+
+export type ThemeCharacterKey =
+  | 'feCharacter'
+  | 'beCharacter'
+  | 'dsCharacter'
+  | 'daCharacter'
+  | 'dlCharacter';
+
+const PART_TO_CHARACTER_KEY: Record<TrackPart, ThemeCharacterKey> = {
+  BACKEND: 'beCharacter',
+  WEB_FRONTEND: 'feCharacter',
+  APP_FRONTEND: 'feCharacter',
+  DESIGN: 'dsCharacter',
+  DATA_ANALYSIS: 'daCharacter',
+  DEEP_LEARNING: 'dlCharacter',
+};
+
+export function getCharacterKeyByPart(part: string): ThemeCharacterKey {
+  return PART_TO_CHARACTER_KEY[part as TrackPart] ?? 'feCharacter';
+}
+
+export const PART_LABEL: Record<string, string> = {
+  BACKEND: '백엔드',
+  WEB_FRONTEND: '웹 프론트엔드',
+  APP_FRONTEND: '앱 프론트엔드',
+  DESIGN: '디자인',
+  DATA_ANALYSIS: '데이터 분석',
+  DEEP_LEARNING: '딥러닝',
+};

--- a/src/features/home-theme/ui/hero-card/HeroCard.tsx
+++ b/src/features/home-theme/ui/hero-card/HeroCard.tsx
@@ -42,11 +42,12 @@ export function HeroCard({ userData, noticeData, imgData }: HeroCardProps) {
     : 'text-foreground-static-black';
 
   return (
-    <div className="relative w-full overflow-hidden bg-transparent">
+    <div className="relative w-full overflow-hidden bg-transparent" aria-hidden="true">
       <svg
         viewBox={`${rectX} ${rectY} ${rectWidth} ${rectHeight}`}
         xmlns="http://www.w3.org/2000/svg"
         className="block h-auto w-full"
+        aria-hidden="true"
       >
         <defs>
           {/* 배경 이미지 */}
@@ -64,6 +65,7 @@ export function HeroCard({ userData, noticeData, imgData }: HeroCardProps) {
               width={rectWidth}
               height={rectHeight}
               preserveAspectRatio="xMidYMid slice"
+              aria-hidden="true"
             />
           </pattern>
 
@@ -92,6 +94,7 @@ export function HeroCard({ userData, noticeData, imgData }: HeroCardProps) {
             width={charSize}
             height={charSize}
             preserveAspectRatio="xMidYMid meet"
+            aria-label={`${userData.part} 캐릭터`}
           />
         </g>
       </svg>

--- a/src/features/home-theme/ui/hero-card/HeroCard.tsx
+++ b/src/features/home-theme/ui/hero-card/HeroCard.tsx
@@ -1,0 +1,114 @@
+import { useId } from 'react';
+
+interface UserData {
+  name: string;
+  batch: number;
+  part: string;
+}
+
+interface NoticeData {
+  title: string;
+  sender: string;
+}
+
+interface ImgData {
+  bgImgUrl: string;
+  charImgUrl: string;
+  isDark: boolean;
+}
+
+export interface HeroCardProps {
+  userData: UserData;
+  noticeData: NoticeData;
+  imgData: ImgData;
+}
+
+export function HeroCard({ userData, noticeData, imgData }: HeroCardProps) {
+  const id = useId();
+  // 백그라운드 모양 생성 로직
+  const rectWidth = 375;
+  const rectHeight = 311.5;
+  const rectX = -187.5;
+  const rectY = -311.5;
+  const radius = 1250;
+  const circleY = -1250;
+
+  const charSize = 187.5;
+  const charX = rectWidth / 2 - charSize; // 187.5 - 187.5 = 0
+  const charY = 0 - charSize;
+
+  const textColor = imgData.isDark
+    ? 'text-foreground-static-white'
+    : 'text-foreground-static-black';
+
+  return (
+    <div className="relative w-full overflow-hidden bg-transparent">
+      <svg
+        viewBox={`${rectX} ${rectY} ${rectWidth} ${rectHeight}`}
+        xmlns="http://www.w3.org/2000/svg"
+        className="block h-auto w-full"
+      >
+        <defs>
+          {/* 배경 이미지 */}
+
+          <pattern
+            id={`bg-pattern-${id}`}
+            patternUnits="userSpaceOnUse"
+            x={rectX}
+            y={rectY}
+            width={rectWidth}
+            height={rectHeight}
+          >
+            <image
+              href={imgData.bgImgUrl}
+              width={rectWidth}
+              height={rectHeight}
+              preserveAspectRatio="xMidYMid slice"
+            />
+          </pattern>
+
+          {/* 원호 클리핑 */}
+          <clipPath id={`arc-clip-${id}`}>
+            <circle cx="0" cy={circleY} r={radius} />
+          </clipPath>
+        </defs>
+
+        {/* 배경 레이어 클리핑 적용 */}
+        <rect
+          x={rectX}
+          y={rectY}
+          width={rectWidth}
+          height={rectHeight}
+          fill={`url(#bg-pattern-${id})`}
+          clipPath={`url(#arc-clip-${id})`}
+        />
+
+        {/* 캐릭터 이미지 */}
+        <g clipPath={`url(#arc-clip-${id})`}>
+          <image
+            href={imgData.charImgUrl}
+            x={charX}
+            y={charY}
+            width={charSize}
+            height={charSize}
+            preserveAspectRatio="xMidYMid meet"
+          />
+        </g>
+      </svg>
+
+      {/* 텍스트 레이어 */}
+      <div className="pointer-events-none absolute inset-0 z-10 flex flex-col">
+        <div className="mt-[4.875rem] flex flex-col gap-1 px-15">
+          <h1 className={`text-body-body5 ${textColor} truncate`}>{noticeData.title}</h1>
+          <h2 className={`text-body-body9 ${textColor} truncate`}>{noticeData.sender}</h2>
+        </div>
+
+        <div className="mt-auto mb-[2.5rem] ml-15 flex w-fit flex-col">
+          <span className={`text-body-body8 ${textColor} truncate`}>{userData.name}</span>
+          <span className={`text-body-body9 ${textColor} truncate`}>{userData.batch}기</span>
+          <span className={`text-body-body9 ${textColor} truncate`}>{userData.part}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/recent-search/api/getRecentSearch.server.ts
+++ b/src/features/recent-search/api/getRecentSearch.server.ts
@@ -1,3 +1,4 @@
+import 'server-only';
 import type { CommonResponse } from '@/shared/api/types';
 import { serverFetchJsonGuarded } from '@/shared/api/serverFetchJsonGuarded';
 import { commonResponseGuard } from '@/shared/api/types';

--- a/src/shared/api/primitives.ts
+++ b/src/shared/api/primitives.ts
@@ -1,8 +1,9 @@
 import type { Guard } from '@/shared/api/types';
 
 export const isString: Guard<string> = (x): x is string => typeof x === 'string';
-
 export const isStringArray: Guard<string[]> = (x): x is string[] =>
   Array.isArray(x) && x.every((v) => typeof v === 'string');
 
 export const isNull: Guard<null> = (x): x is null => x === null;
+
+export const isNumber: Guard<number> = (x): x is number => typeof x === 'number';

--- a/src/shared/config/path.ts
+++ b/src/shared/config/path.ts
@@ -2,7 +2,10 @@ export const PAGE_ROUTES = {
   HOME: '/',
   LOGIN: '/login',
   ONBOARDING: '/onboarding',
+
+  // 멤버 관련
   PROFILE: '/profile',
+  MEMBER_SEARCH: '/member-search',
 
   // 캘린더 관련
   CALENDAR: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,7 +32,8 @@
     ".next/types/**/*.ts",
     "**/*.js",
     "**/*.mjs",
-    ".storybook/**/*"
+    ".storybook/**/*",
+    "scripts/update-theme.ts"
   ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 any가 사용되지 않았습니다
- [x] 스토리북에 추가했습니다 (해당 시)
- [x] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈
- close #353

## 📌 작업 목적
- 히어로카드 api 연결

## 🔨 주요 작업 내용
- 파트에 맞게 캐릭터 이미지 렌더링
- 주소록 url 연결
- supabase에 이미지 업로드

## 🧪 테스트 방법
- 홈 화면 확인

## 💬 논의할 점
- env가 변경되었습니다
- home이 server에서 불러오는 부분과 client에서 불러오는 게 나뉘어져 있어서 error가 뜨는데 이건 한번에 수정해야할 것 같습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 테마 기반 히어로 카드 컴포넌트 추가 — 동적 배경·캐릭터 이미지와 사용자 정보 표시
  * 홈 페이지를 서버/클라이언트 구성으로 분리하여 서버에서 데이터 조립 후 클라이언트에 전달
  * 멤버 검색 경로 추가

* **개선 사항**
  * 홈 데이터 응답 런타임 가드 및 오류 처리 강화
  * 테마 로드·선택 및 파트→캐릭터 매핑 로직 추가

* **잡업(Chores)**
  * 테마 업데이트용 CLI 스크립트와 npm 스크립트 추가
  * 공용 유효성 검사 유틸(숫자 검사 등) 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->