### PR TITLE
[FEAT] Input 컴포넌트 제작

### DIFF
--- a/packages/ui/components/input/Input.stories.tsx
+++ b/packages/ui/components/input/Input.stories.tsx
@@ -24,7 +24,7 @@ const meta = {
       control: 'text',
       description: 'Placeholder 문구',
     },
-    isDisabled: {
+    disabled: {
       control: 'boolean',
       description: '비활성화 여부',
     },
@@ -101,7 +101,7 @@ export const Password: Story = {
 export const Disabled: Story = {
   args: {
     type: 'text',
-    isDisabled: true,
+    disabled: true,
     initialValue: '수정할 수 없습니다',
   },
 };

--- a/packages/ui/components/input/Input.stories.tsx
+++ b/packages/ui/components/input/Input.stories.tsx
@@ -1,0 +1,115 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { useState } from 'react';
+import { Input, type InputProps } from './Input';
+import { SurfIcon } from '../icon/SurfIcon';
+
+function ControlledInput(
+  props: Omit<InputProps, 'value' | 'onChange'> & { initialValue?: string },
+) {
+  const [val, setVal] = useState(props.initialValue ?? '');
+  return <Input {...props} value={val} onChange={setVal} />;
+}
+
+const meta = {
+  title: 'Shared/UI/Input',
+  component: ControlledInput,
+  tags: ['autodocs'],
+  argTypes: {
+    type: {
+      control: { type: 'select' },
+      options: ['text', 'email', 'number', 'password', 'search', 'tel', 'url'],
+      description: '입력 타입',
+    },
+    placeholder: {
+      control: 'text',
+      description: 'Placeholder 문구',
+    },
+    isDisabled: {
+      control: 'boolean',
+      description: '비활성화 여부',
+    },
+    readOnly: {
+      control: 'boolean',
+      description: '읽기 전용 여부',
+    },
+    guideMessage: {
+      control: 'text',
+      description: '가이드 메시지',
+    },
+    errorMessage: {
+      control: 'text',
+      description: '에러 메시지',
+    },
+  },
+} satisfies Meta<typeof ControlledInput>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    type: 'text',
+    placeholder: '내용을 입력하세요',
+  },
+};
+
+export const GuideMessage: Story = {
+  args: {
+    type: 'text',
+    placeholder: '가이드 메시지가 표시됩니다',
+    guideMessage: '영문, 숫자 조합 8자 이상',
+  },
+};
+
+export const ErrorMessage: Story = {
+  args: {
+    type: 'text',
+    placeholder: '에러 상태',
+    errorMessage: '필수 입력 항목입니다.',
+  },
+};
+
+export const WithIcon: Story = {
+  render: (args) => <ControlledInput {...args} icon={<SurfIcon name="Search" size="m" />} />,
+  args: {
+    type: 'search',
+    placeholder: '검색어를 입력하세요',
+  },
+};
+
+export const WithPrefixSuffix: Story = {
+  render: (args) => (
+    <ControlledInput
+      {...args}
+      prefix={<span className="text-body-body9 text-foreground-tertiary">₩</span>}
+      suffix={<span className="text-body-body9 text-foreground-tertiary">원</span>}
+    />
+  ),
+  args: {
+    type: 'number',
+    placeholder: '금액',
+  },
+};
+
+export const Password: Story = {
+  args: {
+    type: 'password',
+    placeholder: '비밀번호',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    type: 'text',
+    isDisabled: true,
+    initialValue: '수정할 수 없습니다',
+  },
+};
+
+export const ReadOnly: Story = {
+  args: {
+    type: 'text',
+    readOnly: true,
+    initialValue: '읽기 전용',
+  },
+};

--- a/packages/ui/components/input/Input.stories.tsx
+++ b/packages/ui/components/input/Input.stories.tsx
@@ -77,12 +77,12 @@ export const WithIcon: Story = {
   },
 };
 
