### PR TITLE
[FIX] 일정 카테고리 통일

### DIFF
--- a/apps/web/src/app-pages/home/ui/HomePageClient.tsx
+++ b/apps/web/src/app-pages/home/ui/HomePageClient.tsx
@@ -58,7 +58,7 @@ export const HomePageClient = ({ heroProps }: { heroProps: HeroCardProps }) => {
           <AnnouncementBar
             title={homeData?.announcementTitle ?? 'Title'}
             date={homeData?.announcementDate ?? '00.00'}
-            category="official" // 카테고리 데이터 필요 {homeData?.announcementCategory ?? 'official'}
+            category="regular" // 카테고리 데이터 필요 {homeData?.announcementCategory ?? 'regular'}
             onClick={() => {
               if (!deepLink) {
                 if (process.env.NODE_ENV === 'development') {

--- a/apps/web/src/app-pages/home/ui/HomePageClient.tsx
+++ b/apps/web/src/app-pages/home/ui/HomePageClient.tsx
@@ -56,8 +56,8 @@ export const HomePageClient = ({ heroProps }: { heroProps: HeroCardProps }) => {
         <div className="flex flex-col gap-16 px-13 pt-15">
           {/* Announcement Bar */}
           <AnnouncementBar
-            title={homeData?.announcementTitle ?? '타이틀 제목 없음'}
-            date={homeData?.announcementDate ?? '날짜없음'}
+            title={homeData?.announcementTitle ?? 'Title'}
+            date={homeData?.announcementDate ?? '00.00'}
             category="official" // 카테고리 데이터 필요 {homeData?.announcementCategory ?? 'official'}
             onClick={() => {
               if (!deepLink) {

--- a/apps/web/src/entities/calendar/model/types.ts
+++ b/apps/web/src/entities/calendar/model/types.ts
@@ -1,9 +1,10 @@
-export type ActivityCategory = 'regular' | 'operation' | 'other';
+import { ScheduleCategory } from '@/entities/schedule/model/types';
+
 export type EventCardType = 'reservation' | 'calendar';
 
 export type DailyActivity = {
   id: number;
-  category: ActivityCategory;
+  category: ScheduleCategory;
   title: string;
   startDate: Date | null;
   endDate: Date | null;

--- a/apps/web/src/entities/calendar/model/types.ts
+++ b/apps/web/src/entities/calendar/model/types.ts
@@ -1,4 +1,4 @@
-export type ActivityCategory = 'official' | 'operation' | 'other';
+export type ActivityCategory = 'regular' | 'operation' | 'other';
 export type EventCardType = 'reservation' | 'calendar';
 
 export type DailyActivity = {

--- a/apps/web/src/entities/calendar/ui/CalendarActivityBadge/CalendarActivityBadge.stories.tsx
+++ b/apps/web/src/entities/calendar/ui/CalendarActivityBadge/CalendarActivityBadge.stories.tsx
@@ -51,7 +51,7 @@ type Story = StoryObj<typeof CalendarActivityBadge>;
 // ───────────────────────────────
 export const Official: Story = {
   args: {
-    item: createDummyItem('official', '공식 일정'),
+    item: createDummyItem('regular', '공식 일정'),
   },
 };
 
@@ -72,7 +72,7 @@ export const Other: Story = {
 // ───────────────────────────────
 export const NotCurrentMonth: Story = {
   args: {
-    item: createDummyItem('official', '이전/다음 달 일정'),
+    item: createDummyItem('regular', '이전/다음 달 일정'),
     isCurrentMonth: false,
   },
 };
@@ -97,10 +97,7 @@ export const AllVariations: Story = {
   render: () => (
     <div className="flex w-[150px] flex-col gap-4">
       <div className="text-sm font-bold">Current Month</div>
-      <CalendarActivityBadge
-        item={createDummyItem('official', '공식 일정')}
-        isCurrentMonth={true}
-      />
+      <CalendarActivityBadge item={createDummyItem('regular', '공식 일정')} isCurrentMonth={true} />
       <CalendarActivityBadge
         item={createDummyItem('operation', '운영 일정')}
         isCurrentMonth={true}
@@ -109,7 +106,7 @@ export const AllVariations: Story = {
 
       <div className="mt-4 text-sm font-bold">Other Month (Opacity 50%)</div>
       <CalendarActivityBadge
-        item={createDummyItem('official', '공식 일정')}
+        item={createDummyItem('regular', '공식 일정')}
         isCurrentMonth={false}
       />
       <CalendarActivityBadge

--- a/apps/web/src/entities/calendar/ui/CalendarActivityBadge/CalendarActivityBadge.tsx
+++ b/apps/web/src/entities/calendar/ui/CalendarActivityBadge/CalendarActivityBadge.tsx
@@ -3,13 +3,13 @@ import type { DailyActivity } from '@/entities/calendar/model/types';
 type Props = { item: DailyActivity; isCurrentMonth?: boolean };
 
 const labelByType: Record<DailyActivity['category'], string> = {
-  official: '정규행사',
+  regular: '정규행사',
   operation: '운영회의',
   other: '기타일정',
 };
 
 const colorByType: Record<DailyActivity['category'], string> = {
-  official: 'bg-background-badge-pink text-foreground-badge-pink-darker',
+  regular: 'bg-background-badge-pink text-foreground-badge-pink-darker',
   operation: 'bg-background-badge-purple text-foreground-badge-purple-darker',
   other: 'bg-background-badge-green text-foreground-badge-green-darker',
 };

--- a/apps/web/src/entities/calendar/ui/CalendarBadge/CalendarBadge.stories.tsx
+++ b/apps/web/src/entities/calendar/ui/CalendarBadge/CalendarBadge.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<typeof CalendarBadge> = {
   argTypes: {
     variation: {
       control: 'radio',
-      options: ['official', 'operation', 'other'],
+      options: ['regular', 'operation', 'other'],
       description: '일정의 유형에 따라 색상과 스타일이 다르게 표시됩니다.',
     },
   },
@@ -22,9 +22,9 @@ type Story = StoryObj<typeof CalendarBadge>;
 // ───────────────────────────────
 // 기본 상태들
 // ───────────────────────────────
-export const Official: Story = {
+export const Regular: Story = {
   args: {
-    variation: 'official',
+    variation: 'regular',
   },
 };
 
@@ -46,7 +46,7 @@ export const Etc: Story = {
 export const AllVariations: Story = {
   render: () => (
     <div className="flex gap-8">
-      <CalendarBadge variation="official" />
+      <CalendarBadge variation="regular" />
       <CalendarBadge variation="operation" />
       <CalendarBadge variation="other" />
     </div>

--- a/apps/web/src/entities/calendar/ui/CalendarBadge/CalendarBadge.tsx
+++ b/apps/web/src/entities/calendar/ui/CalendarBadge/CalendarBadge.tsx
@@ -1,9 +1,9 @@
 type CalendarBadgeProps = {
-  variation: 'official' | 'operation' | 'other';
+  variation: 'regular' | 'operation' | 'other';
 };
 
 const BADGE_STYLE = {
-  official: {
+  regular: {
     text: '정규행사',
     color:
       'bg-background-badge-pink text-foreground-badge-pink shadow-[inset_0_0_10px_0_var(--background-tag-pink-darker,rgba(255,112,172,0.1))]',

--- a/apps/web/src/entities/calendar/ui/DailyActivityBadgeList/DailyActivityBadgeList.stories.tsx
+++ b/apps/web/src/entities/calendar/ui/DailyActivityBadgeList/DailyActivityBadgeList.stories.tsx
@@ -3,7 +3,7 @@ import { DailyActivityBadgeList } from './DailyActivityBadgeList';
 import type { DailyActivity } from '@/entities/calendar/model/types';
 
 const createDummyItems = (count: number): DailyActivity[] => {
-  const types: DailyActivity['category'][] = ['official', 'operation', 'other'];
+  const types: DailyActivity['category'][] = ['regular', 'operation', 'other'];
   return Array.from({ length: count }, (_, i) => ({
     id: i,
     category: types[i % 3],

--- a/apps/web/src/entities/calendar/ui/DayChipRadio/DayChipRadio.stories.tsx
+++ b/apps/web/src/entities/calendar/ui/DayChipRadio/DayChipRadio.stories.tsx
@@ -34,13 +34,13 @@ const createMockDay = (date: Date, displayMonth: Date = TODAY): CalendarDay => {
 // mock 데이터
 const mockActivityMap: ActivityMap = {
   [toYmd(TODAY)]: [
-    createActivity(1, 'official', '오늘 공식 일정'),
+    createActivity(1, 'regular', '오늘 공식 일정'),
     createActivity(2, 'operation', '오늘 운영 회의'),
     createActivity(3, 'other', '추가 일정 (더보기)'),
   ],
   [toYmd(TOMORROW)]: [
-    createActivity(4, 'official', '내일 일정 하나'),
-    createActivity(5, 'official', '내일 일정 하나'),
+    createActivity(4, 'regular', '내일 일정 하나'),
+    createActivity(5, 'regular', '내일 일정 하나'),
   ],
   [toYmd(PREV_MONTH_DAY)]: [createActivity(6, 'other', '지난달 일정')],
 };

--- a/apps/web/src/entities/calendar/ui/EventCard/EventCard.stories.tsx
+++ b/apps/web/src/entities/calendar/ui/EventCard/EventCard.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/nextjs';
-import type { ActivityCategory, EventCardType } from '../../model/types';
+import type { EventCardType } from '../../model/types';
 import { EventCard } from './EventCard';
+import { ScheduleCategory } from '@/entities/schedule/model/types';
 
 // 더미 데이터
 const SAMPLE_START_DATE = new Date('2025-11-08T14:00:00');
@@ -20,7 +21,7 @@ const meta: Meta<typeof EventCard> = {
     },
     category: {
       control: 'radio',
-      options: ['official', 'operation', 'other'] as ActivityCategory[],
+      options: ['official', 'operation', 'other'] as ScheduleCategory[],
       description: '이벤트 태그의 종류',
     },
     mode: {

--- a/apps/web/src/entities/calendar/ui/EventCard/EventCard.stories.tsx
+++ b/apps/web/src/entities/calendar/ui/EventCard/EventCard.stories.tsx
@@ -53,7 +53,7 @@ const meta: Meta<typeof EventCard> = {
   },
   args: {
     title: '후반기 만남의 장',
-    category: 'official',
+    category: 'regular',
     mode: 'calendar',
     startDate: SAMPLE_START_DATE,
     endDate: SAMPLE_END_DATE,

--- a/apps/web/src/entities/calendar/ui/EventCard/EventCard.tsx
+++ b/apps/web/src/entities/calendar/ui/EventCard/EventCard.tsx
@@ -2,14 +2,15 @@
 
 import { SurfIcon } from '@surf/ui/icon';
 import { useState } from 'react';
-import { ActivityCategory, EventCardType } from '@/entities/calendar/model/types';
+import { EventCardType } from '@/entities/calendar/model/types';
 import { CalendarBadge } from '@/entities/calendar/ui/CalendarBadge/CalendarBadge';
 import { formatScheduleDate } from '@/entities/calendar/utils/formatScheduleDate';
+import { ScheduleCategory } from '@/entities/schedule/model/types';
 import { ScheduleActionSheet } from '@/features/schedule/ui/ScheduleActionSheet/ScheduleActionSheet';
 
 /**
  * 이벤트 카드 컴포넌트
- * @param category - 일정 이벤트 유형 (ActivityCategory: 'official', 'operation', 'other' 중 하나)
+ * @param category - 일정 이벤트 유형 (ScheduleCategory: 'regular', 'operation', 'other' 중 하나)
  * @param scheduleId - 일정 ID (바텀 시트 오픈 시 필요)
  * @param title - 일정 이벤트 제목
  * @param startDate - 일정 이벤트 시작 날짜 (Date 객체)
@@ -23,7 +24,7 @@ import { ScheduleActionSheet } from '@/features/schedule/ui/ScheduleActionSheet/
  * @param mode - 이벤트 카드 모드 (EventCardType: 'reservation', 'calendar' 중 하나)
  */
 export type EventCardProps = {
-  category: ActivityCategory;
+  category: ScheduleCategory;
   scheduleId?: string | number;
   title: string;
   startDate: Date | null;

--- a/apps/web/src/entities/calendar/ui/EventDateCard/EventDateCard.stories.tsx
+++ b/apps/web/src/entities/calendar/ui/EventDateCard/EventDateCard.stories.tsx
@@ -50,7 +50,7 @@ const meta: Meta<typeof EventDateCard<EventItem>> = {
       {
         id: '1',
         title: '후반기 만남의 장',
-        category: 'official',
+        category: 'regular',
         mode: 'calendar',
         startDate: new Date('2025-11-20T10:00:00'),
         endDate: new Date('2025-11-21T18:00:00'),
@@ -96,7 +96,7 @@ export const MixedCases: Story = {
       {
         id: '1',
         title: '일반 회원 보기 (공지 있음)',
-        category: 'official',
+        category: 'regular',
         mode: 'calendar',
         startDate: new Date(),
         endDate: new Date(),

--- a/apps/web/src/entities/calendar/ui/EventDateCard/EventDateCard.stories.tsx
+++ b/apps/web/src/entities/calendar/ui/EventDateCard/EventDateCard.stories.tsx
@@ -1,12 +1,13 @@
 import type { Meta, StoryObj } from '@storybook/nextjs';
-import type { ActivityCategory, EventCardType } from '../../model/types';
+import type { EventCardType } from '../../model/types';
 import { EventCard } from '../EventCard/EventCard';
 import { EventDateCard } from './EventDateCard';
+import { ScheduleCategory } from '@/entities/schedule/model/types';
 
 type EventItem = {
   id: string;
   title: string;
-  category: ActivityCategory;
+  category: ScheduleCategory;
   mode: EventCardType;
   startDate?: Date | null;
   endDate?: Date | null;

--- a/apps/web/src/entities/post/api/types.ts
+++ b/apps/web/src/entities/post/api/types.ts
@@ -1,4 +1,5 @@
 // API 공통 응답 형식
+import { ActivityCategory } from '@/entities/calendar/model/types';
 import { CommonResponse } from '@/shared/api/types';
 
 // 게시글 상세 이미지 타입
@@ -82,7 +83,7 @@ export type PostDetailResponse = CommonResponse<PostDetailData>;
 // 특정 게시글의 일정
 export type PostScheduleData = {
   scheduleId: number;
-  category: string;
+  category: ActivityCategory;
   title: string;
   startAt: string;
   endAt: string;

--- a/apps/web/src/entities/post/api/types.ts
+++ b/apps/web/src/entities/post/api/types.ts
@@ -1,5 +1,5 @@
 // API 공통 응답 형식
-import { ActivityCategory } from '@/entities/calendar/model/types';
+import { ScheduleCategory } from '@/entities/schedule/model/types';
 import { CommonResponse } from '@/shared/api/types';
 
 // 게시글 상세 이미지 타입
@@ -83,7 +83,7 @@ export type PostDetailResponse = CommonResponse<PostDetailData>;
 // 특정 게시글의 일정
 export type PostScheduleData = {
   scheduleId: number;
-  category: ActivityCategory;
+  category: ScheduleCategory;
   title: string;
   startAt: string;
   endAt: string;

--- a/apps/web/src/entities/schedule/ui/announcement-bar/AnnouncementBar.stories.tsx
+++ b/apps/web/src/entities/schedule/ui/announcement-bar/AnnouncementBar.stories.tsx
@@ -1,8 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/nextjs';
+import { ScheduleCategory } from '../../model/types';
 import { AnnouncementBar } from './AnnouncementBar';
-import type { ActivityCategory } from '@/entities/calendar/model/types';
 
-const CATEGORY_OPTIONS: ActivityCategory[] = ['regular', 'operation', 'other'];
+const CATEGORY_OPTIONS: ScheduleCategory[] = ['regular', 'operation', 'other'];
 
 const meta: Meta<typeof AnnouncementBar> = {
   title: 'Entities/UI/Schedule/AnnouncementBar',

--- a/apps/web/src/entities/schedule/ui/announcement-bar/AnnouncementBar.stories.tsx
+++ b/apps/web/src/entities/schedule/ui/announcement-bar/AnnouncementBar.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs';
 import { AnnouncementBar } from './AnnouncementBar';
 import type { ActivityCategory } from '@/entities/calendar/model/types';
 
-const CATEGORY_OPTIONS: ActivityCategory[] = ['official', 'operation', 'other'];
+const CATEGORY_OPTIONS: ActivityCategory[] = ['regular', 'operation', 'other'];
 
 const meta: Meta<typeof AnnouncementBar> = {
   title: 'Entities/UI/Schedule/AnnouncementBar',
@@ -26,6 +26,6 @@ export const Default: Story = {
   args: {
     title: '후반기 만남의 장 공지',
     date: '12.31',
-    category: 'official',
+    category: 'regular',
   },
 };

--- a/apps/web/src/entities/schedule/ui/announcement-bar/AnnouncementBar.tsx
+++ b/apps/web/src/entities/schedule/ui/announcement-bar/AnnouncementBar.tsx
@@ -1,10 +1,10 @@
-import { ActivityCategory } from '@/entities/calendar/model/types';
+import { ScheduleCategory } from '../../model/types';
 import { CalendarBadge } from '@/entities/calendar/ui/CalendarBadge/CalendarBadge';
 
 interface AnnouncementBarProps {
   title: string;
   date: string;
-  category: ActivityCategory;
+  category: ScheduleCategory;
   onClick?: () => void;
 }
 

--- a/apps/web/src/features/calendar/api/types.ts
+++ b/apps/web/src/features/calendar/api/types.ts
@@ -1,4 +1,4 @@
-import { ActivityCategory } from '@/entities/calendar/model/types';
+import { ScheduleCategory } from '@/entities/schedule/model/types';
 import { CommonResponse } from '@/shared/api/types';
 
 // 캘린더 일정 조회 api params 타입
@@ -10,7 +10,7 @@ export type CalendarScheduleRequest = {
 // 단일 일정 조회 응답 api DTO 타입
 export type scheduleResDTO = {
   scheduleId: number;
-  category: ActivityCategory;
+  category: ScheduleCategory;
   title: string;
   startAt: string;
   endAt: string;

--- a/apps/web/src/features/calendar/api/types.ts
+++ b/apps/web/src/features/calendar/api/types.ts
@@ -1,3 +1,4 @@
+import { ActivityCategory } from '@/entities/calendar/model/types';
 import { CommonResponse } from '@/shared/api/types';
 
 // 캘린더 일정 조회 api params 타입
@@ -9,7 +10,7 @@ export type CalendarScheduleRequest = {
 // 단일 일정 조회 응답 api DTO 타입
 export type scheduleResDTO = {
   scheduleId: number;
-  category: string;
+  category: ActivityCategory;
   title: string;
   startAt: string;
   endAt: string;

--- a/apps/web/src/features/calendar/model/mapper.ts
+++ b/apps/web/src/features/calendar/model/mapper.ts
@@ -1,24 +1,7 @@
 import { format, eachDayOfInterval, isValid } from 'date-fns';
 import { scheduleResDTO } from '../api/types';
-import { ActivityCategory } from '@/entities/calendar/model/types';
 import { ActivityMap } from '@/entities/calendar/model/types';
 import { EventCardProps } from '@/entities/calendar/ui/EventCard/EventCard';
-
-/**
- * 서버에서 내려주는 카테고리 문자열을 UI에서 사용하는 ActivityCategory로 변환
- */
-export const mapCategoryToActivityCategory = (category: string): ActivityCategory => {
-  switch (category) {
-    case '정규행사':
-      return 'official';
-    case '운영회의':
-      return 'operation';
-    case '기타일정':
-      return 'other';
-    default:
-      return 'official';
-  }
-};
 
 /**
  * 단일 DTO를 UI에서 사용하는 일정 객체로 변환
@@ -27,7 +10,7 @@ const mapDTOToEvent = (dto: scheduleResDTO): EventCardProps => {
   return {
     scheduleId: dto.scheduleId,
     title: dto.title,
-    category: mapCategoryToActivityCategory(dto.category),
+    category: dto.category,
     startDate: new Date(dto.startAt),
     endDate: new Date(dto.endAt),
     location: dto.location,

--- a/apps/web/src/features/schedule/create/api/mapper.ts
+++ b/apps/web/src/features/schedule/create/api/mapper.ts
@@ -1,19 +1,5 @@
 import type { ScheduleFormData } from '../model/types';
-import type { ScheduleCategory } from '@/entities/schedule/model/types';
 import type { ScheduleCreateRequest } from '@/entities/schedule/model/types';
-
-function categoryToLabel(category: string): string {
-  switch (category) {
-    case 'regular':
-      return '정규행사';
-    case 'operation':
-      return '운영회의';
-    case 'other':
-      return '기타일정';
-    default:
-      return '정규행사';
-  }
-}
 
 export function toFormLocation(location: string | null | undefined): string {
   return location === '미정' ? '' : (location ?? '');
@@ -28,7 +14,7 @@ export function toServerLocation(location: string | null | undefined): string {
 
 export function mapScheduleFormToRequest(form: ScheduleFormData): ScheduleCreateRequest {
   return {
-    category: categoryToLabel(form.category) as ScheduleCategory,
+    category: form.category,
     title: form.title,
     startAt: form.startDate.toISOString(),
     endAt: form.endDate.toISOString(),

--- a/apps/web/src/features/schedule/edit/api/types.ts
+++ b/apps/web/src/features/schedule/edit/api/types.ts
@@ -16,7 +16,7 @@ export type EditScheduleResponse = CommonResponse<void>;
 // 일정 단건 type
 export type SingleSchedule = {
   scheduleId: number;
-  category: string;
+  category: ScheduleCategory;
   title: string;
   startAt: string;
   endAt: string;

--- a/apps/web/src/widgets/post-detail/PostBodySection.tsx
+++ b/apps/web/src/widgets/post-detail/PostBodySection.tsx
@@ -7,7 +7,6 @@ import { PostScheduleData } from '@/entities/post/api/types';
 import { PostDetail } from '@/entities/post/model/types';
 import { PostImage } from '@/entities/post/ui/post-image/PostImage';
 import { PostProfile } from '@/entities/post/ui/post-profile/PostProfile';
-import { mapCategoryToActivityCategory } from '@/features/calendar/model/mapper';
 import { useToggleLikeMutation } from '@/features/post/model/useToggleLikeMutation';
 import { useToggleScrapMutation } from '@/features/post/model/useToggleScrapMutation';
 
@@ -72,7 +71,7 @@ export const PostBodySection = ({ post, schedule, onClickLikeCount }: PostBodySe
         <EventCard
           scheduleId={schedule.scheduleId}
           title={schedule.title}
-          category={mapCategoryToActivityCategory(schedule.category)}
+          category={schedule.category}
           mode="reservation"
           location={schedule.location}
           startDate={new Date(schedule.startAt)}

--- a/apps/web/src/widgets/post/post-editor/PostEditor.tsx
+++ b/apps/web/src/widgets/post/post-editor/PostEditor.tsx
@@ -5,12 +5,10 @@ import { EditorContent } from '@tiptap/react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import '@/features/post/post-editor/ui/PostEditor.style.css';
-import { ActivityCategory } from '@/entities/calendar/model/types';
 import { EventCard } from '@/entities/calendar/ui/EventCard/EventCard';
 import { UploadImage } from '@/entities/image/model/types';
 import { POST_VALIDATION } from '@/entities/post/model/validation';
 import { ImageList } from '@/entities/post/post-image/ui/ImageList';
-import { ScheduleCategory } from '@/entities/schedule/model/types';
 import { useImageManager } from '@/features/image/model/useImageManager';
 import { usePostEditor } from '@/features/post/post-editor/lib/usePostEditor';
 import { PostEditorToolbar } from '@/features/post/post-editor/ui/PostEditorToolbar';
@@ -171,16 +169,10 @@ export const PostEditor = ({
   const renderScheduleCard = () => {
     if (!linkedSchedule) return null;
 
-    const categoryMap: Record<ScheduleCategory, ActivityCategory> = {
-      regular: 'official',
-      operation: 'operation',
-      other: 'other',
-    };
-
     return (
       <div className="p-13">
         <EventCard
-          category={categoryMap[linkedSchedule.category]}
+          category={linkedSchedule.category}
           title={linkedSchedule.title}
           startDate={linkedSchedule.startDate}
           endDate={linkedSchedule.endDate}


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 any가 사용되지 않았습니다
- [x] 스토리북에 추가했습니다 (해당 시)
- [x] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈
- close #433 

## ⚠️ 기존 문제
- 일정 카테고리가 한글/영어가 혼재되어 사용되어 홈 화면의 AnnounceBar에 공지사항 일정이 나오지 않는 문제

## ☑️ 해결 방법
- 일정 카테고리는 'regular' | 'operation' | 'other' 로 통일
- 불필요하게 한글로 변환하는 코드들은 모두 삭제
- string/ActivityCategory로 일정의 category 타입을 정의한 것 모두 ScheduleCategory로 통일

## 🧪 테스트 방법
- 캘린더 화면에서 일정을 생성한 후 콘솔에 불러와진 일정 데이터의 카테고리가 모두 영문인지 확인

## ✔️ 설치 라이브러리
-

## 📷 실행 영상 또는 스크린샷
-

## 💬 논의할 점
-

## 🙋🏻 참고 자료
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 캘린더 활동 배지의 카테고리 표시가 "공식"에서 "정규"로 변경되었습니다.
  * 공지 바의 기본 제목, 날짜, 카테고리 값이 업데이트되었습니다.
  * 일정 카테고리 라벨 및 배지 스타일이 조정되었습니다.

* **리팩터링**
  * 카테고리 타입 체계가 통합 및 단순화되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->