### PR TITLE
[FIX] 약관 동의 바텀 시트 위치 변경

### DIFF
--- a/src/app-pages/home/ui/HomePage.tsx
+++ b/src/app-pages/home/ui/HomePage.tsx
@@ -6,17 +6,12 @@ import { Carousel } from '@/shared/ui/carousel/Carousel';
 import { HeaderMode } from '@/shared/ui/header/Header';
 import { Shortcut } from '@/shared/ui/shortcut/Shortcut';
 import { AppHeader } from '@/widgets/header/ui/AppHeader';
-import { LawBottomSheet } from '@/features/laws/ui/LawBottomSheet';
-import { useLawAgreement } from '@/features/laws/model/useLawAgreement';
-import { useState } from 'react';
 import { TAVE_CHANNEL_LINKS, SPONSOR_LINKS, SHORTCUT_LINKS } from '@/entities/home/model/constants';
 import { useRouter } from 'next/navigation';
 import { PAGE_ROUTES } from '@/shared/config/path';
 
 export const HomePage = () => {
   const router = useRouter();
-  const { agreements, handleCheck, isAllRequiredChecked, onClickLawDetail } = useLawAgreement();
-  const [isOpen, setIsOpen] = useState(!agreements.laws1 || !agreements.laws2 || !agreements.laws3);
 
   const { data: homeData } = useGetHome();
   const deepLink = homeData?.announcementDeepLink ?? '';
@@ -135,25 +130,6 @@ export const HomePage = () => {
           </div>
         </div>
       </div>
-
-      {/* 약관 바텀 시트 */}
-      {isAllRequiredChecked ? null : (
-        <LawBottomSheet
-          isOpen={isOpen}
-          onClose={() => setIsOpen(false)}
-          agreements={agreements}
-          onCheck={handleCheck}
-          onClickPrimaryBtn={() => {
-            if (isAllRequiredChecked) {
-              setIsOpen(false);
-            } else {
-              alert('필수 약관에 모두 동의해 주세요.');
-            }
-          }}
-          onClickLawDetail={onClickLawDetail}
-          allAgreed={isAllRequiredChecked}
-        />
-      )}
     </div>
   );
 };

--- a/src/app-pages/onboarding/ui/OnBoardingPage.tsx
+++ b/src/app-pages/onboarding/ui/OnBoardingPage.tsx
@@ -68,19 +68,17 @@ export default function OnBoardingPage() {
       <OnBoardingForm />
 
       {/* 약관 바텀 시트 */}
-      {isAllRequiredChecked ? null : (
-        <LawBottomSheet
-          isOpen={isOpen}
-          onClose={() => setIsOpen(false)}
-          agreements={agreements}
-          onCheck={handleCheck}
-          onClickPrimaryBtn={() => {
-            setIsOpen(false);
-          }}
-          onClickLawDetail={onClickLawDetail}
-          allAgreed={isAllRequiredChecked}
-        />
-      )}
+      <LawBottomSheet
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        agreements={agreements}
+        onCheck={handleCheck}
+        onClickPrimaryBtn={() => {
+          setIsOpen(false);
+        }}
+        onClickLawDetail={onClickLawDetail}
+        allAgreed={isAllRequiredChecked}
+      />
     </FormProvider>
   );
 }

--- a/src/app-pages/onboarding/ui/OnBoardingPage.tsx
+++ b/src/app-pages/onboarding/ui/OnBoardingPage.tsx
@@ -3,13 +3,27 @@
 import { useOnboardingStore } from '@/features/onboarding/model/useOnboardingStore';
 import { OnBoardingFormData } from '@/features/onboarding/model/types';
 import OnBoardingForm from '@/widgets/onboarding/ui/OnBoardingForm';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