-export const WithPrefixSuffix: Story = {
+export const WithLeadingTrailing: Story = {
   render: (args) => (
     <ControlledInput
       {...args}
-      prefix={<span className="text-body-body9 text-foreground-tertiary">₩</span>}
-      suffix={<span className="text-body-body9 text-foreground-tertiary">원</span>}
+      leading={<span className="text-body-body9 text-foreground-tertiary">₩</span>}
+      trailing={<span className="text-body-body9 text-foreground-tertiary">원</span>}
     />
   ),
   args: {

--- a/packages/ui/components/input/Input.tsx
+++ b/packages/ui/components/input/Input.tsx
@@ -77,7 +77,6 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
     const [isFocused, setIsFocused] = useState(false);
     const uid = useId();
 
-    const isInteractive = !disabled && !readOnly;
     const hasValue = value.trim().length > 0;
     const isPasswordType = type === 'password';
     const [isPasswordVisible, setIsPasswordVisible] = useState(false);
@@ -86,7 +85,9 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
     const textColor = hasValue ? 'text-foreground-normal' : 'text-foreground-tertiary';
 
     const borderColor =
-      isInteractive && isFocused ? 'border border-border-primary' : 'border border-transparent';
+      isFocused && !disabled && !readOnly
+        ? 'border border-border-primary'
+        : 'border border-transparent';
 
     const containerOpacity = disabled ? 'opacity-50' : '';
 
@@ -98,13 +99,13 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
     }, [uid, errorMessage, guideMessage]);
 
     const handleFocus = (e: React.FocusEvent<HTMLInputElement>) => {
-      if (!isInteractive) return;
+      if (disabled) return;
       setIsFocused(true);
       onFocusProp?.(e);
     };
 
     const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
-      if (!isInteractive) return;
+      if (disabled) return;
       setIsFocused(false);
       onBlurProp?.(e);
     };
@@ -138,7 +139,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
             onFocus={handleFocus}
             onBlur={handleBlur}
             onMouseDown={(e) => {
-              if (!isInteractive) e.preventDefault();
+              if (disabled) e.preventDefault();
             }}
             onChange={handleChange}
             className={[
@@ -152,7 +153,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
             aria-invalid={!!errorMessage}
             aria-readonly={readOnly || undefined}
             aria-describedby={describedBy}
-            tabIndex={readOnly ? -1 : undefined}
+            tabIndex={disabled ? -1 : undefined}
             {...rest}
           />
 

--- a/packages/ui/components/input/Input.tsx
+++ b/packages/ui/components/input/Input.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import React, { forwardRef, useId, useMemo, useState, type InputHTMLAttributes } from 'react';
+import { SurfIcon } from '../icon/SurfIcon';
+
+/**
+ * 공용 Input props
+ *
+ * 사용 예시:
+ * ```tsx
+ * <Input
+ *   type="password"
+ *   value={value}
+ *   onChange={setValue}
+ *   guideMessage="영문/숫자 조합 8자 이상"
+ *   prefix={<span>@</span>}
+ *   suffix={<span>원</span>}
+ * />
+ * ```
+ */
+export type InputProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'onChange' | 'value'> & {
+  /**
+   * 입력값 (controlled)
+   */
+  value: string;
+  /**
+   * 값 변경 콜백 (controlled)
+   */
+  onChange: (value: string) => void;
+  /**
+   * 하단 가이드 메시지
+   */
+  guideMessage?: string;
+  /**
+   * 하단 에러 메시지 (guideMessage보다 우선)
+   */
+  errorMessage?: string;
+  /**
+   * 비활성화 상태
+   */
+  isDisabled?: boolean;
+  /**
+   * 읽기 전용 상태
+   */
+  readOnly?: boolean;
+  /**
+   * 우측에 표시할 아이콘 슬롯
+   */
+  icon?: React.ReactNode;
+  /**
+   * 좌측 슬롯 (prefix)
+   */
+  prefix?: React.ReactNode;
+  /**
+   * 우측 슬롯 (suffix)
+   */
+  suffix?: React.ReactNode;
+};
+
+/**
+ * 공용 Input 컴포넌트
+ *
+ */
+export const Input = forwardRef<HTMLInputElement, InputProps>(
+  (
+    {
+      value,
+      onChange,
+      guideMessage,
+      errorMessage,
+      type = 'text',
+      placeholder = '내용을 입력하세요',
+      isDisabled = false,
+      readOnly = false,
+      icon,
+      prefix,
+      suffix,
+      className = '',
+      onFocus: onFocusProp,
+      onBlur: onBlurProp,
+      ...rest
+    },
+    ref,
+  ) => {
+    const [isFocused, setIsFocused] = useState(false);
+    const uid = useId();
+
+    const isInteractive = !isDisabled && !readOnly;
+    const hasValue = value.trim().length > 0;
+    const isPasswordType = type === 'password';
+    const [isPasswordVisible, setIsPasswordVisible] = useState(false);
+    const inputType = isPasswordType ? (isPasswordVisible ? 'text' : 'password') : type;
+
+    const textColor = hasValue ? 'text-foreground-normal' : 'text-foreground-tertiary';
+
+    const borderColor =
+      isInteractive && isFocused ? 'border border-border-primary' : 'border border-transparent';
+
+    const containerOpacity = isDisabled ? 'opacity-50' : '';
+
+    const { describedBy, guideId, errorId } = useMemo(() => {
+      const gId = `input-guide-${uid}`;
+      const eId = `input-error-${uid}`;
+      const dBy = errorMessage ? eId : guideMessage ? gId : undefined;
+      return { describedBy: dBy, guideId: gId, errorId: eId };
+    }, [uid, errorMessage, guideMessage]);
+
+    const handleFocus = (e: React.FocusEvent<HTMLInputElement>) => {
+      if (!isInteractive) return;
+      setIsFocused(true);
+      onFocusProp?.(e);
+    };
+
+    const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+      if (!isInteractive) return;
+      setIsFocused(false);
+      onBlurProp?.(e);
+    };
+
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      onChange(e.target.value);
+    };
+
+    return (
+      <div
+        className={`flex flex-col gap-5 ${containerOpacity} ${className}`}
+        data-readonly={readOnly || undefined}
+        data-disabled={isDisabled || undefined}
+      >
+        <div
+          className={[
+            'bg-background-quaternary',
+            'rounded-3 box-border flex items-center gap-7 p-10',
+            borderColor,
+          ].join(' ')}
+        >
+          {prefix ? <div className="flex items-center">{prefix}</div> : null}
+
+          <input
+            ref={ref}
+            value={value}
+            placeholder={placeholder}
+            disabled={isDisabled}
+            readOnly={readOnly}
+            type={inputType}
+            onFocus={handleFocus}
+            onBlur={handleBlur}
+            onMouseDown={(e) => {
+              if (!isInteractive) e.preventDefault();
+            }}
+            onChange={handleChange}
+            className={[
+              'text-body-body9',
+              'w-full min-w-0 bg-transparent outline-none',
+              'box-content appearance-none border-0 p-0',
+              'placeholder:text-foreground-tertiary',
+              textColor,
+              readOnly ? 'cursor-default select-text' : '',
+            ].join(' ')}
+            aria-invalid={!!errorMessage}
+            aria-readonly={readOnly || undefined}
+            aria-describedby={describedBy}
+            tabIndex={readOnly ? -1 : undefined}
+            {...rest}
+          />
+
+          {suffix ? <div className="flex items-center">{suffix}</div> : null}
+
+          {isPasswordType ? (
+            <button
+              type="button"
+              aria-label={isPasswordVisible ? '비밀번호 숨기기' : '비밀번호 보기'}
+              aria-pressed={isPasswordVisible}
+              disabled={isDisabled}
+              onClick={() => setIsPasswordVisible((prev) => !prev)}
+              className="text-foreground-tertiary flex items-center"
+            >
+              <SurfIcon name={isPasswordVisible ? 'SmileCircleSolid' : 'SmileCircle'} size="m" />
+            </button>
+          ) : null}
+
+          {icon ? <div className="text-foreground-tertiary flex items-center">{icon}</div> : null}
+        </div>
+
+        {errorMessage ? (
+          <div
+            id={errorId}
+            className="text-caption-caption6 text-foreground-danger px-10"
+            role="alert"
+            aria-live="polite"
+          >
+            {errorMessage}
+          </div>
+        ) : guideMessage ? (
+          <div id={guideId} className="text-caption-caption6 text-foreground-normal px-10">
+            {guideMessage}
+          </div>
+        ) : null}
+      </div>
+    );
+  },
+);
+
+Input.displayName = 'Input';

