### PR TITLE
[FIX] 알림 권한 요청 거부 시 예외 처리

### DIFF
--- a/apps/web/src/app-pages/notification/ui/NotificationPage.tsx
+++ b/apps/web/src/app-pages/notification/ui/NotificationPage.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { HeaderMode } from '@surf/ui/header';
+import { useToastStore } from '@surf/ui/store/toastStore';
 import { Tab } from '@surf/ui/tab';
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import type { NotificationTab } from '@/entities/notification/model/notificationTab';
 import { useGetNotifications } from '@/entities/notification/model/useGetNotifications';
 import { useReadNotification } from '@/entities/notification/model/useReadNotification';
@@ -20,6 +21,14 @@ const tabItems = [
 export const NotificationPage = () => {
   const router = useRouter();
   const [currentTab, setCurrentTab] = useState<NotificationTab>('ALL');
+  const showToast = useToastStore((state) => state.show);
+
+  useEffect(() => {
+    if (Notification.permission === 'denied') {
+      // 이미 거부된 경우 브라우저 설정 유도
+      showToast('알림 권한이 차단되어 있습니다. 브라우저 설정에서 알림을 허용해주세요.');
+    }
+  }, [showToast]);
 
   const { data, isLoading } = useGetNotifications(currentTab);
   const { mutate: readNotification, isPending } = useReadNotification();

--- a/apps/web/src/app/providers/FCMInitializer.tsx
+++ b/apps/web/src/app/providers/FCMInitializer.tsx
@@ -1,72 +1,62 @@
 'use client';
 
 import { isAxiosError } from 'axios';
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { useRegisterToken } from '@/entities/notification/model/useRegisterToken';
 import { getValidStatus } from '@/features/auth/api/getValidStatus';
+import { useAuthStore } from '@/features/auth/model/useAuthStore';
 import { getFcmToken } from '@/shared/lib/fcm';
 
 export const FCMInitializer = () => {
   const { mutate: registerToken } = useRegisterToken();
-  const initRef = useRef(false);
+  const memberId = useAuthStore((s) => s.memberId);
 
-  useEffect(
-    () => {
-      if (initRef.current) return;
-      initRef.current = true;
+  useEffect(() => {
+    // 로그아웃 상태이거나 로딩 중이면 스킵
+    if (!memberId) return;
 
-      async function init() {
-        try {
-          // 1. 로그인 상태 확인 (API 호출)
-          await getValidStatus();
+    async function init() {
+      try {
+        // 1. 로그인 상태 확인
+        await getValidStatus();
 
-          // 2. 이미 등록되었다면 스킵
-          const isRegistered = sessionStorage.getItem('isFcmRegistered');
-          if (isRegistered === 'true') {
-            if (process.env.NODE_ENV === 'development') {
-              console.log('[FCMInitializer] Token already registered in session. Skipping.');
-            }
-            return;
-          }
-
+        // 2. 이미 등록되었다면 스킵
+        const isRegistered = sessionStorage.getItem('isFcmRegistered');
+        if (isRegistered === 'true') {
           if (process.env.NODE_ENV === 'development') {
-            console.log('[FCMInitializer] User is logged in. Requesting FCM token...');
+            console.log('[FCMInitializer] Token already registered in session. Skipping.');
           }
+          return;
+        }
 
-          // 2. FCM 토큰 발급 및 권한 요청
-          const token = await getFcmToken();
+        // 3. FCM 토큰 발급 및 권한 요청
+        const token = await getFcmToken();
 
-          if (!token) {
-            if (process.env.NODE_ENV === 'development') {
-              console.log('[FCMInitializer] Failed to get FCM token or permission denied.');
-            }
-            return;
-          }
-
-          // 3. 서버에 토큰 등록
+        if (!token) {
           if (process.env.NODE_ENV === 'development') {
-            console.log('[FCMInitializer] Registering token to server');
+            console.log('[FCMInitializer] Failed to get FCM token.');
           }
+          return;
+        }
 
-          registerToken({ token, platform: 'WEB' });
-        } catch (error) {
-          if (
-            isAxiosError(error) &&
-            (error.response?.status === 401 || error.response?.status === 403)
-          ) {
-            if (process.env.NODE_ENV === 'development') {
-              console.log('[FCMInitializer] User not logged in (Auth failed). Skipping FCM.');
-            }
-          } else {
-            console.error('[FCMInitializer] Unexpected error during initialization:', error);
+        // 4. 서버에 토큰 등록
+        registerToken({ token, platform: 'WEB' });
+      } catch (error) {
+        if (
+          isAxiosError(error) &&
+          (error.response?.status === 401 || error.response?.status === 403)
+        ) {
+          if (process.env.NODE_ENV === 'development') {
+            console.log('[FCMInitializer] User not logged in (Auth failed). Skipping FCM.');
           }
+        } else {
+          console.error('[FCMInitializer] Unexpected error during initialization:', error);
         }
       }
+    }
 
-      void init();
-    }, // eslint-disable-next-line react-hooks/exhaustive-deps
-    [],
-  ); // 한 번만 실행 보장
+    void init();
+  }, [memberId, registerToken]);
 
   return null;
 };


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 any가 사용되지 않았습니다
- [x] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈
- close #437 

## 📌 작업 목적
- 알림 권한 요청 거부 시 예외 상황 처리

## 🔨 주요 작업 내용
- 사용자가 알림 권한 요청 거부 시 다시 자동으로 요청할 수 없음.(브라우저가 막음) -> 알림 화면 진입 시 Toast로 알림 권한을 허용해 달라는 문구 추가
- 홈 화면에 진입 시 알림 권한 요청하도록 로직 수정

## 🧪 테스트 방법
- 로그인 후 홈 화면에 진입했을 때 알림 권한 요청이 뜨는지 확인
- 만약 권한 요청이 뜨지 않는 다면 아래를 실행한 후 다시 새로고침
( 개발자모드 -> Application -> SessionStorage에 isRegistered 삭제
  개발자모드 -> Application -> Service Worker에 등록된 것이 있으면 UnRegister
<img width="300" height="230" alt="image" src="https://github.com/user-attachments/assets/87948ed3-d774-4f57-a2e1-396e5eadd733" />
권한 재설정 클릭 )


## ✔️ 설치 라이브러리
-

## 📷 실행 영상 또는 스크린샷
-

## 💬 논의할 점
-

## 🙋🏻 참고 자료
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 브라우저 알림이 거부되었을 때 토스트 알림이 표시됩니다.

* **Refactor**
  * FCM(Firebase Cloud Messaging) 초기화 로직을 최적화하여 더 안정적인 초기화 흐름을 제공합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->