### PR TITLE
[FEAT] 어드민 가입 신청 선택된 인원 승인/거절 처리 기능 구현

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -21,7 +21,8 @@
     "next": "15.5.9",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-hook-form": "^7.71.0"
+    "react-hook-form": "^7.71.0",
+    "next-themes": "^0.4.6"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "4.1.1",

--- a/apps/admin/src/app/layout.tsx
+++ b/apps/admin/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import '@/shared/styles/globals.css';
+import { ThemeProvider } from 'next-themes';
 import type { ReactNode } from 'react';
 import { QueryProvider } from '@/shared/providers/QueryProvider';
 import { GlobalComponents } from '@/shared/ui/global-components/GlobalComponents';
@@ -22,9 +23,11 @@ const RootLayout = ({ children }: { children: ReactNode }) => {
       </head>
       <body className="flex min-h-screen items-center justify-center bg-gray-200">
         <QueryProvider>
-          <main className="bg-background-normal box-content flex h-full w-dvw sm:h-[min(100dvh,calc(100dvw*812/375))] sm:w-[min(100dvw,calc(100dvh*375/812))]">
-            {children}
-          </main>
+          <ThemeProvider attribute="data-theme" defaultTheme="system" enableSystem>
+            <main className="bg-background-normal box-content flex h-full w-dvw sm:h-[min(100dvh,calc(100dvw*812/375))] sm:w-[min(100dvw,calc(100dvh*375/812))]">
+              {children}
+            </main>
+          </ThemeProvider>
           <GlobalComponents />
         </QueryProvider>
       </body>

--- a/apps/admin/src/entities/signup-request/ui/SignupRequestItem.tsx
+++ b/apps/admin/src/entities/signup-request/ui/SignupRequestItem.tsx
@@ -1,6 +1,7 @@
 import { Checkbox } from '@surf/ui/checkbox';
 import { SurfIcon } from '@surf/ui/icon';
 import { InfoBadge } from '@surf/ui/info-badge';
+import type { ChangeEvent } from 'react';
 import { SignupRequestStatus } from '../model/types';
 import { RequestStatusBadge } from './RequestStatusBadge';
 import { PART_LABELS } from '@/entities/member/model/constants';
@@ -13,6 +14,8 @@ interface SignupRequestItemProps {
   registeredAt: string;
   checked: boolean;
   status: SignupRequestStatus;
+  isSelectionEnabled?: boolean;
+  onToggle: (e: ChangeEvent<HTMLInputElement>) => void;
 }
 export const SignupRequestItem = ({
   name,
@@ -20,6 +23,8 @@ export const SignupRequestItem = ({
   registeredAt,
   status,
   checked,
+  isSelectionEnabled = false,
+  onToggle,
 }: SignupRequestItemProps) => {
   return (
     <div
@@ -27,7 +32,9 @@ export const SignupRequestItem = ({
         checked ? 'bg-background-notification' : ''
       }`}
     >
-      <Checkbox />
+      {isSelectionEnabled && (
+        <Checkbox isChecked={checked} onChange={onToggle} isDisabled={!isSelectionEnabled} />
+      )}
 
       <div className="flex w-full grow flex-col items-start gap-5 overflow-hidden">
         <h3 className="text-body-body6 text-foreground-normal">{name}</h3>

--- a/apps/admin/src/entities/signup-request/ui/SignupRequestItem.tsx
+++ b/apps/admin/src/entities/signup-request/ui/SignupRequestItem.tsx
@@ -33,7 +33,12 @@ export const SignupRequestItem = ({
       }`}
     >
       {isSelectionEnabled && (
-        <Checkbox isChecked={checked} onChange={onToggle} isDisabled={!isSelectionEnabled} />
+        <Checkbox
+          isChecked={checked}
+          onChange={onToggle}
+          isDisabled={!isSelectionEnabled}
+          aria-label={`${name} 선택`}
+        />
       )}
 
       <div className="flex w-full grow flex-col items-start gap-5 overflow-hidden">

--- a/apps/admin/src/features/signup-request/api/updateSignupRequest.ts
+++ b/apps/admin/src/features/signup-request/api/updateSignupRequest.ts
@@ -1,0 +1,14 @@
+import { CommonResponse } from '@/shared/api/types';
+import { axiosInstance } from '@/shared/lib/axiosInstance';
+
+export async function updateSignupRequest(
+  memberIds: number[],
+  nextStatus: string,
+): Promise<CommonResponse<null>> {
+  const response = await axiosInstance.patch<CommonResponse<null>>(
+    `/v1/admin/members/${nextStatus}`,
+    memberIds,
+  );
+
+  return response.data;
+}

--- a/apps/admin/src/features/signup-request/api/updateSignupRequest.ts
+++ b/apps/admin/src/features/signup-request/api/updateSignupRequest.ts
@@ -1,14 +1,23 @@
+import { SignupRequestStatus } from '@/entities/signup-request/model/types';
 import { CommonResponse } from '@/shared/api/types';
 import { axiosInstance } from '@/shared/lib/axiosInstance';
+import { handleApiError } from '@/shared/lib/handleApiError';
 
 export async function updateSignupRequest(
   memberIds: number[],
-  nextStatus: string,
+  nextStatus: SignupRequestStatus,
 ): Promise<CommonResponse<null>> {
-  const response = await axiosInstance.patch<CommonResponse<null>>(
-    `/v1/admin/members/${nextStatus}`,
-    memberIds,
-  );
+  try {
+    const response = await axiosInstance.patch<CommonResponse<null>>(
+      `/v1/admin/members/${nextStatus}`,
+      memberIds,
+    );
 
-  return response.data;
+    return response.data;
+  } catch (error) {
+    throw handleApiError(
+      error,
+      `회원 가입${nextStatus === 'approve' ? '승인' : '거절'}에 실패했습니다.`,
+    );
+  }
 }

--- a/apps/admin/src/features/signup-request/model/queries/signupRequestQueryKeys.ts
+++ b/apps/admin/src/features/signup-request/model/queries/signupRequestQueryKeys.ts
@@ -6,6 +6,16 @@ export interface SignupRequestFilters {
   pageSize?: number;
 }
 
+export function normalizeSignupRequestFilters(filters: SignupRequestFilters): SignupRequestFilters {
+  const normalized = { ...filters };
+
+  if (!normalized.keyword) {
+    delete normalized.keyword;
+  }
+
+  return normalized;
+}
+
 /**
  * 가입 신청 관련 Query Keys
  *

--- a/apps/admin/src/features/signup-request/model/queries/signupRequestQueryOptions.ts
+++ b/apps/admin/src/features/signup-request/model/queries/signupRequestQueryOptions.ts
@@ -6,7 +6,11 @@ import {
   InfiniteSelectResult,
   PageWithContent,
 } from '@/shared/lib/tanstack-query/infiniteQueryUtils';
-import { signupRequestQueryKeys, SignupRequestFilters } from './signupRequestQueryKeys';
+import {
+  signupRequestQueryKeys,
+  SignupRequestFilters,
+  normalizeSignupRequestFilters,
+} from './signupRequestQueryKeys';
 
 import { toSignupRequestMember } from '../mapper';
 import { SIGNUP_REQUEST_PAGE_SIZE, SIGNUP_REQUEST_STALE_TIME } from '../constants';
@@ -32,10 +36,7 @@ export function signupRequestQueryOptions({
   filters,
   fetcher = getSignupRequestListClient,
 }: SignupRequestQueryOptionsParams) {
-  const normalizedFilters: SignupRequestFilters = { ...filters };
-  if (!normalizedFilters.keyword) {
-    delete normalizedFilters.keyword;
-  }
+  const normalizedFilters = normalizeSignupRequestFilters(filters);
 
   return infiniteQueryOptions<
     PageWithContent<SignupRequestMember>,

--- a/apps/admin/src/features/signup-request/model/selectionPolicy.ts
+++ b/apps/admin/src/features/signup-request/model/selectionPolicy.ts
@@ -1,0 +1,34 @@
+import { SignupRequestMember, SignupRequestStatus } from '@/entities/signup-request/model/types';
+
+export type SelectionPolicy = {
+  selectedCount: number;
+  canApprove: boolean;
+  canReject: boolean;
+};
+
+export function getSelectedStatuses(
+  members: SignupRequestMember[],
+  selectedIds: Set<number>,
+): SignupRequestStatus[] {
+  const statuses: SignupRequestStatus[] = [];
+
+  for (const member of members) {
+    if (selectedIds.has(member.id)) {
+      statuses.push(member.status);
+    }
+  }
+
+  return statuses;
+}
+
+export function getSelectionPolicy(statuses: SignupRequestStatus[]): SelectionPolicy {
+  const selectedCount = statuses.length;
+  const hasSelection = selectedCount > 0;
+  const allWaiting = hasSelection && statuses.every((status) => status === 'waiting');
+
+  return {
+    selectedCount,
+    canApprove: allWaiting,
+    canReject: allWaiting,
+  };
+}

--- a/apps/admin/src/features/signup-request/model/useUpdateRequestStatusMutation.ts
+++ b/apps/admin/src/features/signup-request/model/useUpdateRequestStatusMutation.ts
@@ -6,11 +6,13 @@ import type {
   SignupRequestStatus,
 } from '@/entities/signup-request/model/types';
 import type { PageWithContent } from '@/shared/lib/tanstack-query/infiniteQueryUtils';
+import type { CommonResponse } from '@/shared/api/types';
 import {
   signupRequestQueryKeys,
   SignupRequestFilters,
   normalizeSignupRequestFilters,
 } from './queries/signupRequestQueryKeys';
+import { updateSignupRequest } from '../api/updateSignupRequest';
 
 type UpdateSignupRequestStatusParams = {
   memberIds: number[];
@@ -21,11 +23,10 @@ type UpdateSignupRequestStatusParams = {
 export const useUpdateSignupRequestStatusMutation = () => {
   const queryClient = useQueryClient();
 
-  return useMutation<UpdateSignupRequestStatusParams, Error, UpdateSignupRequestStatusParams>({
+  return useMutation<CommonResponse<null>, Error, UpdateSignupRequestStatusParams>({
     mutationKey: ['signup-request', 'update'],
-    // TODO: API 연동 시 mutationFn을 실제 요청으로 교체.
-    mutationFn: (params) => Promise.resolve(params),
-    onSuccess: (params) => {
+    mutationFn: (params) => updateSignupRequest(params.memberIds, params.nextStatus),
+    onSuccess: (_data, params) => {
       const normalizedFilters = normalizeSignupRequestFilters(params.filters);
       const queryKey = signupRequestQueryKeys.list(normalizedFilters);
 

--- a/apps/admin/src/features/signup-request/model/useUpdateRequestStatusMutation.ts
+++ b/apps/admin/src/features/signup-request/model/useUpdateRequestStatusMutation.ts
@@ -1,0 +1,58 @@
+'use client';
+
+import { InfiniteData, useMutation, useQueryClient } from '@tanstack/react-query';
+import type {
+  SignupRequestMember,
+  SignupRequestStatus,
+} from '@/entities/signup-request/model/types';
+import type { PageWithContent } from '@/shared/lib/tanstack-query/infiniteQueryUtils';
+import {
+  signupRequestQueryKeys,
+  SignupRequestFilters,
+  normalizeSignupRequestFilters,
+} from './queries/signupRequestQueryKeys';
+
+type UpdateSignupRequestStatusParams = {
+  memberIds: number[];
+  nextStatus: SignupRequestStatus;
+  filters: SignupRequestFilters;
+};
+
+export const useUpdateSignupRequestStatusMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<UpdateSignupRequestStatusParams, Error, UpdateSignupRequestStatusParams>({
+    mutationKey: ['signup-request', 'update'],
+    // TODO: API 연동 시 mutationFn을 실제 요청으로 교체.
+    mutationFn: (params) => Promise.resolve(params),
+    onSuccess: (params) => {
+      const normalizedFilters = normalizeSignupRequestFilters(params.filters);
+      const queryKey = signupRequestQueryKeys.list(normalizedFilters);
+
+      const idSet = new Set(params.memberIds);
+      queryClient.setQueryData<InfiniteData<PageWithContent<SignupRequestMember>, number>>(
+        queryKey,
+        (data) => {
+          if (!data) {
+            return data;
+          }
+
+          return {
+            ...data,
+            pages: data.pages.map((page) => ({
+              ...page,
+              content: page.content.map((member) =>
+                idSet.has(member.id) ? { ...member, status: params.nextStatus } : member,
+              ),
+            })),
+          };
+        },
+      );
+    },
+    onError: (error) => {
+      if (error instanceof Error) {
+        console.error('[Signup Request Status Update Error]', error.message);
+      }
+    },
+  });
+};

--- a/apps/admin/src/features/signup-request/ui/RequestListTopBar.tsx
+++ b/apps/admin/src/features/signup-request/ui/RequestListTopBar.tsx
@@ -4,14 +4,27 @@ interface RequestListTopBarProps {
   mode: 'select' | 'view';
   totalCount: number;
   selectCount: number;
+  onClickSelect?: () => void;
+  onClickCancel?: () => void;
 }
-export const RequestListTopBar = ({ mode, totalCount, selectCount }: RequestListTopBarProps) => {
+export const RequestListTopBar = ({
+  mode,
+  totalCount,
+  selectCount,
+  onClickSelect,
+  onClickCancel,
+}: RequestListTopBarProps) => {
   if (mode === 'select') {
     return (
-      <div className="px-16 py-10">
+      <div className="flex w-full flex-row items-center justify-between px-16 py-10">
         <span className="text-body-body8 text-foreground-normal-lighter text-nowrap">
           {selectCount}개 선택됨
         </span>
+        <div className="inline-block">
+          <TextButton type="button" size="s" variant="secondary" onClick={onClickCancel}>
+            취소
+          </TextButton>
+        </div>
       </div>
     );
   }
@@ -23,7 +36,7 @@ export const RequestListTopBar = ({ mode, totalCount, selectCount }: RequestList
       </span>
 
       <div className="inline-block">
-        <TextButton type="button" size="s" variant="primary">
+        <TextButton type="button" size="s" variant="primary" onClick={onClickSelect}>
           선택하기
         </TextButton>
       </div>

--- a/apps/admin/src/features/signup-request/ui/SignupRequestList.tsx
+++ b/apps/admin/src/features/signup-request/ui/SignupRequestList.tsx
@@ -3,6 +3,9 @@ import { SignupRequestItem } from '@/entities/signup-request/ui/SignupRequestIte
 
 interface SignupRequestListProps {
   members: SignupRequestMember[];
+  isSelectionEnabled: boolean;
+  selectedIds: Set<number>;
+  onToggleSelect: (memberId: number) => void;
 }
 
 /**
@@ -10,7 +13,12 @@ interface SignupRequestListProps {
  *
  * members 배열을 받아서 SignupRequestItem으로 렌더링합니다.
  */
-export const SignupRequestList = ({ members }: SignupRequestListProps) => {
+export const SignupRequestList = ({
+  members,
+  isSelectionEnabled,
+  selectedIds,
+  onToggleSelect,
+}: SignupRequestListProps) => {
   //TODO: Empty Space 적용 필요
   if (members.length === 0) {
     return <div>가입 신청 내역이 없습니다.</div>;
@@ -25,8 +33,10 @@ export const SignupRequestList = ({ members }: SignupRequestListProps) => {
           university={member.university}
           tracks={member.tracks}
           registeredAt={member.registeredAt}
-          checked={false}
+          checked={selectedIds.has(member.id)}
           status={member.status}
+          isSelectionEnabled={isSelectionEnabled}
+          onToggle={() => onToggleSelect(member.id)}
         />
       ))}
     </div>

--- a/apps/admin/src/shared/ui/BottomActionBar.tsx
+++ b/apps/admin/src/shared/ui/BottomActionBar.tsx
@@ -22,11 +22,7 @@ export const BottomActionBar = ({ actions }: BottomActionBarProps) => {
   if (actions.length > 2) throw new Error('BottomActionBar supports up to 2 actions.');
 
   return (
-    <div
-      className={
-        'fixed bottom-0 left-1/2 z-50 w-dvw -translate-x-1/2 sm:w-[min(100dvw,calc(100dvh*375/812))]'
-      }
-    >
+    <div className="mx-auto flex w-full sm:w-[min(100dvw,calc(100dvh*375/812))]">
       <div
         className={'h-[4.5rem] w-full max-w-screen-sm pb-[calc(env(safe-area-inset-bottom)+12px)]'}
       >
@@ -37,6 +33,7 @@ export const BottomActionBar = ({ actions }: BottomActionBarProps) => {
                 size="l"
                 variant={a.variant || 'primary'}
                 isDisabled={a.disabled}
+                onClick={a.onClick}
                 className="h-full w-full rounded-none"
               >
                 {a.label}

--- a/apps/admin/src/widgets/signup-request/ui/SignupRequestListContent.tsx
+++ b/apps/admin/src/widgets/signup-request/ui/SignupRequestListContent.tsx
@@ -1,34 +1,47 @@
 'use client';
 
-import { useSignupRequestList } from '@/features/signup-request/model/queries/useSignupRequestList';
+import { SignupRequestMember } from '@/entities/signup-request/model/types';
 import { SignupRequestList } from '@/features/signup-request/ui/SignupRequestList';
 import { useInfiniteScroll } from '@/shared/hooks/useInfiniteScroll';
 
 interface SignupRequestListContentProps {
-  keyword: string;
+  members: SignupRequestMember[];
+  isSelectionEnabled: boolean;
+  selectedIds: Set<number>;
+  onToggleSelect: (memberId: number) => void;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  onLoadMore: () => void;
 }
 
 /**
  * 가입 신청 목록 콘텐츠 컴포넌트
  *
  */
-export const SignupRequestListContent = ({ keyword }: SignupRequestListContentProps) => {
-  const { members, fetchNextPage, hasNextPage, isFetchingNextPage } = useSignupRequestList({
-    keyword,
-  });
-
+export const SignupRequestListContent = ({
+  members,
+  isSelectionEnabled,
+  selectedIds,
+  onToggleSelect,
+  hasNextPage,
+  isFetchingNextPage,
+  onLoadMore,
+}: SignupRequestListContentProps) => {
   // 무한 스크롤 트리거
   const triggerRef = useInfiniteScroll({
     hasNextPage,
     isFetching: isFetchingNextPage,
-    onLoadMore: () => {
-      void fetchNextPage();
-    },
+    onLoadMore,
   });
 
   return (
     <div className="scrollbar-hide flex-1 overflow-y-auto">
-      <SignupRequestList members={members} />
+      <SignupRequestList
+        members={members}
+        isSelectionEnabled={isSelectionEnabled}
+        selectedIds={selectedIds}
+        onToggleSelect={onToggleSelect}
+      />
       {/* 무한 스크롤 트리거 */}
       <div ref={triggerRef} className="h-10" />
       {isFetchingNextPage && (

--- a/apps/admin/src/widgets/signup-request/ui/SignupRequestListWidget.tsx
+++ b/apps/admin/src/widgets/signup-request/ui/SignupRequestListWidget.tsx
@@ -1,6 +1,16 @@
-import { Suspense } from 'react';
+'use client';
+
+import { useAlertStore } from '@surf/ui/store/alertStore';
+import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { SignupRequestListContent } from './SignupRequestListContent';
+import { useSignupRequestList } from '@/features/signup-request/model/queries/useSignupRequestList';
+import {
+  getSelectedStatuses,
+  getSelectionPolicy,
+} from '@/features/signup-request/model/selectionPolicy';
+import { useUpdateSignupRequestStatusMutation } from '@/features/signup-request/model/useUpdateRequestStatusMutation';
 import { RequestListTopBar } from '@/features/signup-request/ui/RequestListTopBar';
+import { BottomActionBar } from '@/shared/ui/BottomActionBar';
 import { ErrorBoundary } from '@/shared/ui/ErrorBoundary';
 
 interface SignupRequestListWidgetProps {
@@ -16,16 +26,163 @@ interface SignupRequestListWidgetProps {
  *
  */
 export const SignupRequestListWidget = ({ keyword }: SignupRequestListWidgetProps) => {
+  const [mode, setMode] = useState<'view' | 'select'>('view');
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+
+  const filters = useMemo(() => (keyword ? { keyword } : {}), [keyword]);
+  const { members, totalCount, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useSignupRequestList(filters);
+
+  const { mutate, isPending } = useUpdateSignupRequestStatusMutation();
+
+  useEffect(() => {
+    setMode('view');
+    setSelectedIds(new Set());
+  }, [keyword]);
+
+  const statuses = getSelectedStatuses(members, selectedIds);
+  const { selectedCount, canApprove, canReject } = getSelectionPolicy(statuses);
+
+  const openAlert = useAlertStore((s) => s.open);
+  const closeAlert = useAlertStore((s) => s.close);
+
+  const handleToggleSelect = (memberId: number) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(memberId)) {
+        next.delete(memberId);
+      } else {
+        next.add(memberId);
+      }
+      return next;
+    });
+  };
+
+  const handleApprove = useCallback(() => {
+    if (!canApprove || selectedIds.size === 0) {
+      return;
+    }
+
+    mutate({
+      memberIds: Array.from(selectedIds),
+      nextStatus: 'approve',
+      filters,
+    });
+    setSelectedIds(new Set());
+  }, [canApprove, filters, mutate, selectedIds]);
+
+  const handleReject = useCallback(() => {
+    if (!canReject || selectedIds.size === 0) {
+      return;
+    }
+
+    mutate({
+      memberIds: Array.from(selectedIds),
+      nextStatus: 'reject',
+      filters,
+    });
+    setSelectedIds(new Set());
+  }, [canReject, filters, mutate, selectedIds]);
+
+  const openApproveAlert = useCallback(() => {
+    openAlert({
+      state: 'default',
+      title: '회원 가입을 승인하시겠습니까?',
+      infoText: `승인 버튼을 누를 시, 선택한 ${selectedCount}명의 인원의 회원가입을 승인합니다.`,
+      actions: [
+        {
+          type: 'solid',
+          variant: 'secondary',
+          label: '취소',
+          onClick: () => {
+            closeAlert();
+          },
+        },
+        {
+          type: 'solid',
+          variant: 'primary',
+          label: '승인하기',
+          onClick: () => {
+            closeAlert();
+            handleApprove();
+          },
+        },
+      ],
+    });
+  }, [closeAlert, handleApprove, openAlert, selectedCount]);
+
+  const openRejectAlert = useCallback(() => {
+    openAlert({
+      state: 'default',
+      title: '회원 가입을 거절하시겠습니까?',
+      infoText: `거절 버튼을 누를 시, 해당 인원의 회원가입이 거절됩니다.`,
+      actions: [
+        {
+          type: 'solid',
+          variant: 'secondary',
+          label: '취소',
+          onClick: () => {
+            closeAlert();
+          },
+        },
+        {
+          type: 'solid',
+          variant: 'warning',
+          label: '거절하기',
+          onClick: () => {
+            closeAlert();
+            handleReject();
+          },
+        },
+      ],
+    });
+  }, [closeAlert, handleReject, openAlert]);
+
+  const bottomActions = [
+    {
+      key: 'approve',
+      label: '승인하기',
+      onClick: openApproveAlert,
+      disabled: !canApprove || isPending,
+    },
+    {
+      key: 'reject',
+      label: '거절하기',
+      onClick: openRejectAlert,
+      disabled: !canReject || isPending,
+    },
+  ];
+
   return (
     <div className="flex h-full flex-col overflow-hidden">
       {/* 회원가입 요청 상단 바 */}
-      <RequestListTopBar mode="view" selectCount={0} totalCount={0} />
+      <RequestListTopBar
+        mode={mode}
+        selectCount={selectedCount}
+        totalCount={totalCount}
+        onClickSelect={() => setMode('select')}
+        onClickCancel={() => {
+          setMode('view');
+          setSelectedIds(new Set());
+        }}
+      />
       {/* 회원가입 요청 멤버 리스트*/}
       <ErrorBoundary fallback={<div>error</div>}>
         <Suspense fallback={<div>loading...</div>}>
-          <SignupRequestListContent keyword={keyword} />
+          <SignupRequestListContent
+            members={members}
+            isSelectionEnabled={mode === 'select'}
+            selectedIds={selectedIds}
+            onToggleSelect={handleToggleSelect}
+            hasNextPage={hasNextPage}
+            isFetchingNextPage={isFetchingNextPage}
+            onLoadMore={() => {
+              void fetchNextPage();
+            }}
+          />
         </Suspense>
       </ErrorBoundary>
+      {mode === 'select' && selectedCount > 0 && <BottomActionBar actions={bottomActions} />}
     </div>
   );
 };

--- a/apps/admin/src/widgets/signup-request/ui/SignupRequestListWidget.tsx
+++ b/apps/admin/src/widgets/signup-request/ui/SignupRequestListWidget.tsx
@@ -127,7 +127,7 @@ export const SignupRequestListWidget = ({ keyword }: SignupRequestListWidgetProp
         },
         {
           type: 'solid',
-          variant: 'warning',
+          variant: 'danger',
           label: '거절하기',
           onClick: () => {
             closeAlert();

--- a/apps/admin/src/widgets/signup-request/ui/SignupRequestListWidget.tsx
+++ b/apps/admin/src/widgets/signup-request/ui/SignupRequestListWidget.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useAlertStore } from '@surf/ui/store/alertStore';
+import { useToastStore } from '@surf/ui/store/toastStore';
 import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { SignupRequestListContent } from './SignupRequestListContent';
 import { useSignupRequestList } from '@/features/signup-request/model/queries/useSignupRequestList';
@@ -33,6 +34,8 @@ export const SignupRequestListWidget = ({ keyword }: SignupRequestListWidgetProp
   const { members, totalCount, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useSignupRequestList(filters);
 
+  const showErrorToast = useToastStore((s) => s.show);
+
   const { mutate, isPending } = useUpdateSignupRequestStatusMutation();
 
   useEffect(() => {
@@ -63,26 +66,44 @@ export const SignupRequestListWidget = ({ keyword }: SignupRequestListWidgetProp
       return;
     }
 
-    mutate({
-      memberIds: Array.from(selectedIds),
-      nextStatus: 'approve',
-      filters,
-    });
-    setSelectedIds(new Set());
-  }, [canApprove, filters, mutate, selectedIds]);
+    mutate(
+      {
+        memberIds: Array.from(selectedIds),
+        nextStatus: 'approve',
+        filters,
+      },
+      {
+        onSuccess: () => {
+          setSelectedIds(new Set());
+        },
+        onError: (error) => {
+          showErrorToast(error.message);
+        },
+      },
+    );
+  }, [canApprove, filters, mutate, selectedIds, showErrorToast]);
 
   const handleReject = useCallback(() => {
     if (!canReject || selectedIds.size === 0) {
       return;
     }
 
-    mutate({
-      memberIds: Array.from(selectedIds),
-      nextStatus: 'reject',
-      filters,
-    });
-    setSelectedIds(new Set());
-  }, [canReject, filters, mutate, selectedIds]);
+    mutate(
+      {
+        memberIds: Array.from(selectedIds),
+        nextStatus: 'reject',
+        filters,
+      },
+      {
+        onSuccess: () => {
+          setSelectedIds(new Set());
+        },
+        onError: (error) => {
+          showErrorToast(error.message);
+        },
+      },
+    );
+  }, [canReject, filters, mutate, selectedIds, showErrorToast]);
 
   const openApproveAlert = useCallback(() => {
     openAlert({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       next:
         specifier: 15.5.9
         version: 15.5.9(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next-themes:
+        specifier: ^0.4.6
+        version: 0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -11352,7 +11355,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 코드에 any가 사용되지 않았습니다
- [ ] 스토리북에 추가했습니다 (해당 시)
- [ ] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈

- close #459 

## 📌 작업 목적

- 어드민 가입 신청 선택된 인원 승인/거절 처리 기능 구현

## 🔨 주요 작업 내용
- 인원 선택 기능 구현 
- 승인/거절 API 연동
- 승인/거절 뮤테이션 로직 구성
- 승인/거절 성공 시 클라이언트 단에서 승인/거절 상태로 캐시 데이터 변환 

## 🧪 테스트 방법

- 어드민 서비스 가입 신청 목록에서 인원 선택 후 승인/거절 테스트 

## 📷 실행 영상 또는 스크린샷

- 승인 성공 시 화면

<img width="3420" height="2214" alt="image" src="https://github.com/user-attachments/assets/88b63d3b-baee-41f4-b574-9f4dd162f54d" />

- 거절 성공 시 화면 

<img width="3420" height="2214" alt="image" src="https://github.com/user-attachments/assets/5f39cc9a-b8f9-45bd-9d95-60bce8e4a6a5" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 라이트/다크 테마 지원 추가
  * 가입 신청 항목 선택 기능 및 선택 모드 토글 추가
  * 선택된 항목에 대한 대량 승인/거절 기능 및 확인 대화상자 추가

* **개선 사항**
  * 하단 액션 바 레이아웃 및 버튼 동작 개선
  * 목록 페이징·선택 흐름의 외부 제어 및 상태 관리 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->