### PR TITLE
[CHORE] 게시글 제목 placeholder 폰트 색상 적용

### DIFF
--- a/src/app-pages/post/write/ui/PostPage.tsx
+++ b/src/app-pages/post/write/ui/PostPage.tsx
@@ -174,7 +174,7 @@ export default function PostPage(props: PostPageProps) {
           maxLength={MAX_TITLE_LENGTH}
           onChange={(e) => setTitle(e.target.value)}
           placeholder="제목을 입력해주세요."
-          className="text-foreground-normal placeholder:foreground-tertiary-lighter text-body-body3 flex flex-1 pt-10 pb-5 focus:outline-none"
+          className="text-foreground-normal placeholder:text-foreground-tertiary-lighter text-body-body3 flex flex-1 pt-10 pb-5 focus:outline-none"
         />
       </div>
 

--- a/src/features/post/post-editor/ui/PostEditor.style.css
+++ b/src/features/post/post-editor/ui/PostEditor.style.css
@@ -8,6 +8,7 @@
   min-width: 1px;
 }
 
+/* placeholder 폰트 색상, 입력 커서 설정 */
 .ProseMirror p.is-editor-empty:first-child::before {
   content: attr(data-placeholder);
   color: var(--color-foreground-tertiary-lighter);

--- a/src/widgets/post/post-editor/PostEditor.tsx
+++ b/src/widgets/post/post-editor/PostEditor.tsx
@@ -179,7 +179,7 @@ export const PostEditor = ({
     <div className="flex w-full min-w-0 flex-col gap-10">
       {/* 본문 에디터 영역 */}
       <div className="text-foreground-normal text-body-body7 relative flex flex-1 overflow-y-auto px-13 break-all">
-        {/* 빈 공간 클릭 시 에디터 포커싱 */}
+        {/* PostEditor.style.css에서 placeholder 및 focusing 스타일 정의 */}
         <button
           type="button"
           aria-label="본문 클릭 영역"


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 any가 사용되지 않았습니다
- [x] 스토리북에 추가했습니다 (해당 시)
- [x] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈
- #391

## 📌 작업 목적
- 게시글 작성시, 제목의 placeholder 폰트 색상을 적용하기

## 🔨 주요 작업 내용
- 제목 placeholder 스타일에 누락되었던 `text-`를 추가하였습니다.
- 본문 스타일링 작업 파일을 주석으로 명시하여 파일 탐색을 쉽게 하도록 개선하였습니다.

## 🧪 테스트 방법
- `http://localhost:3000/board/1/post/create`
- 제목과 본문의 placeholder 색상이 같은지 확인해주세요.

## 📷 실행 영상 또는 스크린샷
<img width="389" height="164" alt="image" src="https://github.com/user-attachments/assets/e10e989a-005e-44e1-83d1-82f80374ca9d" />


## 💬 논의할 점
- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 포스트 제목 입력 필드의 플레이스홀더 텍스트 색상 스타일 수정

## 스타일
* 포스트 에디터의 빈 상태에 대한 플레이스홀더 스타일링 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->