### PR TITLE
[FEAT] 마이페이지 설정- 테마 변경 화면 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "firebase": "^12.7.0",
     "keen-slider": "^6.8.6",
     "next": "15.5.9",
+    "next-themes": "^0.4.6",
     "react": "19.1.0",
     "react-day-picker": "^9.11.1",
     "react-dom": "19.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       next:
         specifier: 15.5.9
         version: 15.5.9(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next-themes:
+        specifier: ^0.4.6
+        version: 0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -4824,6 +4827,12 @@ packages:
 
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+
+  next-themes@0.4.6:
+    resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
+    peerDependencies:
+      react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
   next@15.5.9:
     resolution: {integrity: sha512-agNLK89seZEtC5zUHwtut0+tNrc0Xw4FT/Dg+B/VLEo9pAcS9rtTKpek3V6kVcVwsB2YlqMaHdfZL4eLEVYuCg==}
@@ -11732,6 +11741,11 @@ snapshots:
   natural-compare@1.4.0: {}
 
   neo-async@2.6.2: {}
+
+  next-themes@0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   next@15.5.9(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:

--- a/src/app-pages/mypage/settings/mode/ui/ModePage.tsx
+++ b/src/app-pages/mypage/settings/mode/ui/ModePage.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { SettingsItem } from '@/entities/settings/ui/SettingsItem';
+import { HeaderMode } from '@/shared/ui/header/Header';
+import { Radio } from '@/shared/ui/radio/Radio';
+import { AppHeader } from '@/widgets/header/ui/AppHeader';
+import { THEME_OPTIONS } from '@/widgets/settings-list/model/constants';
+import { useTheme } from 'next-themes';
+import { useEffect, useState } from 'react';
+
+export const ModePage = () => {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) return null;
+
+  return (
+    <div>
+      <AppHeader
+        overrideHeader={{
+          title: '테마 변경',
+          mode: HeaderMode.Default,
+          hasLeftIcon: true,
+        }}
+      />
+
+      {THEME_OPTIONS.map((option) => (
+        <SettingsItem
+          key={option.value}
+          leftIconName={option.icon}
+          rightContent={
+            <div>
+              <Radio
+                id={option.value}
+                name="mode"
+                value={option.value}
+                isChecked={theme === option.value}
+                onChange={() => setTheme(option.value)}
+              />
+            </div>
+          }
+          onClick={() => setTheme(option.value)}
+        >
+          {option.label}
+        </SettingsItem>
+      ))}
+    </div>
+  );
+};

--- a/src/app-pages/post/write/ui/PostPage.tsx
+++ b/src/app-pages/post/write/ui/PostPage.tsx
@@ -137,9 +137,12 @@ export default function PostPage(props: PostPageProps) {
         className="mx-auto flex w-full sm:w-[360px]"
       >
         <ModalSheet.Container>
-          <ModalSheet.Header />
+          <ModalSheet.Header className="bg-background-normal-lighter" />
           <ModalSheet.Content>
-            <div id={categorySheetId} className="flex flex-col gap-5 p-15">
+            <div
+              id={categorySheetId}
+              className="bg-background-normal-lighter flex flex-col gap-5 p-15"
+            >
               {Object.values(POST_CATEGORIES).map((item) => (
                 <button
                   key={item.id}

--- a/src/app/(protected)/(sub)/settings/mode/page.tsx
+++ b/src/app/(protected)/(sub)/settings/mode/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { ModePage } from '@/app-pages/mypage/settings/mode/ui/ModePage';
+
+export default function Page() {
+  return <ModePage />;
+}

--- a/src/app/providers/QueryProvider.tsx
+++ b/src/app/providers/QueryProvider.tsx
@@ -3,6 +3,7 @@
 import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactNode } from 'react';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { ThemeProvider } from 'next-themes';
 
 import getQueryClient from '@/shared/lib/tanstack-query/getQueryClient';
 
@@ -11,8 +12,10 @@ export function QueryProvider({ children }: { children: ReactNode }) {
 
   return (
     <QueryClientProvider client={queryClient}>
-      {children}
-      {process.env.NODE_ENV === 'development' && <ReactQueryDevtools />}
+      <ThemeProvider attribute="data-theme" defaultTheme="system" enableSystem>
+        {children}
+        {process.env.NODE_ENV === 'development' && <ReactQueryDevtools />}
+      </ThemeProvider>
     </QueryClientProvider>
   );
 }

--- a/src/entities/settings/ui/SettingsItem.tsx
+++ b/src/entities/settings/ui/SettingsItem.tsx
@@ -9,6 +9,7 @@ type SurfIconName = ComponentProps<typeof SurfIcon>['name'];
 export type SettingsItemProps = Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'disabled'> & {
   leftIconName?: SurfIconName | null;
   rightIconName?: SurfIconName | null;
+  rightContent?: ReactNode;
   isDisabled?: boolean;
   children: ReactNode;
   onClick?: (e: MouseEvent<HTMLButtonElement>) => void;
@@ -22,6 +23,7 @@ export const SettingsItem = forwardRef<HTMLButtonElement, SettingsItemProps>(
     {
       leftIconName,
       rightIconName,
+      rightContent,
       isDisabled = false,
       children,
       type = 'button',
@@ -50,7 +52,8 @@ export const SettingsItem = forwardRef<HTMLButtonElement, SettingsItemProps>(
           )}
           {children && <span className="text-body-body9 text-foreground-normal">{children}</span>}
         </div>
-        {rightIconName && (
+        {rightContent}
+        {rightIconName && !rightContent && (
           <SurfIcon
             name={rightIconName}
             size={'s'}

--- a/src/widgets/settings-list/model/constants.ts
+++ b/src/widgets/settings-list/model/constants.ts
@@ -2,8 +2,8 @@ import { SettingsItemType } from './types';
 
 export const THEME_OPTIONS = [
   { value: 'system', label: '시스템 설정 모드', icon: 'Cog' },
-  { value: 'light', label: '라이트 모드', icon: 'Sun' },
-  { value: 'dark', label: '다크 모드', icon: 'Moon' },
+  { value: 'light', label: '라이트 모드', icon: 'SunSolid' },
+  { value: 'dark', label: '다크 모드', icon: 'MoonSolid' },
 ] as const;
 
 export const SETTINGS_ITEMS: SettingsItemType[] = [
@@ -27,7 +27,7 @@ export const SETTINGS_ITEMS: SettingsItemType[] = [
   },
   {
     id: 'mode',
-    leftIconName: 'CircleHalf',
+    leftIconName: 'CircleHalfSolid',
     text: '테마 변경',
     action: { type: 'NAVIGATE', payload: '/settings/mode' },
   },

--- a/src/widgets/settings-list/model/constants.ts
+++ b/src/widgets/settings-list/model/constants.ts
@@ -1,5 +1,11 @@
 import { SettingsItemType } from './types';
 
+export const THEME_OPTIONS = [
+  { value: 'system', label: '시스템 설정 모드', icon: 'Cog' },
+  { value: 'light', label: '라이트 모드', icon: 'Sun' },
+  { value: 'dark', label: '다크 모드', icon: 'Moon' },
+] as const;
+
 export const SETTINGS_ITEMS: SettingsItemType[] = [
   {
     id: 'scraps',
@@ -18,6 +24,12 @@ export const SETTINGS_ITEMS: SettingsItemType[] = [
     leftIconName: 'ChatDots',
     text: '피드백 보내기',
     action: { type: 'NAVIGATE', payload: '/settings/feedback' },
+  },
+  {
+    id: 'mode',
+    leftIconName: 'CircleHalf',
+    text: '테마 변경',
+    action: { type: 'NAVIGATE', payload: '/settings/mode' },
   },
   {
     id: 'policy',


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 any가 사용되지 않았습니다
- [x] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈
- close #341 

## 📌 작업 목적
- 마이페이지 설정- 테마 변경 화면 추가

## 🔨 주요 작업 내용
- `next-themes` 라이브러리 설치 및 `ThemeProvider` 설정
- `SettingsItem` 컴포넌트 prop 추가 (rightContent)
- 테마 변경 페이지 (ModePage) 추가, 테마 전역 변경 로직은 `useTheme` 사용

## 🧪 테스트 방법
1. pnpm run dev
2. `http://localhost:3000/settings` 접속하여 테마 변경 화면 접속 후 테마 변경되는지 확인

## ✔️ 설치 라이브러리
- next-themes

## 📷 실행 영상 또는 스크린샷
- 

## 💬 논의할 점
- 

## 🙋🏻 참고 자료
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 테마 선택 기능 추가: 시스템/라이트/다크 모드 선택 가능
  * 설정 메뉴에 별도 테마 변경 페이지 추가

* **UI 변경**
  * 게시물 작성 모달의 카테고리 시트에 배경 스타일 개선
  * 설정 목록에 테마 변경 항목 추가로 접근성 향상

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->