### PR TITLE
[FIX] SSR 환경에서 axios baseURL 상대경로로 인한 Invalid URL 에러 해결

### DIFF
--- a/apps/admin/src/app/(protected)/(main)/signup-request/page.tsx
+++ b/apps/admin/src/app/(protected)/(main)/signup-request/page.tsx
@@ -1,5 +1,6 @@
 import { HydrationBoundary, dehydrate } from '@tanstack/react-query';
 import { SignupRequestPage } from '@/app-pages/signup-request/ui/SignupRequestPage';
+import { getSignupRequestListServer } from '@/features/signup-request/api/getSignupRequestListServer';
 import { signupRequestQueryOptions } from '@/features/signup-request/model/queries/signupRequestQueryOptions';
 import { getQueryClient } from '@/shared/lib/tanstack-query/queryClient';
 
@@ -12,7 +13,9 @@ const Page = async () => {
   const queryClient = getQueryClient();
 
   // Server-side prefetch: 첫 페이지 데이터 미리 로드
-  await queryClient.prefetchInfiniteQuery(signupRequestQueryOptions({}));
+  await queryClient.prefetchInfiniteQuery(
+    signupRequestQueryOptions({ filters: {}, fetcher: getSignupRequestListServer }),
+  );
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>

--- a/apps/admin/src/entities/member/model/types.ts
+++ b/apps/admin/src/entities/member/model/types.ts
@@ -44,5 +44,5 @@ export interface Member {
   university: string;
   profileImageUrl: string;
   tracks: MemberTrack[];
-  registeredAt: Date;
+  registeredAt: string;
 }

--- a/apps/admin/src/entities/signup-request/ui/SignupRequestItem.stories.tsx
+++ b/apps/admin/src/entities/signup-request/ui/SignupRequestItem.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<typeof SignupRequestItem> = {
       { generation: 15, part: 'DESIGN' },
       { generation: 16, part: 'WEB_FRONTEND' },
     ],
-    registeredAt: new Date('2025-01-15T16:32:00'),
+    registeredAt: '25.06.30 12:12',
     status: 'waiting',
     checked: false,
   },

--- a/apps/admin/src/entities/signup-request/ui/SignupRequestItem.tsx
+++ b/apps/admin/src/entities/signup-request/ui/SignupRequestItem.tsx
@@ -5,13 +5,12 @@ import { SignupRequestStatus } from '../model/types';
 import { RequestStatusBadge } from './RequestStatusBadge';
 import { PART_LABELS } from '@/entities/member/model/constants';
 import { MemberTrack } from '@/entities/member/model/types';
-import { formatDateTime } from '@/shared/utils/date';
 
 interface SignupRequestItemProps {
   name: string;
   university: string;
   tracks: MemberTrack[];
-  registeredAt: Date;
+  registeredAt: string;
   checked: boolean;
   status: SignupRequestStatus;
 }
