### PR TITLE
[CHORE] 탈퇴한 멤버 클릭 시 프로필 이동 못하도록 제어

### DIFF
--- a/src/app-pages/post/PostDetailPage.tsx
+++ b/src/app-pages/post/PostDetailPage.tsx
@@ -200,13 +200,28 @@ export default function PostDetailPage({ postId }: PostDetailPageProps) {
                 {/* 목록 */}
                 {!isLikesLoading &&
                   !isLikesError &&
-                  likedUsers.map((user) => (
-                    <SheetItem
-                      key={user.id}
-                      title={user.name}
-                      node={<Avatar size="xs" src={user.profileImageUrl} className="rounded-3!" />}
-                    />
-                  ))}
+                  likedUsers.map((user, index) => {
+                    if (!user.id) {
+                      return (
+                        <SheetItem
+                          key={`withdrawn-${index}`}
+                          title={user.name} // '탈퇴한 회원'으로 표시됨
+                          node={<Avatar size="xs" className="rounded-3!" />}
+                        />
+                      );
+                    }
+
+                    return (
+                      <SheetItem
+                        key={user.id}
+                        title={user.name}
+                        node={
+                          <Avatar size="xs" src={user.profileImageUrl} className="rounded-3!" />
+                        }
+                        onClick={() => {}} // TODO: 사용자 프로필 이동 기능 추가
+                      />
+                    );
+                  })}
 
                 {/* 비어 있을 때 */}
                 {!isLikesLoading && !isLikesError && likedUsers.length === 0 && (

--- a/src/entities/post/api/types.ts
+++ b/src/entities/post/api/types.ts
@@ -52,6 +52,7 @@ export type FullPostListResponse = CommonResponse<PostListApiResponse>;
 
 // 게시글 상세 데이터 타입
 export type PostDetailData = {
+  memberId: number | null;
   postId: number;
   title: string;
   content: string;

--- a/src/entities/post/api/types.ts
+++ b/src/entities/post/api/types.ts
@@ -122,7 +122,7 @@ export type GetBoardPostsRequest = {
 
 // 좋아요 누른 유저 타입
 export interface LikedUser {
-  id: number;
+  id: number | null;
   name: string;
   profileImageUrl: string;
 }

--- a/src/entities/post/model/mappers.ts
+++ b/src/entities/post/model/mappers.ts
@@ -45,6 +45,7 @@ export const transformDetailToPost = (item: PostDetailData): PostDetail => {
   const dateObj = toKST(toDate(item.postedAt));
 
   return {
+    memberId: item.memberId,
     postId: item.postId,
     title: item.title,
     content: item.content,

--- a/src/entities/post/model/types.ts
+++ b/src/entities/post/model/types.ts
@@ -8,6 +8,7 @@ export type PostBadgeProps = {
 };
 
 export type PostDetail = {
+  memberId: number | null;
   postId: number;
   title: string;
   content: string;

--- a/src/entities/post/ui/post-profile/PostProfile.stories.tsx
+++ b/src/entities/post/ui/post-profile/PostProfile.stories.tsx
@@ -6,6 +6,7 @@ const meta: Meta<typeof PostProfile> = {
   component: PostProfile,
   tags: ['autodocs'],
   argTypes: {
+    memberId: { control: 'number' },
     profileImgUrl: { control: 'text' },
     nickname: { control: 'text' },
     date: { control: 'text' },
@@ -13,6 +14,7 @@ const meta: Meta<typeof PostProfile> = {
     viewCount: { control: 'number' },
   },
   args: {
+    memberId: 1,
     nickname: '사용자 이름',
     date: '2023-01-01',
     time: '12:00',
@@ -23,14 +25,12 @@ const meta: Meta<typeof PostProfile> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-  render: (args) => {
-    return <PostProfile {...args} />;
-  },
+export const Default: Story = {};
+
+export const Withdrawn: Story = {
   args: {
-    nickname: '사용자 이름',
-    date: '2023-01-01',
-    time: '12:00',
-    viewCount: 100,
+    memberId: null,
+    nickname: '탈퇴한 사용자',
+    profileImgUrl: undefined,
   },
 };

--- a/src/entities/post/ui/post-profile/PostProfile.tsx
+++ b/src/entities/post/ui/post-profile/PostProfile.tsx
@@ -1,6 +1,7 @@
 import { Avatar } from '@/shared/ui/avatar/Avatar';
 
 type PostProfileProps = {
+  memberId: number | null;
   profileImgUrl?: string;
   nickname: string;
   date: string;
@@ -8,13 +9,38 @@ type PostProfileProps = {
   viewCount: number;
 };
 
-export function PostProfile({ profileImgUrl, nickname, date, time, viewCount }: PostProfileProps) {
+export function PostProfile({
+  memberId,
+  profileImgUrl,
+  nickname,
+  date,
+  time,
+  viewCount,
+}: PostProfileProps) {
+  const isClickable = memberId !== null;
   return (
     <section className="flex items-center gap-10" aria-label={`${nickname}님의 작성 게시글 정보`}>
-      <Avatar src={profileImgUrl} size="m" alt={`${nickname}의 프로필 이미지`} />
+      {/* TODO: 프로필 이미지 클릭 시 사용자 프로필 페이지로 이동 */}
+      <Avatar
+        src={profileImgUrl}
+        size="m"
+        alt={`${nickname}의 프로필 이미지`}
+        className={isClickable ? 'cursor-pointer' : 'cursor-default'}
+        onClick={isClickable ? () => {} : undefined}
+      />
       <div className="flex flex-col items-start justify-center py-3">
-        <strong className="text-body-body6 text-foreground-normal">{nickname}</strong>
-
+        {/* TODO: 닉네임 클릭 시 사용자 프로필 페이지로 이동 */}
+        {isClickable ? (
+          <button
+            type="button"
+            onClick={() => {}}
+            className="text-body-body6 text-foreground-normal"
+          >
+            {nickname}
+          </button>
+        ) : (
+          <strong className="text-body-body6 text-foreground-normal">{nickname}</strong>
+        )}
         <div className="text-foreground-normal-lighter text-caption-caption4 flex items-center gap-7 pt-3">
           <time dateTime={date} aria-label={`작성일 ${date}`}>
             {date}

--- a/src/shared/ui/sheet/SheetItem.stories.tsx
+++ b/src/shared/ui/sheet/SheetItem.stories.tsx
@@ -76,9 +76,10 @@ export const LikedUsersInSheet: Story = {
   render: () => {
     const [open, setOpen] = useState(false);
     const users = [
-      { id: 1, name: '홍길동' },
-      { id: 2, name: '김철수' },
-      { id: 3, name: '이영희' },
+      { id: 1, name: '홍길동', onClick: () => alert('홍길동 클릭') },
+      { id: 2, name: '김철수', onClick: () => alert('김철수 클릭') },
+      { id: 3, name: '이영희', onClick: () => alert('이영희 클릭') },
+      { id: null, name: '탈퇴한 회원' },
     ];
 
     return (
@@ -97,8 +98,8 @@ export const LikedUsersInSheet: Story = {
                     <SheetItem
                       key={user.id}
                       title={user.name}
+                      onClick={user.onClick}
                       node={<Avatar size="xs" className="rounded-3!" />}
-                      onClick={() => alert(`${user.name} 클릭`)}
                     />
                   ))}
                 </div>

--- a/src/shared/ui/sheet/SheetItem.tsx
+++ b/src/shared/ui/sheet/SheetItem.tsx
@@ -29,11 +29,18 @@ const TEXT_COLOR_STYLES: Record<TextColor, string> = {
 export function SheetItem({ title, node, onClick, textColor = 'normal' }: SheetItemProps) {
   const textColorClass = TEXT_COLOR_STYLES[textColor];
 
+  const Wrapper = onClick ? 'button' : 'div';
+
   return (
-    <button onClick={onClick} className="flex w-full items-center gap-8 px-12 py-10">
+    <Wrapper
+      onClick={onClick}
+      className={`flex w-full items-center gap-8 px-12 py-10 ${
+        onClick ? 'cursor-pointer' : 'cursor-default'
+      }`}
+    >
       {node && <div className="flex h-[1.5rem] w-[1.5rem] items-center justify-center">{node}</div>}
 
       <span className={`text-body-body6 ${textColorClass}`}>{title}</span>
-    </button>
+    </Wrapper>
   );
 }

--- a/src/widgets/post-detail/PostBodySection.tsx
+++ b/src/widgets/post-detail/PostBodySection.tsx
@@ -51,6 +51,7 @@ export function PostBodySection({ post, schedule, onClickLikeCount }: PostBodySe
   return (
     <div className="flex flex-col gap-16">
       <PostProfile
+        memberId={post.memberId}
         profileImgUrl={post.profileImageUrl}
         nickname={post.writer}
         date={post.date}


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 any가 사용되지 않았습니다
- [x] 스토리북에 추가했습니다 (해당 시)
- [x] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈
- close #389

## 📌 작업 목적
- 게시글 상세 조회, 좋아요 목록에서 탈퇴한 멤버 클릭 시 프로필 이동을 못하도록 제어합니다.

## 🔨 주요 작업 내용
- API 응답 타입에 memberId 추가 및 null 가능 처리
- UI에서는 onClick 여부에 따라 cursor-pointer의 활성화 로직을 제어했습니다.
  - 일반 회원이면 onClick으로 프로필 이동 가능 (타회원 프로필 페이지가 아직 없어 todo화 했습니다.)
  - 탈퇴한 회원이면 프로필 이동 불가능

## ⚠️ 기존 문제
- SheetItem이 button 태그로 이루어졌고, 전역적으로 button에는 cursor-pointer가 들어가 있습니다. 탈퇴한 회원일 경우에도 커서가 활성화되었습니다.

## ☑️ 해결 방법
- onClick 필드 여부에 따라 button 또는 div 태그가 될 수 있도록 하였습니다.

## 💬 논의할 점
- 댓글은 아직 합쳐져 있지 않아 작업하지 못했습니다. 탈퇴한 회원 클릭 안되도록 처리 해주시면 감사하겠습니다! @Chaejy 

## 🧪 테스트 방법
- `pnpm storybook`
- `shared/ui/SheetItem/LikedUsersInSheet`에서 탈퇴한 회원 확인
- `entities/ui/post/postHeader/Withdrawn` 확인

## 📷 실행 영상 또는 스크린샷

https://github.com/user-attachments/assets/591e792f-5014-41cf-9c47-b0d16ae1c2f0

https://github.com/user-attachments/assets/3b119c96-901e-4cd0-86fe-e50b01afdbaa



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * "좋아요" 목록에서 탈퇴한 사용자를 별도로 표시하여 구분합니다. 탈퇴한 사용자는 기본 아바타와 함께 표시됩니다.
  * 사용자 프로필의 상호작용을 멤버 상태에 따라 동적으로 처리합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->