+import { LawBottomSheet } from '@/features/laws/ui/LawBottomSheet';
+import { useLawAgreement } from '@/features/laws/model/useLawAgreement';
+import { useGetValidStatusQuery } from '@/features/auth/model/useGetValidStatusQuery';
 
 export default function OnBoardingPage() {
   const nickname = useOnboardingStore((s) => s.nickname);
   const email = useOnboardingStore((s) => s.email);
   const profileImageUrl = useOnboardingStore((s) => s.profileImageUrl);
+
+  const { agreements, handleCheck, isAllRequiredChecked, onClickLawDetail } = useLawAgreement();
+  const [isOpen, setIsOpen] = useState(!agreements.laws1 || !agreements.laws2 || !agreements.laws3);
+
+  const { data: statusData } = useGetValidStatusQuery();
+
+  useEffect(() => {
+    if (statusData?.memberStatus === 'REGISTERING') {
+      setIsOpen(true);
+    }
+  }, [statusData]);
 
   const methods = useForm<OnBoardingFormData>({
     defaultValues: {
@@ -52,6 +66,25 @@ export default function OnBoardingPage() {
   return (
     <FormProvider {...methods}>
       <OnBoardingForm />
+
+      {/* 약관 바텀 시트 */}
+      {isAllRequiredChecked ? null : (
+        <LawBottomSheet
+          isOpen={isOpen}
+          onClose={() => setIsOpen(false)}
+          agreements={agreements}
+          onCheck={handleCheck}
+          onClickPrimaryBtn={() => {
+            if (isAllRequiredChecked) {
+              setIsOpen(false);
+            } else {
+              alert('필수 약관에 모두 동의해 주세요.');
+            }
+          }}
+          onClickLawDetail={onClickLawDetail}
+          allAgreed={isAllRequiredChecked}
+        />
+      )}
     </FormProvider>
   );
 }

--- a/src/app-pages/onboarding/ui/OnBoardingPage.tsx
+++ b/src/app-pages/onboarding/ui/OnBoardingPage.tsx
@@ -75,11 +75,7 @@ export default function OnBoardingPage() {
           agreements={agreements}
           onCheck={handleCheck}
           onClickPrimaryBtn={() => {
-            if (isAllRequiredChecked) {
-              setIsOpen(false);
-            } else {
-              alert('필수 약관에 모두 동의해 주세요.');
-            }
+            setIsOpen(false);
           }}
           onClickLawDetail={onClickLawDetail}
           allAgreed={isAllRequiredChecked}

--- a/src/app-pages/onboarding/ui/OnBoardingPage.tsx
+++ b/src/app-pages/onboarding/ui/OnBoardingPage.tsx
@@ -14,16 +14,29 @@ export default function OnBoardingPage() {
   const email = useOnboardingStore((s) => s.email);
   const profileImageUrl = useOnboardingStore((s) => s.profileImageUrl);
 
-  const { agreements, handleCheck, isAllRequiredChecked, onClickLawDetail } = useLawAgreement();
-  const [isOpen, setIsOpen] = useState(!agreements.laws1 || !agreements.laws2 || !agreements.laws3);
+  const {
+    agreements,
+    handleCheck,
+    isAllRequiredChecked,
+    onClickLawDetail,
+    isAgreed,
+    confirmAgreement,
+  } = useLawAgreement();
+  const [isOpen, setIsOpen] = useState(true);
 
   const { data: statusData } = useGetValidStatusQuery();
 
   useEffect(() => {
-    if (statusData?.memberStatus === 'REGISTERING') {
+    if (isAgreed) {
+      setIsOpen(false);
+    }
+  }, [isAgreed]);
+
+  useEffect(() => {
+    if (statusData?.memberStatus === 'REGISTERING' && !isAgreed) {
       setIsOpen(true);
     }
-  }, [statusData]);
+  }, [statusData, isAgreed]);
 
   const methods = useForm<OnBoardingFormData>({
     defaultValues: {
@@ -74,6 +87,7 @@ export default function OnBoardingPage() {
         agreements={agreements}
         onCheck={handleCheck}
         onClickPrimaryBtn={() => {
+          confirmAgreement();
           setIsOpen(false);
         }}
         onClickLawDetail={onClickLawDetail}

--- a/src/features/auth/model/useGetValidStatusQuery.ts
+++ b/src/features/auth/model/useGetValidStatusQuery.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+import { getValidStatus } from '@/features/auth/api/getValidStatus';
+import { ValidStatusResponse } from '@/features/auth/api/types';
+
+export const useGetValidStatusQuery = () => {
+  return useQuery<ValidStatusResponse['data']>({
+    queryKey: ['validStatus'],
+    queryFn: getValidStatus,
+  });
+};

--- a/src/features/laws/model/useAgreementStore.ts
+++ b/src/features/laws/model/useAgreementStore.ts
@@ -1,25 +1,38 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
 export type AgreementId = 'laws1' | 'laws2' | 'laws3';
 
-interface AgreementState {
+export interface AgreementState {
   agreements: Record<AgreementId, boolean>;
+  isAgreed: boolean;
   setAgreement: (id: string, checked: boolean) => void;
+  setAgreed: (agreed: boolean) => void;
   resetAgreements: () => void; // 동의 여부 초기화용
 }
 
-export const useAgreementStore = create<AgreementState>((set) => ({
-  agreements: {
-    laws1: false,
-    laws2: false,
-    laws3: false,
-  },
-  setAgreement: (id, checked) =>
-    set((state) => ({
-      agreements: { ...state.agreements, [id]: checked },
-    })),
-  resetAgreements: () =>
-    set({
-      agreements: { laws1: false, laws2: false, laws3: false },
+export const useAgreementStore = create(
+  persist<AgreementState>(
+    (set) => ({
+      agreements: {
+        laws1: false,
+        laws2: false,
+        laws3: false,
+      },
+      isAgreed: false,
+      setAgreement: (id: string, checked: boolean) =>
+        set((state: AgreementState) => ({
+          agreements: { ...state.agreements, [id]: checked },
+        })),
+      setAgreed: (agreed: boolean) => set({ isAgreed: agreed }),
+      resetAgreements: () =>
+        set({
+          agreements: { laws1: false, laws2: false, laws3: false },
+          isAgreed: false,
+        }),
     }),
-}));
+    {
+      name: 'agreement-storage',
+    },
+  ),
+);

--- a/src/features/laws/model/useAgreementStore.ts
+++ b/src/features/laws/model/useAgreementStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { persist, createJSONStorage } from 'zustand/middleware';
 
 export type AgreementId = 'laws1' | 'laws2' | 'laws3';
 
@@ -33,6 +33,7 @@ export const useAgreementStore = create(
     }),
     {
       name: 'agreement-storage',
+      storage: createJSONStorage(() => sessionStorage),
     },
   ),
 );

--- a/src/features/laws/model/useLawAgreement.ts
+++ b/src/features/laws/model/useLawAgreement.ts
@@ -5,10 +5,14 @@ import { useAgreementStore } from './useAgreementStore';
 export const useLawAgreement = () => {
   const router = useRouter();
 
-  const { agreements, setAgreement } = useAgreementStore();
+  const { agreements, setAgreement, isAgreed, setAgreed } = useAgreementStore();
 
   const handleCheck = (id: string, checked: boolean) => {
     setAgreement(id, checked);
+  };
+
+  const confirmAgreement = () => {
+    setAgreed(true);
   };
 
   const isAllRequiredChecked = agreements.laws1 && agreements.laws2 && agreements.laws3;
@@ -23,5 +27,12 @@ export const useLawAgreement = () => {
     }
   };
 
-  return { agreements, handleCheck, isAllRequiredChecked, onClickLawDetail };
+  return {
+    agreements,
+    handleCheck,
+    isAllRequiredChecked,
+    onClickLawDetail,
+    isAgreed,
+    confirmAgreement,
+  };
 };

--- a/src/widgets/onboarding/ui/OnBoardingForm.tsx
+++ b/src/widgets/onboarding/ui/OnBoardingForm.tsx
@@ -14,6 +14,7 @@ import { trackOnBoardingEvent } from '@/features/onboarding/lib/trackOnBoardingE
 import { useImageUploader } from '@/entities/image/model/useImageUploader';
 import { safeUUID } from '@/shared/utils/uuid';
 import { Alert } from '@/shared/ui/alert/Alert';
+import { useAgreementStore } from '@/features/laws/model/useAgreementStore';
 
 const STEP_ANALYTICS_NAMES: Record<number, 'nickname' | 'track' | 'contact'> = {
   0: 'nickname',
@@ -137,6 +138,7 @@ export default function OnBoardingForm() {
       input_count: filledCount,
     });
     await submitOnBoarding(submitData);
+    useAgreementStore.getState().resetAgreements();
     setIsAlertOpen(true);
   }
 


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 any가 사용되지 않았습니다
- [x] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈
- close #357 

## 📌 작업 목적
- 약관 동의 바텀 시트 위치 변경

## 🔨 주요 작업 내용
- 온보딩 첫 화면으로 약관 동의 바텀 시트 위치 변경

## 🧪 테스트 방법
1. pnpm run dev
2. `http://localhost:3000/onboarding` 접속 후 약관 바텀 시트가 뜨는지 확인

## ✔️ 설치 라이브러리
- 

## 📷 실행 영상 또는 스크린샷
- 

## 💬 논의할 점
- 

## 🙋🏻 참고 자료
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 온보딩 프로세스 중 필수 약관 동의 화면 추가
  * 가입 상태에 따른 약관 자동 표시 기능 추가

* **Refactor**
  * 약관 동의 상태 관리 개선 및 세션 기반 저장 적용
  * 홈페이지에서 약관 동의 기능 제거

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->