### PR TITLE
[FEAT] 어드민 로그인 API 연동

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -18,7 +18,8 @@
     "next": "15.5.9",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-hook-form": "^7.71.0"
+    "react-hook-form": "^7.71.0",
+    "axios": "^1.12.2"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "4.1.1",
@@ -35,12 +36,20 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@types/webpack": "^5.28.5",
+    "@eslint/js": "^9.35.0",
     "eslint": "^9",
     "eslint-import-resolver-typescript": "^4.4.4",
+    "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-storybook": "9.1.5",
+    "eslint-plugin-import": "^2",
+    "eslint-plugin-jsx-a11y": "^6",
+    "eslint-plugin-react": "^7",
+    "eslint-plugin-react-hooks": "^5",
+    "globals": "^16.3.0",
     "storybook": "9.1.16",
     "tailwindcss": "^4",
     "typescript": "^5",
+    "typescript-eslint": "^8.42.0",
     "webpack": "^5.102.1"
   }
 }

--- a/apps/admin/src/app/(protected)/layout.tsx
+++ b/apps/admin/src/app/(protected)/layout.tsx
@@ -1,9 +1,9 @@
 import type { ReactNode } from 'react';
+import { verifySession } from '@/shared/lib/dal';
 // import { AuthHydrator } from '../providers/AuthHydrator';
-// import { verifySession } from '@/shared/lib/dal';
 
