### PR TITLE
[FIX/REFACTOR] 게시글 에디터 초기화 로직 안정화 및 데이터 동기화 버그 수정

### DIFF
--- a/apps/web/src/app-pages/board/ui/BoardPage.tsx
+++ b/apps/web/src/app-pages/board/ui/BoardPage.tsx
@@ -7,6 +7,8 @@ import { POST_BOARDS } from '@/entities/post/model/board';
 import { TAB_CATEGORIES, TAB_CATEGORY_LIST } from '@/entities/post/model/tab';
 import { PostFab } from '@/entities/post/ui/post-fab/PostFab';
 import { useAuthStore } from '@/features/auth/model/useAuthStore';
+import { usePostFormStore } from '@/features/post/post-form/model/usePostFormStore';
+import { useCreatePostScheduleStore } from '@/features/schedule/create-post-schedule/model/useCreatePostScheduleStore';
 import { PAGE_ROUTES } from '@/shared/config/path';
 import { AppHeader } from '@/widgets/header/ui/AppHeader';
 import { PostListContainer } from '@/widgets/post-list/ui/PostListContainer';
@@ -37,6 +39,16 @@ const BoardPage = ({ boardId: boardIdProp }: { boardId: string }) => {
     }
   };
 
+  // 게시글 생성 화면 이동 전 스토어 초기화
+  const { resetForm } = usePostFormStore();
+  const { clearLinkedSchedule } = useCreatePostScheduleStore();
+
+  const handlePostClick = () => {
+    resetForm();
+    clearLinkedSchedule();
+    router.push(PAGE_ROUTES.BOARD.POST_CREATE(boardId));
+  };
+
   return (
     <>
       <AppHeader
@@ -63,7 +75,7 @@ const BoardPage = ({ boardId: boardIdProp }: { boardId: string }) => {
         <div className="pointer-events-none fixed inset-0 z-50">
           <div className="relative mx-auto h-full sm:max-w-[360px]">
             <div className="pointer-events-auto absolute right-15 bottom-15">
-              <PostFab onClick={() => router.push(PAGE_ROUTES.BOARD.POST_CREATE(boardId))} />
+              <PostFab onClick={handlePostClick} />
             </div>
           </div>
         </div>

--- a/apps/web/src/app-pages/post/write/ui/PostPage.tsx
+++ b/apps/web/src/app-pages/post/write/ui/PostPage.tsx
@@ -8,12 +8,13 @@ import { useToastStore } from '@surf/ui/store/toastStore';
 import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useState } from 'react';
 import { Sheet as ModalSheet } from 'react-modal-sheet';
-import { usePostForm } from '../../../../features/post/post-form/model/usePostForm';
 import { POST_BOARDS } from '@/entities/post/model/board';
 import { POST_CATEGORIES } from '@/entities/post/model/category';
 import { POST_VALIDATION } from '@/entities/post/model/validation';
 import { PostBadge } from '@/entities/post/ui/post-badge/PostBadge';
 import { DateTimePicker } from '@/entities/schedule/ui/DateTimePicker/DateTimePicker';
+import { usePostForm } from '@/features/post/post-form/model/usePostForm';
+import { usePostFormStore } from '@/features/post/post-form/model/usePostFormStore';
 import { AppHeader } from '@/widgets/header/ui/AppHeader';
 import { PostEditor } from '@/widgets/post/post-editor/PostEditor';
 
@@ -29,6 +30,9 @@ const PostPage = (props: PostPageProps) => {
 
   const { mode, boardId } = props;
   const postId = mode === 'edit' ? props.postId : undefined;
+
+  // 초기화 허용 플래그 설정
+  const { setCanInitialize } = usePostFormStore();
 
   // 로직 훅 호출 (Logic과 View의 연결 고리)
   const {
@@ -64,6 +68,12 @@ const PostPage = (props: PostPageProps) => {
 
   // 예약 시간 임시 저장용 state (취소 시 롤백 위함)
   const [tempDate, setTempDate] = useState<Date>(new Date());
+
+  // 마운트시 초기화 허용
+  useEffect(() => {
+    setCanInitialize(true);
+  }, [setCanInitialize]);
+
   // 모달 열릴 때 현재 예약 시간으로 초기화
   useEffect(() => {
     if (isReservationModalOpen) {
@@ -128,13 +138,22 @@ const PostPage = (props: PostPageProps) => {
           onClick: () => {
             closeExitAlert();
             resetPostState();
+            setCanInitialize(false);
             router.back();
           },
         },
       ],
     });
     setShowExitAlert(false);
-  }, [closeExitAlert, openAlert, resetPostState, router, setShowExitAlert, showExitAlert]);
+  }, [
+    closeExitAlert,
+    openAlert,
+    resetPostState,
+    router,
+    setShowExitAlert,
+    showExitAlert,
+    setCanInitialize,
+  ]);
 
   return (
     <div className="flex h-full w-full flex-1 flex-col">

--- a/apps/web/src/features/post/post-form/model/types.ts
+++ b/apps/web/src/features/post/post-form/model/types.ts
@@ -13,6 +13,7 @@ export interface PostFormState {
   reservedAt: Date | null;
   initialSnapshot: PostSnapshot | null;
   isEditorInitialized: boolean;
+  canInitialize: boolean;
 
   // Actions
   setField: <K extends keyof PostFormState>(field: K, value: PostFormState[K]) => void;
@@ -20,6 +21,7 @@ export interface PostFormState {
   setIsEditorInitialized: (isInit: boolean) => void;
   resetForm: () => void;
   setSnapshot: (snapshot: PostSnapshot) => void;
+  setCanInitialize: (canInit: boolean) => void;
 }
 
 export type EditorState = Pick<PostFormState, 'content' | 'images'>;

--- a/apps/web/src/features/post/post-form/model/usePostForm.ts
+++ b/apps/web/src/features/post/post-form/model/usePostForm.ts
@@ -48,6 +48,7 @@ export const usePostForm = ({ mode, boardId, postId }: Props) => {
     setField,
     setEditorState,
     resetForm,
+    setCanInitialize,
   } = usePostFormStore();
 
   const { linkedSchedule, setLinkedSchedule, clearLinkedSchedule } = useCreatePostScheduleStore();
@@ -102,8 +103,9 @@ export const usePostForm = ({ mode, boardId, postId }: Props) => {
   const resetPostState = useCallback(() => {
     clearLinkedSchedule();
     resetForm();
+    setCanInitialize(false);
     isScheduleInitializedRef.current = false;
-  }, [clearLinkedSchedule, resetForm]);
+  }, [clearLinkedSchedule, resetForm, setCanInitialize]);
 
   const {
     isOpen: isCategoryOpen,
@@ -150,6 +152,7 @@ export const usePostForm = ({ mode, boardId, postId }: Props) => {
       setShowExitAlert(true);
     } else {
       resetPostState();
+      setCanInitialize(false);
       router.back();
     }
   };
@@ -301,6 +304,7 @@ export const usePostForm = ({ mode, boardId, postId }: Props) => {
       await Promise.all(invalidatePromises);
 
       resetPostState();
+      setCanInitialize(false);
       if (targetPostId) router.replace(PAGE_ROUTES.BOARD.POST_DETAIL(boardId, targetPostId));
     } catch (err) {
       console.error('게시글 처리 실패', err);

--- a/apps/web/src/features/post/post-form/model/usePostFormStore.ts
+++ b/apps/web/src/features/post/post-form/model/usePostFormStore.ts
@@ -42,3 +42,32 @@ export const usePostFormStore = create<PostFormState>((set, get) => ({
   setSnapshot: (snapshot) => set({ initialSnapshot: snapshot }),
   setCanInitialize: (canInit) => set({ canInitialize: canInit }),
 }));
+
+// usePostFormStore.ts 파일 맨 아래에 추가
+usePostFormStore.subscribe((state, prevState) => {
+  if (process.env.NODE_ENV === 'development') {
+    if (state.canInitialize !== prevState.canInitialize) {
+      console.log('🔔 canInitialize 변경:', prevState.canInitialize, '->', state.canInitialize);
+    }
+    if (state.isEditorInitialized !== prevState.isEditorInitialized) {
+      console.log(
+        '✅ isEditorInitialized 변경:',
+        prevState.isEditorInitialized,
+        '->',
+        state.isEditorInitialized,
+      );
+    }
+    if (state.content !== prevState.content) {
+      console.log('✍️ content 변경:', {
+        before: prevState.content,
+        after: state.content,
+      });
+    }
+    if (state.images !== prevState.images) {
+      console.log('🖼️ images 변경:', {
+        before: prevState.images,
+        after: state.images,
+      });
+    }
+  }
+});

--- a/apps/web/src/features/post/post-form/model/usePostFormStore.ts
+++ b/apps/web/src/features/post/post-form/model/usePostFormStore.ts
@@ -43,9 +43,8 @@ export const usePostFormStore = create<PostFormState>((set, get) => ({
   setCanInitialize: (canInit) => set({ canInitialize: canInit }),
 }));
 
-// usePostFormStore.ts 파일 맨 아래에 추가
-usePostFormStore.subscribe((state, prevState) => {
-  if (process.env.NODE_ENV === 'development') {
+if (process.env.NODE_ENV === 'development') {
+  usePostFormStore.subscribe((state, prevState) => {
     if (state.canInitialize !== prevState.canInitialize) {
       console.log('🔔 canInitialize 변경:', prevState.canInitialize, '->', state.canInitialize);
     }
@@ -69,5 +68,5 @@ usePostFormStore.subscribe((state, prevState) => {
         after: state.images,
       });
     }
-  }
-});
+  });
+}

--- a/apps/web/src/features/post/post-form/model/usePostFormStore.ts
+++ b/apps/web/src/features/post/post-form/model/usePostFormStore.ts
@@ -10,6 +10,7 @@ export const usePostFormStore = create<PostFormState>((set, get) => ({
   reservedAt: null,
   initialSnapshot: null,
   isEditorInitialized: false,
+  canInitialize: false,
 
   setField: (field, value) => set((state) => ({ ...state, [field]: value })),
   setEditorState: (content, images) => set({ content, images }),
@@ -39,4 +40,5 @@ export const usePostFormStore = create<PostFormState>((set, get) => ({
     });
   },
   setSnapshot: (snapshot) => set({ initialSnapshot: snapshot }),
+  setCanInitialize: (canInit) => set({ canInitialize: canInit }),
 }));

--- a/apps/web/src/features/post/post-form/model/usePostInitialization.ts
+++ b/apps/web/src/features/post/post-form/model/usePostInitialization.ts
@@ -31,10 +31,11 @@ export const usePostInitialization = ({
   isInitializedRef,
   isScheduleFetching,
 }: Props) => {
-  const { initialSnapshot, setSnapshot, content, images } = usePostFormStore();
+  const { initialSnapshot, setSnapshot, content, images, canInitialize } = usePostFormStore();
 
   useEffect(() => {
     // 1. 초기화 가드
+    if (!canInitialize) return;
     if (mode === 'create' || isInitializedRef.current) return;
     if (mode === 'edit' && !postDetail) return;
     // 일정이 있는 게시글인데, 일정을 아직 가져오지 못했거나 '새로 가져오는 중(Fetching)'이면 대기
@@ -145,5 +146,6 @@ export const usePostInitialization = ({
     content,
     images,
     isScheduleFetching,
+    canInitialize,
   ]);
 };

--- a/apps/web/src/widgets/post/post-editor/PostEditor.tsx
+++ b/apps/web/src/widgets/post/post-editor/PostEditor.tsx
@@ -53,8 +53,11 @@ export const PostEditor = ({
   } = useImageManager();
 
   const contentRef = useRef<string>(initialContent);
-  const { isEditorInitialized: isInitialized, setIsEditorInitialized: setIsInitialized } =
-    usePostFormStore();
+  const {
+    isEditorInitialized: isInitialized,
+    setIsEditorInitialized: setIsInitialized,
+    canInitialize,
+  } = usePostFormStore();
   const [isDataSynced, setIsDataSynced] = useState(false);
   const keyboardOffset = useKeyboardOffset();
   const { MAX_IMAGES } = POST_VALIDATION;
@@ -68,18 +71,18 @@ export const PostEditor = ({
     (html: string) => {
       contentRef.current = html;
       // 초기화 완료 후에만 부모 컴포넌트의 상태를 업데이트
-      if (isInitialized) {
+      if (isInitialized && canInitialize) {
         onChange({ content: html, images });
       }
     },
-    [onChange, images, isInitialized],
+    [onChange, images, isInitialized, canInitialize],
   );
 
   const editor = usePostEditor(initialContent, onUpdate);
 
   // 외부 데이터(initialValue) 주입 및 초기화 세션 관리
   useEffect(() => {
-    if (!editor || isInitialized) return;
+    if (!editor || isInitialized || !canInitialize) return;
 
     // 생성 모드: 데이터 주입을 기다리지 않고 즉시 활성화
     if (mode === 'create') {
@@ -111,26 +114,35 @@ export const PostEditor = ({
       setImages(initialImages);
       setIsInitialized(true);
     }
-  }, [editor, isInitialized, setIsInitialized, initialContent, initialImages, setImages, mode]);
+  }, [
+    editor,
+    isInitialized,
+    setIsInitialized,
+    initialContent,
+    initialImages,
+    setImages,
+    mode,
+    canInitialize,
+  ]);
 
   // 복귀 시 초기 이미지가 들어오면 로컬 상태에 동기화
   useEffect(() => {
-    if (isDataSynced || !isInitialized || !initialImages) return;
+    if (isDataSynced || !isInitialized || !initialImages || !canInitialize) return;
 
     // 현재 로컬 images가 비어있고, initialImages가 있으면 동기화
     if (images.length === 0 && initialImages.length > 0) {
       setImages(initialImages);
       setIsDataSynced(true);
     }
-  }, [isInitialized, initialImages, images.length, isDataSynced, setImages]);
+  }, [isInitialized, initialImages, images.length, isDataSynced, setImages, canInitialize]);
 
   // 3. Side Effects
 
   // 이미지 리스트 변경 감지 (삭제/순서변경 등) 시 부모에게 알림
   useEffect(() => {
-    if (!isInitialized) return;
+    if (!isInitialized || !canInitialize) return;
     onChange({ content: contentRef.current, images });
-  }, [images, onChange, isInitialized]);
+  }, [images, onChange, isInitialized, canInitialize]);
 
   // 4. Handlers
   const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/apps/web/src/widgets/post/post-editor/PostEditor.tsx
+++ b/apps/web/src/widgets/post/post-editor/PostEditor.tsx
@@ -22,8 +22,8 @@ import { useKeyboardOffset } from '@/shared/hooks/useKeyboardOffset';
 
 export type PostEditorProps = {
   mode: PostPageMode;
-  initialContent: string;
-  initialImages: UploadImage[];
+  initialContent: string; // Store에서 내려오는 전역 본문 데이터
+  initialImages: UploadImage[]; // Store에서 내려오는 전역 이미지 데이터
   linkedSchedule: ScheduleFormData | null;
   onChange: (data: { content: string; images: UploadImage[] }) => void;
   onScheduleRemove: () => void;
@@ -33,15 +33,29 @@ export type PostEditorProps = {
 
 export const PostEditor = ({
   mode,
-  initialContent,
-  initialImages,
+  initialContent: storeContent,
+  initialImages: storeImages,
   linkedSchedule,
   onChange,
   onScheduleRemove,
   onReservationClick,
   isPublished,
 }: PostEditorProps) => {
-  // 1. Hooks & Refs
+  /**
+   * [플래그 역할 정의]
+   * 1. canInitialize (전역): 페이지 진입 시 데이터 준비가 완료되었음을 알리는 신호 (부모 제어)
+   * 2. isInitialized (전역): 게시글 데이터가 에디터에 "생애 최초 1회" 주입되었음을 의미 (재주입 방지)
+   * 3. isLocalInitialized (지역): 현재 마운트된 에디터 인스턴스에 데이터가 주입되었는지 여부 (복귀 시 대응)
+   */
+  const {
+    isEditorInitialized: isInitialized,
+    setIsEditorInitialized: setIsInitialized,
+    canInitialize,
+  } = usePostFormStore();
+
+  const isLocalInitialized = useRef(false);
+  const contentRef = useRef<string>(storeContent);
+
   const {
     inputRef,
     images,
@@ -52,25 +66,16 @@ export const PostEditor = ({
     openPicker,
   } = useImageManager();
 
-  const contentRef = useRef<string>(initialContent);
-  const {
-    isEditorInitialized: isInitialized,
-    setIsEditorInitialized: setIsInitialized,
-    canInitialize,
-  } = usePostFormStore();
-  const [isDataSynced, setIsDataSynced] = useState(false);
   const keyboardOffset = useKeyboardOffset();
   const { MAX_IMAGES } = POST_VALIDATION;
-
   const [showImageLimitAlert, setShowImageLimitAlert] = useState(false);
 
-  // 2. Editor Callbacks & Initialization
+  // --- 1. Editor Callbacks ---
 
-  // TipTap 내용 업데이트 핸들러
   const onUpdate = useCallback(
     (html: string) => {
       contentRef.current = html;
-      // 초기화 완료 후에만 부모 컴포넌트의 상태를 업데이트
+      // 초기화가 완료된 후, 유효한 페이지 세션 내에서만 부모 스토어 업데이트 전파
       if (isInitialized && canInitialize) {
         onChange({ content: html, images });
       }
@@ -78,73 +83,79 @@ export const PostEditor = ({
     [onChange, images, isInitialized, canInitialize],
   );
 
-  const editor = usePostEditor(initialContent, onUpdate);
+  const editor = usePostEditor(storeContent, onUpdate);
 
-  // 외부 데이터(initialValue) 주입 및 초기화 세션 관리
+  // --- 2. Data Initialization (로컬 & 전역 동기화) ---
+
+  /**
+   * [CASE A: 일정 페이지 복귀 대응]
+   * 전역 초기화는 이미 끝났지만(true), 컴포넌트가 재마운트되어 로컬 상태가 비어있을 때 실행
+   */
+  useEffect(() => {
+    if (!canInitialize || !editor) return;
+
+    if (isInitialized && !isLocalInitialized.current) {
+      if (storeContent) editor.commands.setContent(storeContent);
+      setImages(storeImages || []);
+
+      isLocalInitialized.current = true;
+      return;
+    }
+  }, [canInitialize, isInitialized, editor, storeContent, storeImages, setImages]);
+
+  /**
+   * [CASE B: 게시글 최초 진입 및 데이터 주입]
+   * 수정 모드의 상세 데이터를 기다리거나, 생성 모드 진입 시 최초 1회 실행
+   */
   useEffect(() => {
     if (!editor || isInitialized || !canInitialize) return;
 
-    // 생성 모드: 데이터 주입을 기다리지 않고 즉시 활성화
     if (mode === 'create') {
-      // 일정 페이지 등 외부에서 돌아온 경우: Zustand에 저장된 이미지를 복구
-      if (initialImages && initialImages.length > 0) {
-        setImages(initialImages);
-      }
+      setImages(storeImages || []);
       setIsInitialized(true);
+      isLocalInitialized.current = true;
       return;
     }
 
-    // 수정 모드: 서버에서 넘어온 데이터를 에디터 및 이미지 매니저에 주입
-    const currentHtml = editor.getHTML();
-    const hasNoContent = currentHtml === '' || currentHtml === '<p></p>';
+    if (mode === 'edit') {
+      // 수정 모드는 서버 데이터(storeContent)가 로드될 때까지 대기
+      if (!storeContent) return;
 
-    // 1) 본문 데이터 주입
-    if (initialContent && hasNoContent) {
-      editor.commands.setContent(initialContent);
-      contentRef.current = initialContent;
-
-      // 이미지가 없는 게시글인 경우 여기서 초기화 완료 처리
-      if (!initialImages || initialImages.length === 0) {
-        setIsInitialized(true);
+      const currentHtml = editor.getHTML();
+      if (currentHtml === '' || currentHtml === '<p></p>') {
+        editor.commands.setContent(storeContent);
+        contentRef.current = storeContent;
       }
-    }
 
-    // 2) 이미지 데이터 주입 (최초 1회)
-    if (initialImages && initialImages.length > 0) {
-      setImages(initialImages);
+      setImages(storeImages || []);
       setIsInitialized(true);
+      isLocalInitialized.current = true;
     }
   }, [
     editor,
     isInitialized,
-    setIsInitialized,
-    initialContent,
-    initialImages,
-    setImages,
-    mode,
     canInitialize,
+    storeContent,
+    storeImages,
+    mode,
+    setImages,
+    setIsInitialized,
   ]);
 
-  // 복귀 시 초기 이미지가 들어오면 로컬 상태에 동기화
+  // --- 3. Side Effects ---
+
+  /**
+   * [이미지 변경 감지 및 부모 전파]
+   * 로컬 주입(isMountedRef)이 끝난 상태에서만 변경 사항을 전역 스토어로 전달 (역류 방지)
+   */
   useEffect(() => {
-    if (isDataSynced || !isInitialized || !initialImages || !canInitialize) return;
+    if (!isInitialized || !canInitialize || !isLocalInitialized.current) return;
 
-    // 현재 로컬 images가 비어있고, initialImages가 있으면 동기화
-    if (images.length === 0 && initialImages.length > 0) {
-      setImages(initialImages);
-      setIsDataSynced(true);
-    }
-  }, [isInitialized, initialImages, images.length, isDataSynced, setImages, canInitialize]);
-
-  // 3. Side Effects
-
-  // 이미지 리스트 변경 감지 (삭제/순서변경 등) 시 부모에게 알림
-  useEffect(() => {
-    if (!isInitialized || !canInitialize) return;
     onChange({ content: contentRef.current, images });
   }, [images, onChange, isInitialized, canInitialize]);
 
-  // 4. Handlers
+  // --- 4. Handlers & Render Helpers ---
+
   const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files;
     if (!files) return;
@@ -154,13 +165,9 @@ export const PostEditor = ({
       e.target.value = '';
       return;
     }
-
     await handleSelectAndUpload(e);
   };
 
-  if (!editor) return null;
-
-  // 5. Render Helpers
   const renderScheduleCard = () => {
     if (!linkedSchedule) return null;
 
@@ -185,6 +192,8 @@ export const PostEditor = ({
       </div>
     );
   };
+
+  if (!editor) return null;
 
   return (
     <div className="flex w-full min-w-0 flex-col gap-10">

--- a/apps/web/src/widgets/post/post-editor/PostEditor.tsx
+++ b/apps/web/src/widgets/post/post-editor/PostEditor.tsx
@@ -122,7 +122,7 @@ export const PostEditor = ({
       if (!storeContent) return;
 
       const currentHtml = editor.getHTML();
-      if (currentHtml === '' || currentHtml === '<p></p>') {
+      if (currentHtml !== storeContent) {
         editor.commands.setContent(storeContent);
         contentRef.current = storeContent;
       }


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 any가 사용되지 않았습니다
- [x] 스토리북에 추가했습니다 (해당 시)
- [x] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈

- close #403
- close #406

## 📌 작업 목적

- 게시글 에디터 초기화 로직 안정화 및 데이터 동기화 버그 수정

## ⚠️ 기존 문제

- 기존 게시글 내용이 새 글 작성시 보이는 현상
- 이미지 모두 삭제시 데이터 재복구되어 지워지지 않는 현상
- 로직 통합 시 초기 데이터가 빈 값으로 초기화되는 현상

## ☑️ 해결 방법

- 에디터 초기화 생명주기 개선: `canInitialize` 플래그를 도입하여 페이지 전환 시 이전 데이터가 노출되는 레이스 컨디션 해결.
- 데이터 역류 방지 로직 적용: 전역(`isInitialized`)과 로컬(`isLocalInitialized`) 초기화 플래그를 계층화하여, 이미지 삭제 시 데이터가 재복구되는 좀비 현상 해결.
- 일정 페이지 복귀 대응: 컴포넌트 재마운트 시 전역 스토어 데이터를 로컬 에디터로 안전하게 복구하는 마운트 동기화 로직 추가.

## 🧪 테스트 방법

- 게시글 작성 후 곧바로 다시 수정 페이지에 진입
- CASE 1
  - 아무 글자, 사진 추가 입력
  - 일정 화면 들어갔다 나오기
  - 다시 수정 페이지 진입하면 수정한 내용이 정상적으로 보여야 합니다.
- CASE 2
  - 아무 글자, 사진 추가 입력
  - 뒤로 가기 (반영 X)
  - 게시글 상세 화면에서 다시 수정 페이지 진입
  - 기존 게시글 내용이 정상적으로 보여야 합니다.
- CASE 3
  - 아무 글자, 사진 추가 입력
  - 수정 완료 (반영 O)
  - 게시글 상세 화면에서 수정한 내용이 정상적으로 보여야 합니다.

## 📷 실행 영상 또는 스크린샷

- 뒤로 가기가 갑자기 안되는 이슈로...

## 💬 논의할 점

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 게시물 작성 진입 시 초기화 허용을 제어하는 플래그 추가
  * 보드에서 새 게시물 생성 시 이전 작성 폼과 예약 연결을 자동으로 초기화

* **개선**
  * 에디터의 단계적(다단계) 초기화 도입으로 초기화 신뢰성 향상
  * 페이지 이동·종료 시 폼 초기화 흐름 및 동기화 강화 (진입/종료 시 초기화 권한 제어)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->