### PR TITLE
[FEAT] 로그아웃, 회원탈퇴 API 연동

### DIFF
--- a/src/features/auth/api/logout.ts
+++ b/src/features/auth/api/logout.ts
@@ -1,0 +1,5 @@
+import { axiosInstance } from '@/shared/lib/axiosInstance';
+
+export async function logout(): Promise<void> {
+  await axiosInstance.post('/auth/logout');
+}

--- a/src/features/auth/api/withdraw.ts
+++ b/src/features/auth/api/withdraw.ts
@@ -1,0 +1,5 @@
+import { axiosInstance } from '@/shared/lib/axiosInstance';
+
+export async function withdraw(): Promise<void> {
+  await axiosInstance.post('/v1/user/members/withdraw');
+}

--- a/src/features/auth/model/useLogout.ts
+++ b/src/features/auth/model/useLogout.ts
@@ -1,0 +1,24 @@
+import { useMutation } from '@tanstack/react-query';
+import { logout } from '@/features/auth/api/logout';
+import { useAuthStore } from '@/features/auth/model/useAuthStore';
+import { useRouter } from 'next/navigation';
+import { useToastStore } from '@/shared/store/toastStore';
+
+export function useLogout() {
+  const clearAuth = useAuthStore((s) => s.clearAuth);
+  const showToast = useToastStore((s) => s.show);
+  const router = useRouter();
+
+  return useMutation({
+    mutationFn: logout,
+    onSuccess: () => {
+      clearAuth();
+      showToast('로그아웃 되었습니다.');
+      router.replace('/login');
+    },
+    onError: (e) => {
+      console.error('로그아웃에 실패했습니다.', e);
+      showToast('로그아웃에 실패했습니다. 잠시 후 다시 시도해주세요.');
+    },
+  });
+}

--- a/src/features/auth/model/useWithdraw.ts
+++ b/src/features/auth/model/useWithdraw.ts
@@ -1,0 +1,24 @@
+import { useMutation } from '@tanstack/react-query';
+import { withdraw } from '@/features/auth/api/withdraw';
+import { useAuthStore } from '@/features/auth/model/useAuthStore';
+import { useRouter } from 'next/navigation';
+import { useToastStore } from '@/shared/store/toastStore';
+
+export function useWithdraw() {
+  const clearAuth = useAuthStore((s) => s.clearAuth);
+  const showToast = useToastStore((s) => s.show);
+  const router = useRouter();
+
+  return useMutation({
+    mutationFn: withdraw,
+    onSuccess: () => {
+      clearAuth();
+      showToast('탈퇴가 완료되었습니다.');
+      router.replace('/login');
+    },
+    onError: (e) => {
+      console.error('회원 탈퇴에 실패했습니다.', e);
+      showToast('회원 탈퇴에 실패했습니다. 잠시 후 다시 시도해주세요.');
+    },
+  });
+}

--- a/src/widgets/settings-list/ui/SettingsList.tsx
+++ b/src/widgets/settings-list/ui/SettingsList.tsx
@@ -6,10 +6,12 @@ import { SettingsItem } from '@/entities/settings/ui/SettingsItem';
 import { Alert } from '@/shared/ui/alert/Alert';
 import { SETTINGS_ITEMS } from '../model/constants';
 import type { AlertType } from '../model/types';
+import { useLogout } from '@/features/auth/model/useLogout';
 
 export const SettingsList = () => {
   const router = useRouter();
   const [activeAlert, setActiveAlert] = useState<AlertType>(null);
+  const { mutate: logoutMutate } = useLogout();
 
   const handleItemClick = useCallback(
     (item: (typeof SETTINGS_ITEMS)[number]) => {
@@ -31,8 +33,11 @@ export const SettingsList = () => {
 
   // TODO: 로그아웃 및 회원탈퇴 훅 features 레이어에서 import 필요. 아래는 임시 코드
   const handleLogout = () => {
-    console.log('로그아웃 처리');
-    setActiveAlert(null);
+    logoutMutate(undefined, {
+      onSuccess: () => {
+        setActiveAlert(null);
+      },
+    });
   };
 
   const handleWithdraw = () => {

--- a/src/widgets/settings-list/ui/SettingsList.tsx
+++ b/src/widgets/settings-list/ui/SettingsList.tsx
@@ -7,11 +7,13 @@ import { Alert } from '@/shared/ui/alert/Alert';
 import { SETTINGS_ITEMS } from '../model/constants';
 import type { AlertType } from '../model/types';
 import { useLogout } from '@/features/auth/model/useLogout';
+import { useWithdraw } from '@/features/auth/model/useWithdraw';
 
 export const SettingsList = () => {
   const router = useRouter();
   const [activeAlert, setActiveAlert] = useState<AlertType>(null);
   const { mutate: logoutMutate } = useLogout();
+  const { mutate: withdrawMutate } = useWithdraw();
 
   const handleItemClick = useCallback(
     (item: (typeof SETTINGS_ITEMS)[number]) => {
@@ -31,7 +33,6 @@ export const SettingsList = () => {
     [router],
   );
 
-  // TODO: 로그아웃 및 회원탈퇴 훅 features 레이어에서 import 필요. 아래는 임시 코드
   const handleLogout = () => {
     logoutMutate(undefined, {
       onSuccess: () => {
@@ -41,10 +42,12 @@ export const SettingsList = () => {
   };
 
   const handleWithdraw = () => {
-    console.log('회원탈퇴 처리');
-    setActiveAlert(null);
+    withdrawMutate(undefined, {
+      onSuccess: () => {
+        setActiveAlert(null);
+      },
+    });
   };
-  // -------------------------------------
 
   const closeAlert = () => {
     setActiveAlert(null);


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 any가 사용되지 않았습니다
- [x] 스토리북에 추가했습니다 (해당 시)
- [x] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈
- close #381

## 📌 작업 목적
- 로그아웃, 회원탈퇴 API 연동

## 🔨 주요 작업 내용
- 로그아웃 API 연동
- 회원탈퇴 API 연동

## 🧪 테스트 방법
1. `pnpm dev`
2. `http://localhost:3000/settings` 접속
3. 로그아웃 및 회원탈퇴 테스트 

## 💬 논의할 점
- 회원탈퇴 API는 아직 백엔드 구현이 미완이라 테스트가 불가합니다. 내일 중으로 완료될 예정이라고 합니다!