### PR TITLE
[FIX] 쪽지보내기 이메일 에러 문구 추가 및 쿼리 파라미터 연동

### DIFF
--- a/apps/admin/next-env.d.ts
+++ b/apps/admin/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/src/app-pages/member/ui/MemberProfilePage.tsx
+++ b/apps/web/src/app-pages/member/ui/MemberProfilePage.tsx
@@ -22,7 +22,14 @@ export const MemberProfilePage = ({ userProfile, memberId }: Props) => {
 
   function handleMessage() {
     if (isMe) return;
-    router.push(PAGE_ROUTES.MESSAGE);
+
+    const params = new URLSearchParams({
+      memberId: String(memberId),
+      nickname: userProfile.username,
+      profileImageUrl: userProfile.profileImgUrl,
+    });
+
+    router.push(`${PAGE_ROUTES.MESSAGE}?${params.toString()}`);
   }
 
   return (

--- a/apps/web/src/app-pages/member/ui/MemberProfilePage.tsx
+++ b/apps/web/src/app-pages/member/ui/MemberProfilePage.tsx
@@ -23,13 +23,13 @@ export const MemberProfilePage = ({ userProfile, memberId }: Props) => {
   function handleMessage() {
     if (isMe) return;
 
-    const params = new URLSearchParams({
-      memberId: String(memberId),
-      nickname: userProfile.username,
-      profileImageUrl: userProfile.profileImgUrl,
-    });
-
-    router.push(`${PAGE_ROUTES.MESSAGE}?${params.toString()}`);
+    router.push(
+      PAGE_ROUTES.MESSAGE({
+        memberId,
+        nickname: userProfile.username,
+        profileImageUrl: userProfile.profileImgUrl,
+      }),
+    );
   }
 
   return (

--- a/apps/web/src/app-pages/message/ui/SendMessagePage.tsx
+++ b/apps/web/src/app-pages/message/ui/SendMessagePage.tsx
@@ -4,11 +4,13 @@ import { Alert } from '@surf/ui/alert';
 import { SolidButton } from '@surf/ui/button';
 import { FieldGroup } from '@surf/ui/field-group';
 import { HeaderMode } from '@surf/ui/header';
+import { useToastStore } from '@surf/ui/store/toastStore';
 import { TextArea } from '@surf/ui/text-area';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useMemo, useState } from 'react';
 import { useSendMessage } from '@/entities/message/model/useSendMessage';
 import { Callout } from '@/entities/message/ui/callout/Callout';
+import { PAGE_ROUTES } from '@/shared/config/path';
 import { useKeyboardOffset } from '@/shared/hooks/useKeyboardOffset';
 import { kakaoImgNormalize } from '@/shared/lib/kakaoImgNormalize';
 import { AppHeader } from '@/widgets/header/ui/AppHeader';
@@ -37,6 +39,8 @@ export const SendMessagePage = () => {
   const keyboardOffset = useKeyboardOffset();
   const router = useRouter();
 
+  const showToast = useToastStore((state) => state.show);
+
   // 쪽지 전송 mutation
   const { mutate: sendMessage, isPending } = useSendMessage();
 
@@ -60,8 +64,9 @@ export const SendMessagePage = () => {
       },
       {
         onSuccess: () => {
+          showToast('상대방의 이메일로 쪽지가 발송되었습니다.');
           setIsSendAlertOpen(false);
-          router.back();
+          router.replace(PAGE_ROUTES.MEMBER.PROFILE(validMemberId));
         },
       },
     );

--- a/apps/web/src/app-pages/message/ui/SendMessagePage.tsx
+++ b/apps/web/src/app-pages/message/ui/SendMessagePage.tsx
@@ -76,6 +76,17 @@ export const SendMessagePage = () => {
     return Number.isInteger(id) && id > 0 ? id : null;
   }, [memberId]);
 
+  // 이메일 에러 메시지
+  const emailErrorMessage = useMemo(() => {
+    if (senderEmail.length === 0) return undefined;
+
+    if (!isValidEmail(senderEmail)) {
+      return '올바른 형태의 이메일을 입력해주세요.';
+    }
+
+    return undefined;
+  }, [senderEmail]);
+
   // 버튼 활성화 조건
   const isBtnEnabled =
     !isPending &&
@@ -104,6 +115,7 @@ export const SendMessagePage = () => {
             value={senderEmail}
             onChange={setSenderEmail}
             readOnly={isPending}
+            errorMessage={emailErrorMessage}
           />
         </FieldGroup>
         <FieldGroup title="추가로 연락받고 싶은 SNS">

--- a/apps/web/src/shared/config/path.ts
+++ b/apps/web/src/shared/config/path.ts
@@ -49,7 +49,21 @@ export const PAGE_ROUTES = {
     },
   },
 
-  MESSAGE: '/message',
+  MESSAGE: (params: { memberId: number | string; nickname?: string; profileImageUrl?: string }) => {
+    const searchParams = new URLSearchParams({
+      memberId: String(params.memberId),
+    });
+
+    if (params.nickname) {
+      searchParams.set('nickname', params.nickname);
+    }
+
+    if (params.profileImageUrl) {
+      searchParams.set('profileImageUrl', params.profileImageUrl);
+    }
+
+    return `/message?${searchParams.toString()}`;
+  },
 
   NOTIFICATION: '/notification',
 


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 any가 사용되지 않았습니다
- [x] 스토리북에 추가했습니다 (해당 시)
- [x] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈
- close #409

## 📌 작업 목적
- 쪽지보내기 이메일 에러 문구 추가 및 쿼리 파라미터 연동

## 🔨 주요 작업 내용
- 쪽지보내기 이메일 입력 시, 올바르지 않은 형식일 경우 에러 문구 표시
- MemberProfilePage에서 쪽지보내기 진입 시 memberId, nickname, profileImageUrl을 쿼리 파라미터로 전달하도록 수정

## ⚠️ 기존 문제
- 쪽지보내기 이메일 입력란에 잘못된 이메일을 입력해도 사용자에게 에러 피드백이 제공되지 않았습니다.
- MemberProfilePage에서 쪽지보내기 버튼 클릭 시, 수신자 정보 없이 `/message` 경로로만 이동하여 쪽지 페이지에서 대상 정보를 알 수 없었습니다.

## ☑️ 해결 방법
- 이메일 입력값에 대해 형식과 맞지 않을 경우, 에러 메시지를 노출하도록 개선하였습니다.
- 쪽지보내기 페이지 진입 시 필요한 수신자 정보를 쿼리 파라미터로 전달하도록 수정하였습니다.

## 🧪 테스트 방법
- MemberProfilePage에서 쪽지보내기 버튼 클릭 시 `/message?memberId=...` 형태로 정상 이동되는지 확인
- 쪽지보내기 페이지에서 수신자 이름 및 프로필 이미지가 정상적으로 표시되는지 확인
- 이메일 입력란에 잘못된 형식의 이메일 입력 시 에러 문구가 표시되는지 확인
- 올바른 이메일 및 필수 입력값을 모두 입력한 경우 쪽지 전송 버튼이 활성화되는지 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 메시지 전송 완료 시 성공 알림 토스트 추가
  * 이메일 필드의 실시간 유효성 검사 피드백 제공

* **개선 사항**
  * 메시지 페이지 진입 시 회원 정보를 컨텍스트 데이터로 전달하여 사용자 경험 향상

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->