--- a/packages/ui/components/input/Input.tsx
+++ b/packages/ui/components/input/Input.tsx
@@ -36,14 +36,6 @@ export type InputProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'onChange' 
    */
   errorMessage?: string;
   /**
-   * 비활성화 상태
-   */
-  isDisabled?: boolean;
-  /**
-   * 읽기 전용 상태
-   */
-  readOnly?: boolean;
-  /**
    * 우측에 표시할 아이콘 슬롯
    */
   icon?: React.ReactNode;
@@ -70,7 +62,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
       errorMessage,
       type = 'text',
       placeholder = '내용을 입력하세요',
-      isDisabled = false,
+      disabled = false,
       readOnly = false,
       icon,
       prefix,
@@ -85,7 +77,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
     const [isFocused, setIsFocused] = useState(false);
     const uid = useId();
 
-    const isInteractive = !isDisabled && !readOnly;
+    const isInteractive = !disabled && !readOnly;
     const hasValue = value.trim().length > 0;
     const isPasswordType = type === 'password';
     const [isPasswordVisible, setIsPasswordVisible] = useState(false);
@@ -96,7 +88,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
     const borderColor =
       isInteractive && isFocused ? 'border border-border-primary' : 'border border-transparent';
 
-    const containerOpacity = isDisabled ? 'opacity-50' : '';
+    const containerOpacity = disabled ? 'opacity-50' : '';
 
     const { describedBy, guideId, errorId } = useMemo(() => {
       const gId = `input-guide-${uid}`;
@@ -125,7 +117,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
       <div
         className={`flex flex-col gap-5 ${containerOpacity} ${className}`}
         data-readonly={readOnly || undefined}
-        data-disabled={isDisabled || undefined}
+        data-disabled={disabled || undefined}
       >
         <div
           className={[
@@ -140,7 +132,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
             ref={ref}
             value={value}
             placeholder={placeholder}
-            disabled={isDisabled}
+            disabled={disabled}
             readOnly={readOnly}
             type={inputType}
             onFocus={handleFocus}
@@ -171,7 +163,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
               type="button"
               aria-label={isPasswordVisible ? '비밀번호 숨기기' : '비밀번호 보기'}
               aria-pressed={isPasswordVisible}
-              disabled={isDisabled}
+              disabled={disabled}
               onClick={() => setIsPasswordVisible((prev) => !prev)}
               className="text-foreground-tertiary flex items-center"
             >

--- a/packages/ui/components/input/Input.tsx
+++ b/packages/ui/components/input/Input.tsx
@@ -13,8 +13,8 @@ import { SurfIcon } from '../icon/SurfIcon';
  *   value={value}
  *   onChange={setValue}
  *   guideMessage="영문/숫자 조합 8자 이상"
- *   prefix={<span>@</span>}
- *   suffix={<span>원</span>}
+ *   leading={<span>@</span>}
+ *   trailing={<span>원</span>}
  * />
  * ```
  */
@@ -40,13 +40,13 @@ export type InputProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'onChange' 
    */
   icon?: React.ReactNode;
   /**
-   * 좌측 슬롯 (prefix)
+   * 좌측 슬롯 (leading)
    */
-  prefix?: React.ReactNode;
+  leading?: React.ReactNode;
   /**
-   * 우측 슬롯 (suffix)
+   * 우측 슬롯 (trailing)
    */
-  suffix?: React.ReactNode;
+  trailing?: React.ReactNode;
 };
 
 /**
@@ -65,8 +65,8 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
       disabled = false,
       readOnly = false,
       icon,
-      prefix,
-      suffix,
+      leading,
+      trailing,
       className = '',
       onFocus: onFocusProp,
       onBlur: onBlurProp,
@@ -127,7 +127,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
             borderColor,
           ].join(' ')}
         >
-          {prefix ? <div className="flex items-center">{prefix}</div> : null}
+          {leading ? <div className="flex items-center">{leading}</div> : null}
 
           <input
             ref={ref}
@@ -157,7 +157,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
             {...rest}
           />
 
-          {suffix ? <div className="flex items-center">{suffix}</div> : null}
+          {trailing ? <div className="flex items-center">{trailing}</div> : null}
 
           {isPasswordType ? (
             <button

--- a/packages/ui/components/input/index.ts
+++ b/packages/ui/components/input/index.ts
@@ -1,0 +1,1 @@
+export * from './Input';


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 코드에 any가 사용되지 않았습니다
- [ ] 스토리북에 추가했습니다 (해당 시)
- [ ] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈

- close #419 

## 📌 작업 목적

- Textarea에는 없는 password, number 등의 type 기능을 활용하기 위해 Input 공용 컴포넌트를 구현했습니다. 

## 🔨 주요 작업 내용

- Textarea 디자인시스템 기반 Input 컴포넌트 구현
- type이 'password'일 경우, 비밀번호 숨기기/보기 토글 기능 추가 
- Input 컴포넌트 스토리북 추가 


## 🧪 테스트 방법

- `storybook:ui` 명령어 입력 후 Input 스토리북 확인 


## 📷 실행 영상 또는 스크린샷

<img width="3644" height="2360" alt="image" src="https://github.com/user-attachments/assets/81d59f84-12da-4870-b7ca-8a2b47da8858" />


## 💬 논의할 점

- 비밀번호 토글할 때 eye icon이 없어서 SmileCircle 활용해서 구현해두었습니다. 추후 아이콘 변경해도 괜찮을 듯 합니다..!!



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 향상된 입력 필드 컴포넌트 추가: 패스워드 가시성 토글, 접두/접미 슬롯, 가이드 및 오류 메시지 우선 처리
  * 아이콘 삽입 및 여러 상태 지원(비활성화, 읽기 전용)과 접근성 속성(aria 등) 강화
  * 컴포넌트가 공개되어 재사용 가능

* **문서(스토리북)**
  * 다양한 사용 예시 추가: 기본, 가이드 메시지, 오류, 아이콘, 접두/접미, 패스워드, 비활성, 읽기전용(제어된 예시 포함)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->