### PR TITLE
[HOTFIX] member 회원 게시글과 매핑된 일정 조회 이슈

### DIFF
--- a/src/app-pages/post/PostDetailPage.tsx
+++ b/src/app-pages/post/PostDetailPage.tsx
@@ -36,11 +36,13 @@ export default function PostDetailPage({ postId }: PostDetailPageProps) {
   const { data: post, isLoading, isError } = usePostDetail(numericPostId);
 
   // 일정 조회 API
+  const scheduleId = post?.scheduleId;
+
   const {
     data: schedule,
     isLoading: isScheduleLoading,
     isError: isScheduleError,
-  } = useGetPostScheduleQuery(numericPostId, !!post?.hasSchedule);
+  } = useGetPostScheduleQuery(numericPostId, scheduleId, !!post?.hasSchedule);
 
   // 좋아요 누른 사람 목록 API
   const {
@@ -57,7 +59,7 @@ export default function PostDetailPage({ postId }: PostDetailPageProps) {
   const { mutate: deletePostMutate } = useDeletePostMutation();
 
   // 로딩/에러 처리
-  if (isLoading || (post?.hasSchedule && isScheduleLoading))
+  if (isLoading || (scheduleId && isScheduleLoading))
     return (
       <div className="flex h-full w-full items-center justify-center">
         <span>불러오는 중...</span>
@@ -71,9 +73,9 @@ export default function PostDetailPage({ postId }: PostDetailPageProps) {
       </div>
     );
 
-  if (post?.hasSchedule && isScheduleError) {
+  if (scheduleId && isScheduleError) {
     if (process.env.NODE_ENV === 'development') {
-      console.warn(`일정 정보(PostID: ${numericPostId})를 불러올 수 없습니다.`);
+      console.warn(`일정 정보(ID: ${scheduleId})를 불러올 수 없습니다.`);
     }
   }
 

--- a/src/app-pages/post/PostDetailPage.tsx
+++ b/src/app-pages/post/PostDetailPage.tsx
@@ -17,7 +17,7 @@ import { Alert } from '@/shared/ui/alert/Alert';
 import { usePathname, useRouter } from 'next/navigation';
 import { Avatar } from '@/shared/ui/avatar/Avatar';
 import { categoryIdToKey } from '@/entities/post/model/category';
-import { useGetSingleSchedule } from '@/features/schedule/edit/model/useGetSingleSchedule';
+import { useGetPostScheduleQuery } from '@/features/post/model/useGetPostScheduleQuery';
 import { useDeletePostMutation } from '@/features/post/model/useDeletePostMutation';
 import { useToastStore } from '@/shared/store/toastStore';
 
@@ -36,15 +36,11 @@ export default function PostDetailPage({ postId }: PostDetailPageProps) {
   const { data: post, isLoading, isError } = usePostDetail(numericPostId);
 
   // 일정 조회 API
-  const scheduleId = post?.scheduleId;
-
   const {
     data: schedule,
     isLoading: isScheduleLoading,
     isError: isScheduleError,
-  } = useGetSingleSchedule(scheduleId, {
-    enabled: !!scheduleId,
-  });
+  } = useGetPostScheduleQuery(numericPostId, !!post?.hasSchedule);
 
   // 좋아요 누른 사람 목록 API
   const {
@@ -61,7 +57,7 @@ export default function PostDetailPage({ postId }: PostDetailPageProps) {
   const { mutate: deletePostMutate } = useDeletePostMutation();
 
   // 로딩/에러 처리
-  if (isLoading || (scheduleId && isScheduleLoading))
+  if (isLoading || (post?.hasSchedule && isScheduleLoading))
     return (
       <div className="flex h-full w-full items-center justify-center">
         <span>불러오는 중...</span>
@@ -75,9 +71,9 @@ export default function PostDetailPage({ postId }: PostDetailPageProps) {
       </div>
     );
 
-  if (scheduleId && isScheduleError) {
+  if (post?.hasSchedule && isScheduleError) {
     if (process.env.NODE_ENV === 'development') {
-      console.warn(`일정 정보(ID: ${scheduleId})를 불러올 수 없습니다.`);
+      console.warn(`일정 정보(PostID: ${numericPostId})를 불러올 수 없습니다.`);
     }
   }
 

--- a/src/features/post/model/useGetPostScheduleQuery.ts
+++ b/src/features/post/model/useGetPostScheduleQuery.ts
@@ -1,12 +1,17 @@
 import { useQuery } from '@tanstack/react-query';
 import { PostScheduleResponse } from '@/entities/post/api/types';
 import { postApi } from '@/entities/post/api/postApi';
+import { scheduleQueryKeys } from '@/features/calendar/api/queryKeys';
 
-export function useGetPostScheduleQuery(postId: number, enabled = true) {
+export function useGetPostScheduleQuery(
+  postId: number,
+  scheduleId: number | undefined | null,
+  enabled = true,
+) {
   return useQuery<PostScheduleResponse['data']>({
-    queryKey: ['postSchedule', postId],
+    queryKey: scheduleQueryKeys.detail(scheduleId!),
     queryFn: () => postApi.getPostSchedule(postId),
-    enabled,
+    enabled: !!scheduleId && enabled,
     retry: false,
   });
 }

--- a/src/widgets/schedule/ui/ScheduleForm.tsx
+++ b/src/widgets/schedule/ui/ScheduleForm.tsx
@@ -28,7 +28,7 @@ export default function ScheduleForm({ onSubmit, initialData }: ScheduleFormProp
   useEffect(() => {
     if (initialData) {
       reset({
-        category: initialData.category || 'regular',
+        category: initialData.category || '',
         title: initialData.title ?? '',
         startDate: ensureUtcDate(initialData.startDate),
         endDate: ensureUtcDate(initialData.endDate),

--- a/src/widgets/schedule/ui/ScheduleForm.tsx
+++ b/src/widgets/schedule/ui/ScheduleForm.tsx
@@ -28,7 +28,7 @@ export default function ScheduleForm({ onSubmit, initialData }: ScheduleFormProp
   useEffect(() => {
     if (initialData) {
       reset({
-        category: initialData.category || '',
+        category: initialData.category || '정규행사',
         title: initialData.title ?? '',
         startDate: ensureUtcDate(initialData.startDate),
         endDate: ensureUtcDate(initialData.endDate),


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 코드에 any가 사용되지 않았습니다
- [ ] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈
- close #

## ⚠️ 기존 문제
- 일정 카테고리 default 값 regular로 전송하여 member 인 회원이 공지사항과 매핑된 일정을 보지 못하는 문제가 있었음

## ☑️ 해결 방법
- default 값 빈 배열로 수정

## 🧪 테스트 방법
- member 인 회원이 공지사항과 매핑된 일정을 볼 수 있는지 확인

## ✔️ 설치 라이브러리
- 

## 📷 실행 영상 또는 스크린샷
- 

## 💬 논의할 점
- 

## 🙋🏻 참고 자료
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 일정 작성/수정 화면에서 기존 데이터를 불러올 때 카테고리 기본값이 올바르게 '정규행사'로 반영됩니다.
  * 게시물 상세에서 일정 정보를 가져오는 로직이 게시물의 일정 보유 여부와 일정 ID 존재를 기준으로 더 엄격히 판단되어 일정 표시 및 로딩/오류 상태가 안정화됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->