-const ProtectedLayout = ({ children }: { children: ReactNode }) => {
-  // const user = await verifySession();
+const ProtectedLayout = async ({ children }: { children: ReactNode }) => {
+  await verifySession();
   return (
     <>
       {/* <AuthHydrator memberId={user.memberId} memberRole={user.memberRole} /> */}

--- a/apps/admin/src/app/(protected)/page.tsx
+++ b/apps/admin/src/app/(protected)/page.tsx
@@ -1,4 +1,4 @@
-import { HomePage } from "@/app-pages/home/ui/HomePage";
+import { HomePage } from '@/app-pages/home/ui/HomePage';
 const Page = () => {
   return <HomePage />;
 };

--- a/apps/admin/src/app/api/proxy/[...path]/route.ts
+++ b/apps/admin/src/app/api/proxy/[...path]/route.ts
@@ -1,0 +1,185 @@
+import { NextRequest, NextResponse } from 'next/server';
+export const runtime = 'nodejs';
+
+const BACKEND = process.env.API_BASE_URL!;
+const IS_DEV = process.env.NODE_ENV !== 'production';
+
+const HOP_BY_HOP = new Set([
+  'connection',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+  'host',
+  'content-length',
+]);
+
+type Ctx = { params: Promise<{ path: string[] }> };
+
+async function handler(req: NextRequest, ctx: Ctx) {
+  const { path } = await ctx.params;
+  return proxy(req, path);
+}
+
+export const GET = handler;
+export const POST = handler;
+export const PUT = handler;
+export const PATCH = handler;
+export const DELETE = handler;
+export const HEAD = handler;
+
+async function proxy(req: NextRequest, path: string[]) {
+  const base = BACKEND.replace(/\/+$/, '');
+  const targetUrl = new URL(`${base}/${path.join('/')}`);
+  targetUrl.search = req.nextUrl.search;
+
+  const body = req.method === 'GET' || req.method === 'HEAD' ? undefined : await req.arrayBuffer();
+
+  const headers = new Headers(req.headers);
+  for (const key of HOP_BY_HOP) headers.delete(key);
+
+  const accessToken = req.cookies.get('accessToken')?.value;
+  if (accessToken && !headers.has('authorization')) {
+    headers.set('authorization', `Bearer ${accessToken}`);
+  }
+
+  const upstream = await fetch(targetUrl, {
+    method: req.method,
+    headers,
+    body,
+    redirect: 'manual',
+  });
+
+  const setCookies = getSetCookies(upstream);
+  console.log('[proxy] upstream status:', upstream.status);
+  console.log('[proxy] upstream content-type:', upstream.headers.get('content-type'));
+  console.log('[proxy] upstream set-cookie:', setCookies);
+
+  return buildResponse(upstream, setCookies);
+}
+
+async function buildResponse(upstream: Response, setCookies: string[]) {
+  const contentType = upstream.headers.get('content-type') ?? '';
+  const refreshValueFromUpstream = findCookieValue(setCookies, 'refreshToken');
+
+  if (contentType.includes('application/json')) {
+    const text = await upstream.text();
+
+    let parsed: unknown = null;
+    try {
+      parsed = text ? JSON.parse(text) : null;
+    } catch {
+      parsed = null;
+    }
+
+    const res = new NextResponse(text, {
+      status: upstream.status,
+      headers: pickHeaders(upstream),
+    });
+
+    if (!IS_DEV) {
+      for (const c of setCookies) res.headers.append('set-cookie', c);
+    } else {
+      if (refreshValueFromUpstream) {
+        res.cookies.set({
+          name: 'refreshToken',
+          value: refreshValueFromUpstream,
+          httpOnly: true,
+          secure: false,
+          sameSite: 'lax',
+          path: '/auth/refresh',
+        });
+      }
+    }
+
+    const token = extractAccessToken(parsed);
+    if (token) {
+      res.cookies.set({
+        name: 'accessToken',
+        value: token,
+        httpOnly: true,
+        secure: !IS_DEV,
+        sameSite: 'lax',
+        path: '/',
+        maxAge: 60 * 30,
+      });
+    }
+
+    return res;
+  }
+
+  const res = new NextResponse(upstream.body, {
+    status: upstream.status,
+    headers: pickHeaders(upstream),
+  });
+
+  if (!IS_DEV) {
+    for (const c of setCookies) res.headers.append('set-cookie', c);
+  } else {
+    if (refreshValueFromUpstream) {
+      res.cookies.set({
+        name: 'refreshToken',
+        value: refreshValueFromUpstream,
+        httpOnly: true,
+        secure: false,
+        sameSite: 'lax',
+        path: '/auth/refresh',
+      });
+    }
+  }
+
+  return res;
+}
+
+function pickHeaders(upstream: Response): Record<string, string> {
+  const headers: Record<string, string> = {};
+  const ct = upstream.headers.get('content-type');
+  const cc = upstream.headers.get('cache-control');
+  const loc = upstream.headers.get('location');
+  if (ct) headers['content-type'] = ct;
+  if (cc) headers['cache-control'] = cc;
+  if (loc) headers['location'] = loc;
+  return headers;
+}
+
+function getSetCookies(res: Response): string[] {
+  const headers = res.headers as Headers & { getSetCookie?: () => string[] };
+  if (typeof headers.getSetCookie === 'function') return headers.getSetCookie() ?? [];
+  const single = res.headers.get('set-cookie');
+  return single ? [single] : [];
+}
+
+function findCookieValue(setCookies: string[], cookieName: string): string | null {
+  for (const c of setCookies) {
+    const first = c.split(';', 1)[0];
+    const eqIdx = first.indexOf('=');
+    if (eqIdx <= 0) continue;
+    const name = first.slice(0, eqIdx).trim();
+    if (name !== cookieName) continue;
+    const value = first.slice(eqIdx + 1);
+    return value || null;
+  }
+  return null;
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null;
+}
+
+function extractAccessToken(v: unknown): string | null {
+  if (!isRecord(v)) return null;
+
+  const data = v['data'];
+  if (isRecord(data)) {
+    const at = data['accessToken'];
+    if (typeof at === 'string' && at.length > 0) return at;
+  }
+
+  const at2 = v['accessToken'];
+  if (typeof at2 === 'string' && at2.length > 0) return at2;
+
+  return null;
+}

--- a/apps/admin/src/app/layout.tsx
+++ b/apps/admin/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import '@/shared/styles/globals.css';
-import { GlobalComponents } from '@surf/ui/global-components';
 import type { ReactNode } from 'react';
+import { GlobalComponents } from '@/shared/ui/global-components/GlobalComponents';
 
 const RootLayout = ({ children }: { children: ReactNode }) => {
   return (

--- a/apps/admin/src/app/layout.tsx
+++ b/apps/admin/src/app/layout.tsx
@@ -1,15 +1,12 @@
-import "@/shared/styles/globals.css";
-import type { ReactNode } from "react";
+import '@/shared/styles/globals.css';
+import { GlobalComponents } from '@surf/ui/global-components';
+import type { ReactNode } from 'react';
 
 const RootLayout = ({ children }: { children: ReactNode }) => {
   return (
     <html lang="ko">
       <head>
-        <link
-          rel="preconnect"
-          href="https://cdn.jsdelivr.net"
-          crossOrigin="anonymous"
-        />
+        <link rel="preconnect" href="https://cdn.jsdelivr.net" crossOrigin="anonymous" />
         <link
           rel="preload"
           as="style"
@@ -26,6 +23,7 @@ const RootLayout = ({ children }: { children: ReactNode }) => {
         <main className="bg-background-normal box-content flex h-full w-dvw sm:h-[min(100dvh,calc(100dvw*812/375))] sm:w-[min(100dvw,calc(100dvh*375/812))]">
           {children}
         </main>
+        <GlobalComponents />
       </body>
     </html>
   );

--- a/apps/admin/src/features/auth/api/login.ts
+++ b/apps/admin/src/features/auth/api/login.ts
@@ -1,0 +1,7 @@
+import { axiosInstance } from '@/shared/lib/axiosInstance';
+import { LoginRequest, LoginResponse } from './types';
+
+export async function login(body: LoginRequest): Promise<LoginResponse> {
+  const res = await axiosInstance.post<LoginResponse>('/v1/manager/sign-in', body);
+  return res.data;
+}

--- a/apps/admin/src/features/auth/api/types.ts
+++ b/apps/admin/src/features/auth/api/types.ts
@@ -1,0 +1,17 @@
+import { CommonResponse } from '@/shared/api/types';
+
+export const SERVER_USER_LEVELS = ['ADMIN', 'PRESIDENT', 'MANAGER'] as const;
+export type ServerUserLevel = (typeof SERVER_USER_LEVELS)[number];
+
+export interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+export interface LoginDTO {
+  accessToken: string;
+  username: string;
+  role: ServerUserLevel;
+}
+
+export type LoginResponse = CommonResponse<LoginDTO>;

--- a/apps/admin/src/features/auth/ui/LoginForm.tsx
+++ b/apps/admin/src/features/auth/ui/LoginForm.tsx
@@ -7,6 +7,7 @@ import { Input } from '@surf/ui/input';
 import { useToastStore } from '@surf/ui/store/toastStore';
 
 import { useRouter } from 'next/navigation';
+import { useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 
 import { login } from '../api/login';
@@ -15,8 +16,10 @@ import { PAGE_ROUTES } from '@/shared/config/path';
 import { handleApiError } from '@/shared/lib/handleApiError';
 
 export const LoginForm = () => {
-  const toast = useToastStore((s) => s.show);
   const router = useRouter();
+
+  const toast = useToastStore((s) => s.show);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
 
   const {
     control,
@@ -33,13 +36,18 @@ export const LoginForm = () => {
   });
 
   const onSubmit = async (values: FormValues) => {
+    if (isLoading) return;
+
     const { email, password } = values;
+    setIsLoading(true);
     try {
       await login({ email, password });
       router.push(PAGE_ROUTES.HOME);
     } catch (e) {
       const error = handleApiError(e, '로그인 중 알 수 없는 오류가 발생했습니다.');
       toast(error.message);
+    } finally {
+      setIsLoading(false);
     }
   };
   return (
@@ -97,7 +105,7 @@ export const LoginForm = () => {
         type="submit"
         variant="primary"
         size="l"
-        className="absolute bottom-[1.25rem] left-1/2 -translate-x-1/2"
+        className="absolute bottom-15 left-1/2 -translate-x-1/2"
         isDisabled={!isValid}
       >
         로그인

--- a/apps/admin/src/features/auth/ui/LoginForm.tsx
+++ b/apps/admin/src/features/auth/ui/LoginForm.tsx
@@ -4,14 +4,23 @@ import { SolidButton } from '@surf/ui/button';
 import { FieldGroup } from '@surf/ui/field-group';
 import { Input } from '@surf/ui/input';
 
+import { useToastStore } from '@surf/ui/store/toastStore';
+
+import { useRouter } from 'next/navigation';
 import { Controller, useForm } from 'react-hook-form';
+
+import { login } from '../api/login';
 import { FormValues } from '../model/types';
+import { PAGE_ROUTES } from '@/shared/config/path';
+import { handleApiError } from '@/shared/lib/handleApiError';
 
 export const LoginForm = () => {
+  const toast = useToastStore((s) => s.show);
+  const router = useRouter();
+
   const {
     control,
     handleSubmit,
-
     formState: { errors, isValid },
   } = useForm<FormValues>({
     mode: 'onChange',
@@ -23,9 +32,15 @@ export const LoginForm = () => {
     },
   });
 
-  const onSubmit = (values: FormValues) => {
+  const onSubmit = async (values: FormValues) => {
     const { email, password } = values;
-    console.log(email, password);
+    try {
+      await login({ email, password });
+      router.push(PAGE_ROUTES.HOME);
+    } catch (e) {
+      const error = handleApiError(e, '로그인 중 알 수 없는 오류가 발생했습니다.');
+      toast(error.message);
+    }
   };
   return (
     <form

--- a/apps/admin/src/middleware.ts
+++ b/apps/admin/src/middleware.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const PUBLIC_PREFIX = [
+  '/login',
+  '/login/callback',
+  '/signup',
+  '/favicon.ico',
+  '/_next',
+  '/robots.txt',
+  '/sitemap.xml',
+  '/onboarding',
+];
+const PUBLIC_EXACT = ['/'];
+
+export function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+
+  // API는 통과 (프록시/라우트핸들러)
+  if (pathname.startsWith('/api')) return NextResponse.next();
+
+  // public route 통과
+  if (PUBLIC_EXACT.includes(pathname)) return NextResponse.next();
+  if (PUBLIC_PREFIX.some((p) => pathname.startsWith(p))) return NextResponse.next();
+
+  // optimistic 통과
+  const hasAccess = req.cookies.has('accessToken');
+
+  if (!hasAccess) {
+    return NextResponse.redirect(new URL('/login', req.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)'],
+};

--- a/apps/admin/src/shared/api/types.ts
+++ b/apps/admin/src/shared/api/types.ts
@@ -1,0 +1,30 @@
+export type CommonResponse<T> = {
+  code: number;
+  message: string;
+  data: T;
+};
+
+export interface PageMeta {
+  pageNumber: number;
+  pageSize: number;
+  numberOfElements: number;
+  isLast: boolean;
+}
+
+export type ServerFetchOptions = Omit<globalThis.RequestInit, 'headers'> & {
+  headers?: Record<string, string>;
+};
+
+export type Guard<T> = (x: unknown) => x is T;
+
+export function commonResponseGuard<T>(dataGuard: Guard<T>): Guard<CommonResponse<T>> {
+  return (x: unknown): x is CommonResponse<T> => {
+    if (typeof x !== 'object' || x === null) return false;
+    const obj = x as Record<string, unknown>;
+
+    if (typeof obj.code !== 'number') return false;
+    if (typeof obj.message !== 'string') return false;
+
+    return dataGuard(obj.data);
+  };
+}

--- a/apps/admin/src/shared/lib/axiosInstance.ts
+++ b/apps/admin/src/shared/lib/axiosInstance.ts
@@ -1,0 +1,14 @@
+import axios from 'axios';
+import { retryOnceOn401 } from './retryOnceOn401';
+
+export const axiosInstance = axios.create({
+  baseURL: '/api/proxy',
+  withCredentials: true,
+  timeout: 15000,
+});
+
+// 401이면 1번 재시도
+axiosInstance.interceptors.response.use(
+  (res) => res,
+  (error) => retryOnceOn401(error, axiosInstance),
+);

--- a/apps/admin/src/shared/lib/dal.ts
+++ b/apps/admin/src/shared/lib/dal.ts
@@ -1,0 +1,139 @@
+import 'server-only';
+import { cookies, headers } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { PAGE_ROUTES } from '@/shared/config/path';
+
+const TIMEOUT_MS = 15_000;
+
+const VALID_PATH = '/api/proxy/v1/user/members/valid-status';
+const REFRESH_PATH = '/api/proxy/auth/refresh';
+
+async function fetchWithTimeout(url: string, init: RequestInit) {
+  const controller = new AbortController();
+  const t = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+function isNextRedirectError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false;
+  if (!('digest' in error)) return false;
+
+  const digest = (error as { digest?: unknown }).digest;
+  return typeof digest === 'string' && digest.startsWith('NEXT_REDIRECT');
+}
+
+function safeErrorMessage(e: unknown): string {
+  if (e instanceof Error) return e.message;
+  if (typeof e === 'string') return e;
+  try {
+    return JSON.stringify(e);
+  } catch {
+    return String(e);
+  }
+}
+
+async function getBaseUrl(): Promise<string> {
+  const h = await headers();
+  const host = h.get('host');
+  const proto = h.get('x-forwarded-proto') ?? 'http';
+  return host ? `${proto}://${host}` : 'http://localhost:3000';
+}
+
+function buildCookieHeaderFromStore(all: { name: string; value: string }[]) {
+  return all.map((c) => `${c.name}=${c.value}`).join('; ');
+}
+
+function mergeCookieHeaderWithSetCookie(origHeader: string, setCookies: string[]) {
+  if (!setCookies.length) return origHeader;
+
+  const jar = new Map<string, string>();
+
+  // 기존 Cookie 헤더 파싱
+  for (const part of origHeader.split(';')) {
+    const p = part.trim();
+    if (!p) continue;
+    const eq = p.indexOf('=');
+    if (eq === -1) continue;
+    const name = p.slice(0, eq).trim();
+    const value = p.slice(eq + 1);
+    jar.set(name, value);
+  }
+
+  // Set-Cookie로 받은 쿠키로 덮어쓰기
+  for (const sc of setCookies) {
+    const first = sc.split(';')[0]?.trim();
+    if (!first) continue;
+    const eq = first.indexOf('=');
+    if (eq === -1) continue;
+    const name = first.slice(0, eq).trim();
+    const value = first.slice(eq + 1);
+    jar.set(name, value);
+  }
+
+  // Cookie 헤더로 직렬화
+  return Array.from(jar.entries())
+    .map(([k, v]) => `${k}=${v}`)
+    .join('; ');
+}
+
+function getSetCookieHeaders(res: Response): string[] {
+  const anyHeaders = res.headers as unknown as { getSetCookie?: () => string[] | undefined };
+  if (typeof anyHeaders.getSetCookie === 'function') return anyHeaders.getSetCookie() ?? [];
+
+  const single = res.headers.get('set-cookie');
+  return single ? [single] : [];
+}
+
+export async function verifySession() {
+  try {
+    const baseUrl = await getBaseUrl();
+
+    const cookieStore = await cookies();
+    const cookieHeader = buildCookieHeaderFromStore(cookieStore.getAll());
+
+    const res = await fetchWithTimeout(`${baseUrl}${VALID_PATH}`, {
+      cache: 'no-store',
+      headers: cookieHeader ? { cookie: cookieHeader } : {},
+    });
+
+    // 최초 검증 성공
+    if (res.ok) {
+      return;
+    }
+
+    // 401이면 refresh -> retry
+    if (res.status === 401) {
+      const refresh = await fetchWithTimeout(`${baseUrl}${REFRESH_PATH}`, {
+        method: 'POST',
+        cache: 'no-store',
+        headers: cookieHeader ? { cookie: cookieHeader } : {},
+      });
+
+      if (!refresh.ok) redirect(PAGE_ROUTES.LOGIN);
+
+      const setCookies = getSetCookieHeaders(refresh);
+      const newCookieHeader = mergeCookieHeaderWithSetCookie(cookieHeader, setCookies);
+
+      const retry = await fetchWithTimeout(`${baseUrl}${VALID_PATH}`, {
+        cache: 'no-store',
+        headers: newCookieHeader ? { cookie: newCookieHeader } : {},
+      });
+
+      if (!retry.ok) redirect(PAGE_ROUTES.LOGIN);
+
+      return;
+    }
+
+    console.error(`[Auth] 검증 실패: ${res.status}`);
+    redirect(PAGE_ROUTES.LOGIN);
+  } catch (error: unknown) {
+    if (isNextRedirectError(error)) throw error;
+
+    console.error('[Auth] 예상치 못한 에러:', safeErrorMessage(error));
+    redirect(PAGE_ROUTES.LOGIN);
+  }
+}

--- a/apps/admin/src/shared/lib/handleApiError.ts
+++ b/apps/admin/src/shared/lib/handleApiError.ts
@@ -1,0 +1,66 @@
+import axios from 'axios';
+
+export type DefaultError = {
+  code: number;
+  message: string;
+  errorCode: string;
+};
+
+export type LoginCallBackError = {
+  timestamp: string;
+  path: string;
+  status: number;
+  message: string;
+  error: string;
+  requestId: string;
+};
+
+export type ErrorResponse = DefaultError | LoginCallBackError;
+
+export function handleApiError(
+  error: unknown,
+  defaultMessage = '[Unknown Error] 알 수 없는 에러',
+): Error {
+  if (axios.isAxiosError(error)) {
+    // 백엔드가 응답을 준 경우
+    if (error.response) {
+      const data = error.response.data as ErrorResponse | undefined;
+      let message = defaultMessage;
+
+      if (data) {
+        if ('errorCode' in data) {
+          message = data.message || defaultMessage;
+          console.error(
+            `[Backend Error] ${data.message} (errorCode=${data.errorCode}, code=${data.code})`,
+          );
+        } else if ('requestId' in data) {
+          message = data.message || defaultMessage;
+          console.error(
+            `[Backend Error - LoginCallback] ${data.message} (error=${data.error}, path=${data.path}, requestId=${data.requestId})`,
+          );
+        }
+      }
+
+      return new Error(message);
+    }
+
+    // 요청은 갔지만 응답 없음
+    if (error.request) {
+      console.error('[Network Error] 서버 응답 없음', error.request);
+      return new Error('서버 응답이 없습니다. 네트워크 상태를 확인해주세요.');
+    }
+
+    // axios 설정 문제 등
+    console.error('[Axios Error]', error.message);
+    return new Error(error.message || defaultMessage);
+  }
+
+  // 일반 프론트 코드 에러
+  if (error instanceof Error) {
+    console.error('[Frontend Code Error]', error);
+    return error;
+  }
+
+  console.error('[Unknown Error]', error);
+  return new Error(defaultMessage);
+}

--- a/apps/admin/src/shared/lib/handleApiError.ts
+++ b/apps/admin/src/shared/lib/handleApiError.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { CommonResponse } from '../api/types';
 
 export type DefaultError = {
   code: number;
@@ -6,16 +7,7 @@ export type DefaultError = {
   errorCode: string;
 };
 
-export type LoginCallBackError = {
-  timestamp: string;
-  path: string;
-  status: number;
-  message: string;
-  error: string;
-  requestId: string;
-};
-
-export type ErrorResponse = DefaultError | LoginCallBackError;
+export type ErrorResponse = DefaultError;
 
 export function handleApiError(
   error: unknown,
@@ -24,7 +16,7 @@ export function handleApiError(
   if (axios.isAxiosError(error)) {
     // 백엔드가 응답을 준 경우
     if (error.response) {
-      const data = error.response.data as ErrorResponse | undefined;
+      const data = error.response.data as ErrorResponse | CommonResponse<null>;
       let message = defaultMessage;
 
       if (data) {
@@ -33,10 +25,10 @@ export function handleApiError(
           console.error(
             `[Backend Error] ${data.message} (errorCode=${data.errorCode}, code=${data.code})`,
           );
-        } else if ('requestId' in data) {
+        } else if ('data' in data) {
           message = data.message || defaultMessage;
           console.error(
-            `[Backend Error - LoginCallback] ${data.message} (error=${data.error}, path=${data.path}, requestId=${data.requestId})`,
+            `[Backend Error] ${data.message} (code=${data.code}, message=${data.message})`,
           );
         }
       }

--- a/apps/admin/src/shared/lib/retryOnceOn401.ts
+++ b/apps/admin/src/shared/lib/retryOnceOn401.ts
@@ -1,0 +1,24 @@
+import axios, { type AxiosInstance } from 'axios';
+
+type AxiosConfig = {
+  _retry?: boolean;
+  [key: string]: unknown;
+};
+
+export async function retryOnceOn401(error: unknown, client: AxiosInstance) {
+  // axios 에러인지 먼저 검증
+  if (!axios.isAxiosError(error)) {
+    throw error;
+  }
+
+  const config = (error.config ?? {}) as AxiosConfig;
+  const status = error.response?.status;
+
+  // 401이면 한 번만 재시도
+  if (status === 401 && !config._retry) {
+    config._retry = true;
+    return client.request({ ...config } as Parameters<AxiosInstance['request']>[0]);
+  }
+
+  throw error;
+}

--- a/apps/admin/src/shared/ui/global-components/GlobalComponents.tsx
+++ b/apps/admin/src/shared/ui/global-components/GlobalComponents.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { AlertViewport } from '@surf/ui/alert';
+import { ToastViewport } from '@surf/ui/toast';
+
+export const GlobalComponents = () => {
+  return (
+    <>
+      <ToastViewport />
+      <AlertViewport />
+    </>
+  );
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@surf/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      axios:
+        specifier: ^1.12.2
+        version: 1.13.2
       next:
         specifier: 15.5.9
         version: 15.5.9(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -60,6 +63,9 @@ importers:
       '@chromatic-com/storybook':
         specifier: 4.1.1
         version: 4.1.1(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.3.1(@types/node@20.19.28)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)))
+      '@eslint/js':
+        specifier: ^9.35.0
+        version: 9.39.2
       '@next/eslint-plugin-next':
         specifier: ^15.5.9
         version: 15.5.9
@@ -102,12 +108,30 @@ importers:
       eslint:
         specifier: ^9
         version: 9.39.2(jiti@2.6.1)
+      eslint-config-prettier:
+        specifier: ^10.1.8
+        version: 10.1.8(eslint@9.39.2(jiti@2.6.1))
       eslint-import-resolver-typescript:
         specifier: ^4.4.4
         version: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import:
+        specifier: ^2
+        version: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-jsx-a11y:
+        specifier: ^6
+        version: 6.10.2(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-react:
+        specifier: ^7
+        version: 7.37.5(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-react-hooks:
+        specifier: ^5
+        version: 5.2.0(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-storybook:
         specifier: 9.1.5
         version: 9.1.5(eslint@9.39.2(jiti@2.6.1))(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.3.1(@types/node@20.19.28)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)))(typescript@5.9.2)
+      globals:
+        specifier: ^16.3.0
+        version: 16.5.0
       storybook:
         specifier: 9.1.16
         version: 9.1.16(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.3.1(@types/node@20.19.28)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
@@ -117,6 +141,9 @@ importers:
       typescript:
         specifier: ^5
         version: 5.9.2
+      typescript-eslint:
+        specifier: ^8.42.0
+        version: 8.50.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
       webpack:
         specifier: ^5.102.1
         version: 5.104.1(esbuild@0.25.12)
@@ -354,7 +381,7 @@ importers:
         version: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-import:
         specifier: ^2
-        version: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
+        version: 2.32.0(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-jsx-a11y:
         specifier: ^6
         version: 6.10.2(eslint@9.39.1(jiti@2.6.1))
@@ -9843,6 +9870,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/eslint-plugin@8.50.0(@typescript-eslint/parser@8.50.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.50.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
+      '@typescript-eslint/scope-manager': 8.50.0
+      '@typescript-eslint/type-utils': 8.50.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.50.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
+      '@typescript-eslint/visitor-keys': 8.50.0
+      eslint: 9.39.2(jiti@2.6.1)
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.1.0(typescript@5.9.2)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/parser@8.50.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.50.0
@@ -9851,6 +9894,18 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.50.0
       debug: 4.4.3
       eslint: 9.39.1(jiti@2.6.1)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.50.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.50.0
+      '@typescript-eslint/types': 8.50.0
+      '@typescript-eslint/typescript-estree': 8.50.0(typescript@5.9.2)
+      '@typescript-eslint/visitor-keys': 8.50.0
+      debug: 4.4.3
+      eslint: 9.39.2(jiti@2.6.1)
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
@@ -9880,6 +9935,18 @@ snapshots:
       '@typescript-eslint/utils': 8.50.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.2)
       debug: 4.4.3
       eslint: 9.39.1(jiti@2.6.1)
+      ts-api-utils: 2.1.0(typescript@5.9.2)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/type-utils@8.50.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)':
+    dependencies:
+      '@typescript-eslint/types': 8.50.0
+      '@typescript-eslint/typescript-estree': 8.50.0(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.50.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
+      debug: 4.4.3
+      eslint: 9.39.2(jiti@2.6.1)
       ts-api-utils: 2.1.0(typescript@5.9.2)
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -11234,6 +11301,10 @@ snapshots:
     dependencies:
       eslint: 9.39.1(jiti@2.6.1)
 
+  eslint-config-prettier@10.1.8(eslint@9.39.2(jiti@2.6.1)):
+    dependencies:
+      eslint: 9.39.2(jiti@2.6.1)
+
   eslint-import-context@0.1.9(unrs-resolver@1.11.1):
     dependencies:
       get-tsconfig: 4.13.0
@@ -11290,7 +11361,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -11305,44 +11376,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
+      '@typescript-eslint/parser': 8.50.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
-      '@rtsao/scc': 1.1.0
-      array-includes: 3.1.9
-      array.prototype.findlastindex: 1.2.6
-      array.prototype.flat: 1.3.3
-      array.prototype.flatmap: 1.3.3
       debug: 3.2.7
-      doctrine: 2.1.0
+    optionalDependencies:
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1))
-      hasown: 2.0.2
-      is-core-module: 2.16.1
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.1
-      semver: 6.3.1
-      string.prototype.trimend: 1.0.9
-      tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.50.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.2)
+      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
     transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
       - supports-color
 
   eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1)):
@@ -11374,7 +11426,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -11385,7 +11437,36 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.6.1))
+      hasown: 2.0.2
+      is-core-module: 2.16.1
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.9
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.50.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1)):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 9.39.1(jiti@2.6.1)
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -11400,7 +11481,6 @@ snapshots:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
-    optional: true
 
   eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
@@ -11421,9 +11501,32 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
+  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.2(jiti@2.6.1)):
+    dependencies:
+      aria-query: 5.3.2
+      array-includes: 3.1.9
+      array.prototype.flatmap: 1.3.3
+      ast-types-flow: 0.0.8
+      axe-core: 4.11.1
+      axobject-query: 4.1.0
+      damerau-levenshtein: 1.0.8
+      emoji-regex: 9.2.2
+      eslint: 9.39.2(jiti@2.6.1)
+      hasown: 2.0.2
+      jsx-ast-utils: 3.3.5
+      language-tags: 1.0.9
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      safe-regex-test: 1.1.0
+      string.prototype.includes: 2.0.1
+
   eslint-plugin-react-hooks@5.2.0(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       eslint: 9.39.1(jiti@2.6.1)
+
+  eslint-plugin-react-hooks@5.2.0(eslint@9.39.2(jiti@2.6.1)):
+    dependencies:
+      eslint: 9.39.2(jiti@2.6.1)
 
   eslint-plugin-react@7.37.5(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
@@ -11434,6 +11537,28 @@ snapshots:
       doctrine: 2.1.0
       es-iterator-helpers: 1.2.1
       eslint: 9.39.1(jiti@2.6.1)
+      estraverse: 5.3.0
+      hasown: 2.0.2
+      jsx-ast-utils: 3.3.5
+      minimatch: 3.1.2
+      object.entries: 1.1.9
+      object.fromentries: 2.0.8
+      object.values: 1.2.1
+      prop-types: 15.8.1
+      resolve: 2.0.0-next.5
+      semver: 6.3.1
+      string.prototype.matchall: 4.0.12
+      string.prototype.repeat: 1.0.0
+
+  eslint-plugin-react@7.37.5(eslint@9.39.2(jiti@2.6.1)):
+    dependencies:
+      array-includes: 3.1.9
+      array.prototype.findlast: 1.2.5
+      array.prototype.flatmap: 1.3.3
+      array.prototype.tosorted: 1.1.4
+      doctrine: 2.1.0
+      es-iterator-helpers: 1.2.1
+      eslint: 9.39.2(jiti@2.6.1)
       estraverse: 5.3.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
@@ -14525,6 +14650,17 @@ snapshots:
       '@typescript-eslint/typescript-estree': 8.50.0(typescript@5.9.2)
       '@typescript-eslint/utils': 8.50.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.2)
       eslint: 9.39.1(jiti@2.6.1)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
+  typescript-eslint@8.50.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.50.0(@typescript-eslint/parser@8.50.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
+      '@typescript-eslint/parser': 8.50.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
+      '@typescript-eslint/typescript-estree': 8.50.0(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.50.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
+      eslint: 9.39.2(jiti@2.6.1)
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 any가 사용되지 않았습니다
- [x] 스토리북에 추가했습니다 (해당 시)
- [x] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈

- close #414 
- close #427 

## 📌 작업 목적

- 서버 API 연동을 위해 axiosInstance, 프록시 로직 등 네트워크 레이어 로직 구성하였고, 로그인 API 연동하여 로그인 기능 완료했습니다. 

## 🔨 주요 작업 내용

- route handler 기반 프록시 로직 구성
- axiosInstance 구성 및 공통 에러 핸들러 로직 구성
- protected layout 최상단에 세션 검증 로직 구성
- accessToken 체킹 미들웨어 로직 구성
- 로그인 API 연동 및 테스트
- 에러 처리를 위해 toast, alert UI 전역 레이아웃에 추가 


## 🧪 테스트 방법

- `pnpm dev:admin` 
- 사이트 접속 후 로그인 화면 리다이렉트 되는지 확인
- 로그인 시 홈 화면 이동 확인 

## ✔️ 설치 라이브러리

- @surf/eslint-config peer dependency에 포함되는 라이브러리 설치
- http 통신을 위해 `axios`설치 

## 📷 실행 영상 또는 스크린샷
- 유저가 없을 경우 
<img width="500"  alt="image" src="https://github.com/user-attachments/assets/a92fe132-247e-4901-88b9-8769a94bb4d9" />

- 비밀번호 에러

<img width="500"  alt="image" src="https://github.com/user-attachments/assets/5ed8151a-2a9b-4388-8c97-8f26fabd4fef" />



## 💬 논의할 점

- web 프로젝트의 `handleApiError` 에러 핸들링 로직 그대로 가져다 쓰려다가, 로그인 에러 응답 형식은 또 달라서 수정 진행했습니다.
- 로그인 에러의 경우 필드가 `code`, `message`, `data`로 되어 있는데, 서버와 합의된 에러 응답 형식이 정해져 있는지 궁금합니다!



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 관리자 앱에 API 프록시 및 인증 토큰 전달 지원 추가
  * 보호된 경로에서의 세션 검증 및 전역 접근 제어 미들웨어 도입
  * 로그인 API 연동 및 로그인 폼에 성공/실패 처리(네비게이션·토스트) 추가
  * 전역 UI 뷰포트(토스트·알림) 통합

* **Chores**
  * axios 기반 HTTP 클라이언트 설정 및 401 재시도 로직 추가
  * 린트 및 개발 도구(ESLint 관련) 의존성 확장

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->