@@ -39,11 +38,8 @@ export const SignupRequestItem = ({
         </div>
 
         <span className="text-body-body11 text-foreground-secondary">
-          <time
-            dateTime={registeredAt.toISOString()}
-            aria-label={`요청 시간  ${formatDateTime(registeredAt)}`}
-          >
-            {formatDateTime(registeredAt)}
+          <time dateTime={registeredAt} aria-label={`요청 시간  ${registeredAt}`}>
+            {registeredAt}
           </time>
         </span>
       </div>

--- a/apps/admin/src/features/signup-request/api/getSignupRequestListClient.ts
+++ b/apps/admin/src/features/signup-request/api/getSignupRequestListClient.ts
@@ -1,33 +1,19 @@
 import { axiosInstance } from '@/shared/lib/axiosInstance';
 import { SignupRequestListResponse, SignupRequestListParams } from './types';
-import { createMockSignupRequestList } from './mockData';
-
-// 목업 모드 활성화 여부
-const USE_MOCK = true;
 
 /**
  * 가입 신청 목록 조회 API
  *
  * @param params - 페이지네이션 파라미터
  * @returns 가입 신청 목록 응답
- *
  */
-export async function getSignupRequestList(
+export async function getSignupRequestListClient(
   params: SignupRequestListParams,
 ): Promise<SignupRequestListResponse> {
-  // 목업 모드
-  if (USE_MOCK) {
-    // 네트워크 지연 시뮬레이션
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    return createMockSignupRequestList(params.pageNum, params.pageSize, params.keyword);
-  }
-
-  // 실제 API 호출
+  // 클라이언트에서 호출 시 axiosInstance 사용
   const response = await axiosInstance.get<SignupRequestListResponse>(
     '/v1/manager/registration-list',
-    {
-      params,
-    },
+    { params },
   );
 
   return response.data;

--- a/apps/admin/src/features/signup-request/api/getSignupRequestListServer.ts
+++ b/apps/admin/src/features/signup-request/api/getSignupRequestListServer.ts
@@ -1,0 +1,23 @@
+import 'server-only';
+import { serverFetchWithCookies } from '@/shared/api/serverFetchWithCookies';
+import { SignupRequestListResponse, SignupRequestListParams } from './types';
+
+/**
+ * 가입 신청 목록 조회 API (Server Component 전용)
+ *
+ * @param params - 페이지네이션 파라미터
+ * @returns 가입 신청 목록 응답
+ */
+export async function getSignupRequestListServer(
+  params: SignupRequestListParams,
+): Promise<SignupRequestListResponse> {
+  const searchParams = new URLSearchParams();
+  searchParams.set('pageNum', String(params.pageNum));
+  searchParams.set('pageSize', String(params.pageSize));
+  if (params.keyword) {
+    searchParams.set('keyword', params.keyword);
+  }
+  const queryString = searchParams.toString();
+  const response = await serverFetchWithCookies(`/v1/manager/registration-list?${queryString}`);
+  return response.json() as Promise<SignupRequestListResponse>;
+}

--- a/apps/admin/src/features/signup-request/model/mapper.ts
+++ b/apps/admin/src/features/signup-request/model/mapper.ts
@@ -32,7 +32,7 @@ export function toSignupRequestMember(dto: SignupRequestItem): SignupRequestMemb
     university: dto.university,
     profileImageUrl: dto.profileImageUrl,
     tracks: dto.trackList.map(toMemberTrack), // trackList → tracks
-    registeredAt: new Date(dto.createdAt), // string → Date
+    registeredAt: dto.createdAt,
     status: 'waiting', // 초기값 설정 (서버에서 제공하지 않음)
   };
 }

--- a/apps/admin/src/features/signup-request/model/queries/signupRequestQueryOptions.ts
+++ b/apps/admin/src/features/signup-request/model/queries/signupRequestQueryOptions.ts
@@ -7,10 +7,16 @@ import {
   PageWithContent,
 } from '@/shared/lib/tanstack-query/infiniteQueryUtils';
 import { signupRequestQueryKeys, SignupRequestFilters } from './signupRequestQueryKeys';
-import { getSignupRequestList } from '../../api/signupRequestApi';
+
 import { toSignupRequestMember } from '../mapper';
 import { SIGNUP_REQUEST_PAGE_SIZE, SIGNUP_REQUEST_STALE_TIME } from '../constants';
-import { SignupRequestListParams } from '../../api/types';
+import { SignupRequestListParams, SignupRequestListResponse } from '../../api/types';
+import { getSignupRequestListClient } from '../../api/getSignupRequestListClient';
+
+interface SignupRequestQueryOptionsParams {
+  filters: SignupRequestFilters;
+  fetcher?: (params: SignupRequestListParams) => Promise<SignupRequestListResponse>;
+}
 
 /**
  * 가입 신청 목록 무한스크롤 Query 옵션
@@ -18,10 +24,19 @@ import { SignupRequestListParams } from '../../api/types';
  * TanStack Query의 infiniteQuery 설정을 정의합니다.
  * queryFn에서 DTO → Domain Model 매핑을 수행하여 캐시에 저장합니다.
  *
- * @param filters - 필터 조건 (keyword, pageSize)
+ * @param params.filters - 필터 조건 (keyword, pageSize)
+ * @param params.isServer - 서버 컴포넌트에서 호출 여부 (옵셔널)
  * @returns infiniteQueryOptions 객체
  */
-export function signupRequestQueryOptions(filters: SignupRequestFilters) {
+export function signupRequestQueryOptions({
+  filters,
+  fetcher = getSignupRequestListClient,
+}: SignupRequestQueryOptionsParams) {
+  const normalizedFilters: SignupRequestFilters = { ...filters };
+  if (!normalizedFilters.keyword) {
+    delete normalizedFilters.keyword;
+  }
+
   return infiniteQueryOptions<
     PageWithContent<SignupRequestMember>,
     Error,
@@ -29,20 +44,20 @@ export function signupRequestQueryOptions(filters: SignupRequestFilters) {
     ReturnType<typeof signupRequestQueryKeys.list>,
     number
   >({
-    queryKey: signupRequestQueryKeys.list(filters),
+    queryKey: signupRequestQueryKeys.list(normalizedFilters),
 
     queryFn: async ({ pageParam = 0 }) => {
       const params: SignupRequestListParams = {
         pageNum: pageParam,
-        pageSize: filters.pageSize || SIGNUP_REQUEST_PAGE_SIZE,
+        pageSize: normalizedFilters.pageSize || SIGNUP_REQUEST_PAGE_SIZE,
       };
 
       // keyword가 있을 때만 파라미터에 추가
-      if (filters.keyword) {
-        params.keyword = filters.keyword;
+      if (normalizedFilters.keyword) {
+        params.keyword = normalizedFilters.keyword;
       }
 
-      const response = await getSignupRequestList(params);
+      const response = await fetcher(params);
       const { content, ...pageMeta } = response.data;
 
       // queryFn에서 매핑: 캐시에 Domain Model로 저장

--- a/apps/admin/src/features/signup-request/model/queries/useSignupRequestList.ts
+++ b/apps/admin/src/features/signup-request/model/queries/useSignupRequestList.ts
@@ -15,7 +15,7 @@ import { SignupRequestFilters } from './signupRequestQueryKeys';
  */
 export function useSignupRequestList(filters: SignupRequestFilters = {}) {
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, refetch } =
-    useSuspenseInfiniteQuery(signupRequestQueryOptions(filters));
+    useSuspenseInfiniteQuery(signupRequestQueryOptions({ filters }));
 
   return {
     // 필터 정보

--- a/apps/admin/src/shared/api/serverFetchWithCookies.ts
+++ b/apps/admin/src/shared/api/serverFetchWithCookies.ts
@@ -1,0 +1,41 @@
+import 'server-only';
+import { cookies, headers } from 'next/headers';
+import type { ServerFetchOptions } from './types';
+
+export async function getBaseUrl(): Promise<string> {
+  const h = await headers();
+  const host = h.get('host');
+  const proto = h.get('x-forwarded-proto') ?? 'http';
+  return host ? `${proto}://${host}` : 'http://localhost:3000';
+}
+
+function toProxyPath(path: string): string {
+  const p = path.startsWith('/') ? path : `/${path}`;
+  return p.startsWith('/api/proxy') ? p : `/api/proxy${p}`;
+}
+
+function buildCookieHeader(store: { getAll(): { name: string; value: string }[] }) {
+  return store
+    .getAll()
+    .map((c) => `${c.name}=${c.value}`)
+    .join('; ');
+}
+
+export async function serverFetchWithCookies(path: string, options: ServerFetchOptions = {}) {
+  const baseUrl = await getBaseUrl();
+  const url = `${baseUrl}${toProxyPath(path)}`;
+
+  const cookieStore = await cookies();
+  const cookie = buildCookieHeader(cookieStore);
+
+  const headersObj: Record<string, string> = {
+    ...(options.headers ?? {}),
+    ...(cookie ? { cookie } : {}),
+  };
+
+  return fetch(url, {
+    ...options,
+    headers: headersObj,
+    cache: options.cache ?? 'no-store',
+  });
+}


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 코드에 any가 사용되지 않았습니다
- [ ] 스토리북에 추가했습니다 (해당 시)
- [ ] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈

- close #455 

## 📌 작업 목적

- 서버 prefetch 시 getSignupRequestListClient 호출 시 TypeError: Invalid URL 발생 에러를 해결했습니다. 

## 🔨 주요 작업 내용

- 서버/클라이언트 fetch 로직 분리
- query key 정규화로 문제 해결

## ⚠️ 기존 문제 (선택)

- axiosInstance의 baseURL이 '/api/proxy'처럼 상대경로로 설정되어 있음
- SSR에서는 브라우저가 아닌 Node 환경이라 상대 URL을 해석할 기준(origin)이 없어서 Invalid URL 에러가 발생
- 추가로, 서버에서 prefetch한 데이터와 클라이언트 query key가 달라서 클라이언트가 다시 fetch를 시도했고, 그 과정에서 SSR에서 axios가 실행되며 문제가 노출됨


## ☑️ 해결 방법 (선택)

- 서버/클라이언트 전용 fetch 로직을 분리하여 server-only 모듈이 클라이언트 번들에 포함되지 않도록 구성
- 서버 prefetch와 클라이언트 캐시 키를 일치시키기 위해 keyword가 비어있는 경우 query key에서 제거하여 불필요한 refetch 방지
- 결과적으로 SSR에서 axios의 상대경로 baseURL 문제로 인한 Invalid URL 발생을 차단하고, 클라이언트 중복 fetch도 해소

## 🧪 테스트 방법

- 어드민 서비스 접속 후 '/signup-request'에서 실제 데이터가 잘 반영되고 있는지 확인 


## 📷 실행 영상 또는 스크린샷

<img width="3420" height="2214" alt="image" src="https://github.com/user-attachments/assets/5cae8e3c-ff97-4beb-827a-57666b2a5161" />

## 💬 논의할 점

- 검색창 인풋은 추후 디바운싱 적용 예정입니다!!! 검색 기능 제외하고 확인해주시면 될거 같아요

