### PR TITLE
[FIX] 게시글 상세 화면에서 일정 카드 클릭 시 캘린더 화면으로 이동 

### DIFF
--- a/apps/web/src/app-pages/calendar/ui/CalendarPage.tsx
+++ b/apps/web/src/app-pages/calendar/ui/CalendarPage.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
 import { useState } from 'react';
 import { PostFab } from '@/entities/post/ui/post-fab/PostFab';
 import { useAuthStore } from '@/features/auth/model/useAuthStore';
@@ -10,7 +11,14 @@ import { Calendar } from '@/widgets/calendar/ui/Calendar';
 
 export const CalendarPage = () => {
   const router = useRouter();
-  const [month, setMonth] = useState<Date>(new Date());
+  const searchParams = useSearchParams();
+  const dateParam = searchParams.get('date');
+
+  const initialDate = dateParam ? new Date(dateParam) : new Date();
+  const isValidDate = !isNaN(initialDate.getTime());
+  const targetDate = isValidDate ? initialDate : new Date();
+
+  const [month, setMonth] = useState<Date>(targetDate);
 
   const memberRole = useAuthStore((s) => s.memberRole);
 
@@ -26,7 +34,12 @@ export const CalendarPage = () => {
   return (
     <div className="relative h-full w-full overflow-hidden">
       <div className="h-full w-full overflow-y-auto">
-        <Calendar month={month} onMonthChange={setMonth} schedules={schedules} />
+        <Calendar
+          month={month}
+          onMonthChange={setMonth}
+          schedules={schedules}
+          initialSelectedDate={targetDate}
+        />
       </div>
 
       {memberRole !== 'member' && (

--- a/apps/web/src/entities/calendar/ui/EventCard/EventCard.tsx
+++ b/apps/web/src/entities/calendar/ui/EventCard/EventCard.tsx
@@ -54,9 +54,7 @@ export const EventCard = ({
   const [isActionSheetOpen, setIsActionSheetOpen] = useState(false);
 
   const handleCardClick = () => {
-    if (mode === 'calendar') {
-      onClickCard?.();
-    }
+    onClickCard?.();
   };
 
   const handleDeleteSchedule = () => {

--- a/apps/web/src/widgets/calendar/ui/Calendar.tsx
+++ b/apps/web/src/widgets/calendar/ui/Calendar.tsx
@@ -52,11 +52,17 @@ type CalendarProps = {
   month: Date;
   onMonthChange: (date: Date) => void;
   schedules: ActivityMap;
+  initialSelectedDate?: Date;
 };
 
-export const Calendar = ({ month, onMonthChange, schedules }: CalendarProps) => {
+export const Calendar = ({
+  month,
+  onMonthChange,
+  schedules,
+  initialSelectedDate,
+}: CalendarProps) => {
   const router = useRouter();
-  const [selectedDay, setSelectedDay] = useState<Date>(new Date());
+  const [selectedDay, setSelectedDay] = useState<Date>(initialSelectedDate || new Date());
   const memberRole = useAuthStore((s) => s.memberRole);
 
   // 날짜 선택 핸들러

--- a/apps/web/src/widgets/post-detail/PostBodySection.tsx
+++ b/apps/web/src/widgets/post-detail/PostBodySection.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { ChipToggle } from '@surf/ui/chip-toggle';
+import { format } from 'date-fns';
+import { useRouter } from 'next/navigation';
 import sanitizeHtml, { IOptions } from 'sanitize-html';
 import { EventCard } from '@/entities/calendar/ui/EventCard/EventCard';
 import { PostScheduleData } from '@/entities/post/api/types';
@@ -10,6 +12,7 @@ import { PostProfile } from '@/entities/post/ui/post-profile/PostProfile';
 import { mapCategoryToActivityCategory } from '@/features/calendar/model/mapper';
 import { useToggleLikeMutation } from '@/features/post/model/useToggleLikeMutation';
 import { useToggleScrapMutation } from '@/features/post/model/useToggleScrapMutation';
+import { PAGE_ROUTES } from '@/shared/config/path';
 
 type PostBodySectionProps = {
   post: PostDetail;
@@ -18,6 +21,8 @@ type PostBodySectionProps = {
 };
 
 export const PostBodySection = ({ post, schedule, onClickLikeCount }: PostBodySectionProps) => {
+  const router = useRouter();
+
   // 좋아요/스크랩 Mutation
   const likeMutation = useToggleLikeMutation();
   const scrapMutation = useToggleScrapMutation();
@@ -48,6 +53,14 @@ export const PostBodySection = ({ post, schedule, onClickLikeCount }: PostBodySe
 
   const cleanContent = sanitizeHtml(post.content, sanitizeOptions);
 
+  // 이벤트 카드 클릭 시 캘린더 화면으로 이동
+  const handleEventCardClick = () => {
+    if (!schedule) return;
+    const date = new Date(schedule.startAt);
+    const dateStr = format(date, 'yyyy-MM-dd');
+    router.push(`${PAGE_ROUTES.CALENDAR.MAIN}?date=${dateStr}`);
+  };
+
   return (
     <div className="flex flex-col gap-16">
       <PostProfile
@@ -77,6 +90,7 @@ export const PostBodySection = ({ post, schedule, onClickLikeCount }: PostBodySe
           location={schedule.location}
           startDate={new Date(schedule.startAt)}
           endDate={new Date(schedule.endAt)}
+          onClickCard={handleEventCardClick}
         />
       )}
 


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 any가 사용되지 않았습니다
- [x] 스토리북에 추가했습니다 (해당 시)
- [x] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈
- close #434 

## 📌 작업 목적
- 게시글 상세 화면에서 일정 카드 클릭 시 캘린더 화면으로 이동 

## 🔨 주요 작업 내용
- Calendar 컴포넌트에 초기 선택 날짜를 설정할 수 있는 initialSelectedDate prop 추가
- CalendarPage 진입 시 URL 쿼리 파라미터 date를 파싱하여 해당 월과 날짜를 초기화
- 게시글 상세 화면(PostBodySection)에서 일정 카드 클릭 시, 해당 일정의 시작 날짜를 로컬 시간 포맷팅하여 캘린더 화면으로 이동하는 라우팅 로직 추가

## 🧪 테스트 방법
- 게시글을 일정을 포함하여 작성 후 일정 카드를 클릭하여 캘린더 화면으로 이동하여 해당 날짜가 선택되어 있는지 확인

## ✔️ 설치 라이브러리
-

## 📷 실행 영상 또는 스크린샷
-

## 💬 논의할 점
-

## 🙋🏻 참고 자료
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 달력이 이제 URL 쿼리 파라미터를 통해 특정 날짜 지정을 지원합니다.
  * 이벤트 카드 클릭 시 해당 날짜로 달력 뷰가 표시됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->