### PR TITLE
[HOTFIX] herocard 응답 수정

### DIFF
--- a/apps/web/src/app-pages/home/ui/HomePageServer.tsx
+++ b/apps/web/src/app-pages/home/ui/HomePageServer.tsx
@@ -1,7 +1,7 @@
 import 'server-only';
 import { HomePageClient } from './HomePageClient';
 import { getHome } from '@/entities/home/api/getHome.server';
-import { buildHeroCardViewModel } from '@/features/home-theme/api/buildHeroCardViewModel.server';
+import { buildHeroCardViewModel } from '@/features/home-theme/api/buildHeroCardViewModel';
 
 export async function HomePageServer() {
   try {

--- a/apps/web/src/entities/home/api/guards.ts
+++ b/apps/web/src/entities/home/api/guards.ts
@@ -8,11 +8,6 @@ const isNullable =
   (x): x is T | null =>
     x === null || g(x);
 
-const isOptionalNullable =
-  <T>(g: Guard<T>): Guard<T | null | undefined> =>
-  (x): x is T | null | undefined =>
-    x === undefined || x === null || g(x);
-
 const isHomeBanner: Guard<HomeBanner> = (x): x is HomeBanner => {
   if (typeof x !== 'object' || x === null) return false;
   const o = x as Record<string, unknown>;
@@ -30,8 +25,8 @@ const isHomeApiResponseData: Guard<HomeApiResponseData> = (x): x is HomeApiRespo
   const o = x as Record<string, unknown>;
 
   return (
-    isString(o.mainText) &&
-    isOptionalNullable(isString)(o.sender) &&
+    isNullable(isString)(o.message) &&
+    isNullable(isString)(o.sender) &&
     Array.isArray(o.banners) &&
     o.banners.every(isHomeBanner) &&
     isString(o.memberName) &&

--- a/apps/web/src/entities/home/api/guards.ts
+++ b/apps/web/src/entities/home/api/guards.ts
@@ -25,8 +25,8 @@ const isHomeApiResponseData: Guard<HomeApiResponseData> = (x): x is HomeApiRespo
   const o = x as Record<string, unknown>;
 
   return (
-    isNullable(isString)(o.message) &&
-    isNullable(isString)(o.sender) &&
+    (o.message === undefined || isNullable(isString)(o.message)) &&
+    (o.sender === undefined || isNullable(isString)(o.sender)) &&
     Array.isArray(o.banners) &&
     o.banners.every(isHomeBanner) &&
     isString(o.memberName) &&

--- a/apps/web/src/entities/home/api/types.ts
+++ b/apps/web/src/entities/home/api/types.ts
@@ -8,15 +8,15 @@ export interface HomeBanner {
 }
 
 export interface HomeApiResponseData {
-  mainText: string;
+  message?: string;
   sender?: string | null;
   banners: HomeBanner[];
   memberName: string;
   memberGeneration: number;
   memberPart: string;
-  nextScheduleTitle: string | null;
-  nextScheduleDate: string | null;
-  nextScheduleDeepLink: string | null;
+  nextScheduleTitle?: string;
+  nextScheduleDate?: string;
+  nextScheduleDeepLink?: string;
 }
 
 export type HomeApiResponse = CommonResponse<HomeApiResponseData>;

--- a/apps/web/src/entities/home/model/mappers.ts
+++ b/apps/web/src/entities/home/model/mappers.ts
@@ -3,8 +3,8 @@ import { mapMemberPartToBatch } from '@/entities/user/model/mappers';
 
 export const mapHomeDataToHomeUI = (data: HomeApiResponseData) => {
   return {
-    noticeDataMainText: data.mainText,
-    //noticeDataSender: data.senderName,
+    noticeDataMessage: data.message,
+    noticeDataSender: data.sender,
     carouselImages: mapBannersToCarouselImages(data.banners),
     userName: data.memberName,
     userBatch: data.memberGeneration,

--- a/apps/web/src/features/home-theme/api/buildHeroCardViewModel.ts
+++ b/apps/web/src/features/home-theme/api/buildHeroCardViewModel.ts
@@ -22,8 +22,8 @@ export async function buildHeroCardViewModel(home: HomeApiResponseData): Promise
 
   return {
     noticeData: {
-      title: home.mainText,
-      sender: home.sender ?? 'TAVE 운영진',
+      message: home.message ?? '',
+      sender: home.sender ?? '',
     },
     userData: {
       name: home.memberName,

--- a/apps/web/src/features/home-theme/ui/hero-card/HeroCard.tsx
+++ b/apps/web/src/features/home-theme/ui/hero-card/HeroCard.tsx
@@ -7,7 +7,7 @@ interface UserData {
 }
 
 interface NoticeData {
-  title: string;
+  message: string;
   sender: string;
 }
 
@@ -102,7 +102,7 @@ export const HeroCard = ({ userData, noticeData, imgData }: HeroCardProps) => {
       {/* 텍스트 레이어 */}
       <div className="pointer-events-none absolute inset-0 z-10 flex flex-col">
         <div className="mt-[4.875rem] flex flex-col gap-1 px-15">
-          <h1 className={`text-body-body5 ${textColor} truncate`}>{noticeData.title}</h1>
+          <h1 className={`text-body-body5 ${textColor} truncate`}>{noticeData.message}</h1>
           <h2 className={`text-body-body9 ${textColor} truncate`}>{noticeData.sender}</h2>
         </div>
 


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 코드에 any가 사용되지 않았습니다
- [ ] 스토리북에 추가했습니다 (해당 시)
- [ ] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈

- close #460

## 📌 작업 목적

- 변경된 응답에 맞춰 수정

## 🔨 주요 작업 내용

- mainText를 message로 변경, sender 하드코딩 삭제 후 연동

## 🧪 테스트 방법

- 홈 화면 접속


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 홈 페이지 공지 데이터가 이제 `message` 필드를 사용하고 일부 공지/일정 항목이 선택적으로 제공됩니다.
  * 히어로 카드에서 공지 텍스트를 `message`로 표시하고, 발신자 기본값이 빈값으로 변경되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->