### PR TITLE
[FIX] 좋아요 및 스크랩 낙관적 업데이트 및 컴포넌트 UI 수정

### DIFF
--- a/apps/web/src/entities/post/api/queryKeys.ts
+++ b/apps/web/src/entities/post/api/queryKeys.ts
@@ -13,6 +13,16 @@ export const postQueryKeys = {
   detail: (postId: number) => [...postQueryKeys.details(), postId] as const,
 
   /* --------------------
+   * 좋아요
+   * -------------------- */
+
+  // 특정 게시글의 좋아요 관련 모든 쿼리 (목록, 개수 등)
+  likes: (postId: number) => [...postQueryKeys.detail(postId), 'likes'] as const,
+
+  // 좋아요를 누른 사용자 목록
+  likeUsers: (postId: number) => [...postQueryKeys.likes(postId), 'users'] as const,
+
+  /* --------------------
    * 게시판 기준 목록
    * -------------------- */
   board: (boardId: number) => [...postQueryKeys.lists(), 'board', boardId] as const,

--- a/apps/web/src/entities/user/ui/user-level/UserLevelBadges.tsx
+++ b/apps/web/src/entities/user/ui/user-level/UserLevelBadges.tsx
@@ -4,11 +4,10 @@ import type { UserLevel } from '@/entities/user/model/types';
 import ManagerBadge from '@/shared/assets/icons/profile/manager-badge.svg';
 import AdminBadge from '@/shared/assets/icons/profile/manager-badge.svg';
 import PresidentBadge from '@/shared/assets/icons/profile/manager-badge.svg';
-import MemberBadge from '@/shared/assets/icons/profile/manager-badge.svg';
 
-export const USER_LEVEL_BADGE: Record<UserLevel, ComponentType<SVGProps<SVGSVGElement>>> = {
+export const USER_LEVEL_BADGE: Record<UserLevel, ComponentType<SVGProps<SVGSVGElement>> | null> = {
   admin: AdminBadge,
   president: PresidentBadge,
   manager: ManagerBadge,
-  member: MemberBadge,
+  member: null,
 };

--- a/apps/web/src/features/comment/ui/Comment.tsx
+++ b/apps/web/src/features/comment/ui/Comment.tsx
@@ -81,7 +81,7 @@ export const Comment = ({
         onClick={onProfileClick}
       />
 
-      <div className="flex flex-col gap-7">
+      <div className="flex w-full flex-col gap-7">
         {/* 이름, 날짜, 시간, 더보기 */}
         <header className="flex items-center">
           <div className="flex gap-8">

--- a/apps/web/src/features/comment/ui/CommentOptionBottomSheet.tsx
+++ b/apps/web/src/features/comment/ui/CommentOptionBottomSheet.tsx
@@ -27,7 +27,7 @@ export const CommentOptionBottomSheet = ({
 
   return (
     <ModalSheet isOpen={isOpen} onClose={onClose}>
-      <ModalSheet.Container className="!right-0 !left-0 mx-auto max-w-[min(100dvw,calc(100dvh*375/812))]">
+      <ModalSheet.Container className="!right-0 !left-0 mx-auto sm:max-w-[min(100dvw,calc(100dvh*375/812))]">
         <ModalSheet.Content>
           <Sheet>
             <div className="flex flex-col">

--- a/apps/web/src/features/post/model/useGetPostLikesQuery.ts
+++ b/apps/web/src/features/post/model/useGetPostLikesQuery.ts
@@ -1,10 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
 import { getPostLikes } from '../api/getPostLikes';
 import { LikedUser } from '@/entities/post/api/types';
+import { postQueryKeys } from '@/entities/post/api/queryKeys';
 
 export function useGetPostLikesQuery(postId: number, enabled = true) {
   return useQuery<LikedUser[]>({
-    queryKey: ['postLikes', postId],
+    queryKey: postQueryKeys.likeUsers(postId),
     queryFn: () => getPostLikes(postId),
     enabled,
   });

--- a/apps/web/src/features/post/model/useToggleLikeMutation.ts
+++ b/apps/web/src/features/post/model/useToggleLikeMutation.ts
@@ -1,30 +1,30 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { InfiniteData, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toggleLike } from '../api/toggleLike';
 import { PostDetail } from '@/entities/post/model/types';
 import { postQueryKeys } from '@/entities/post/api/queryKeys';
+import { PostListApiResponse } from '@/entities/post/api/types';
 
 export const useToggleLikeMutation = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationKey: ['post', 'toggleLike'],
+    mutationKey: [...postQueryKeys.all, 'toggleLike'],
     mutationFn: ({ postId, liked }: { postId: number; liked: boolean }) =>
       toggleLike(postId, liked),
 
-    // optimistic update
     onMutate: async ({ postId, liked }) => {
-      const queryKey = postQueryKeys.detail(postId);
+      const detailKey = postQueryKeys.detail(postId);
+      const listKey = postQueryKeys.lists();
 
-      // 1) 기존 요청 취소
-      await queryClient.cancelQueries({ queryKey });
+      await queryClient.cancelQueries({ queryKey: detailKey });
+      await queryClient.cancelQueries({ queryKey: listKey });
 
-      // 2) 이전 데이터 백업
-      const prevData = queryClient.getQueryData<PostDetail>(queryKey);
+      const prevDetail = queryClient.getQueryData<PostDetail>(detailKey);
+      const prevLists = queryClient.getQueriesData({ queryKey: listKey });
 
-      // 3) 캐시 직접 수정 → UI 즉시 반영
-      queryClient.setQueryData<PostDetail | undefined>(queryKey, (old) => {
+      // 1. 상세 페이지 캐시 업데이트
+      queryClient.setQueryData<PostDetail>(detailKey, (old) => {
         if (!old) return old;
-
         return {
           ...old,
           likedByMe: !liked,
@@ -32,23 +32,74 @@ export const useToggleLikeMutation = () => {
         };
       });
 
-      return { prevData };
+      // 2. 목록 캐시 업데이트
+      queryClient.setQueriesData<InfiniteData<PostListApiResponse> | PostListApiResponse>(
+        { queryKey: listKey },
+        (old) => {
+          if (!old) return old;
+
+          // 무한 스크롤 데이터 구조인 경우 (InfiniteData)
+          if ('pages' in old) {
+            return {
+              ...old,
+              pages: old.pages.map((page) => ({
+                ...page,
+                content: page.content.map((post) =>
+                  post.postId === postId
+                    ? {
+                        ...post,
+                        likedByMe: !liked,
+                        likeCount: liked ? post.likeCount - 1 : post.likeCount + 1,
+                      }
+                    : post,
+                ),
+              })),
+            };
+          }
+
+          // 일반 페이징 데이터 구조인 경우 (PostListApiResponse)
+          if ('content' in old) {
+            return {
+              ...old,
+              content: old.content.map((post) =>
+                post.postId === postId
+                  ? {
+                      ...post,
+                      likedByMe: !liked,
+                      likeCount: liked ? post.likeCount - 1 : post.likeCount + 1,
+                    }
+                  : post,
+              ),
+            };
+          }
+
+          return old;
+        },
+      );
+
+      return { prevDetail, prevLists };
     },
 
     // 실패 시 롤백
     onError: (_err, variables, context) => {
-      const queryKey = postQueryKeys.detail(variables.postId);
-
-      if (context?.prevData) {
-        queryClient.setQueryData(queryKey, context.prevData);
+      // 상세 데이터 롤백
+      if (context?.prevDetail) {
+        queryClient.setQueryData(postQueryKeys.detail(variables.postId), context.prevDetail);
+      }
+      // 목록 데이터들 롤백 (getQueriesData로 백업한 모든 리스트 복구)
+      if (context?.prevLists) {
+        context.prevLists.forEach(([queryKey, oldData]) => {
+          queryClient.setQueryData(queryKey, oldData);
+        });
       }
     },
-
-    // 최종 서버 상태로 동기화
     onSettled: (_data, _error, variables) => {
-      const queryKey = postQueryKeys.detail(variables.postId);
+      const postId = variables.postId;
 
-      void queryClient.invalidateQueries({ queryKey });
+      // 게시글 상세 무효화
+      void queryClient.invalidateQueries({
+        queryKey: postQueryKeys.detail(postId),
+      });
     },
   });
 };

--- a/apps/web/src/features/post/model/useToggleScrapMutation.ts
+++ b/apps/web/src/features/post/model/useToggleScrapMutation.ts
@@ -1,30 +1,35 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { InfiniteData, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toggleScrap } from '../api/toggleScrap';
 import { PostDetail } from '@/entities/post/model/types';
 import { postQueryKeys } from '@/entities/post/api/queryKeys';
+import { PostListApiResponse } from '@/entities/post/api/types';
 
 export const useToggleScrapMutation = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationKey: ['post', 'toggleScrap'],
+    mutationKey: [...postQueryKeys.all, 'toggleScrap'],
     mutationFn: ({ postId, scrapped }: { postId: number; scrapped: boolean }) =>
       toggleScrap(postId, scrapped),
 
     // Optimistic update
     onMutate: async ({ postId, scrapped }) => {
-      const queryKey = postQueryKeys.detail(postId);
+      const detailKey = postQueryKeys.detail(postId);
+      const listKey = postQueryKeys.lists();
 
-      // 1) 기존 요청 취소
-      await queryClient.cancelQueries({ queryKey });
+      await queryClient.cancelQueries({ queryKey: detailKey });
+      await queryClient.cancelQueries({ queryKey: listKey });
 
-      // 2) 이전 데이터 백업
-      const prevData = queryClient.getQueryData<PostDetail>(queryKey);
+      const prevDetail = queryClient.getQueryData<PostDetail>(detailKey);
+      const prevLists = queryClient.getQueriesData<
+        InfiniteData<PostListApiResponse> | PostListApiResponse
+      >({
+        queryKey: listKey,
+      });
 
-      // 3) 캐시 직접 수정 → UI 즉시 반영
-      queryClient.setQueryData<PostDetail | undefined>(queryKey, (old) => {
+      // 1. 상세 페이지 캐시 업데이트
+      queryClient.setQueryData<PostDetail>(detailKey, (old) => {
         if (!old) return old;
-
         return {
           ...old,
           scrappedByMe: !scrapped,
@@ -32,23 +37,58 @@ export const useToggleScrapMutation = () => {
         };
       });
 
-      return { prevData };
+      // 2. 목록 캐시 업데이트
+      queryClient.setQueriesData<InfiniteData<PostListApiResponse> | PostListApiResponse>(
+        { queryKey: listKey },
+        (old) => {
+          if (!old) return old;
+
+          // 무한 스크롤 구조
+          if ('pages' in old) {
+            return {
+              ...old,
+              pages: old.pages.map((page) => ({
+                ...page,
+                content: page.content.map((post) =>
+                  post.postId === postId ? { ...post, scrappedByMe: !scrapped } : post,
+                ),
+              })),
+            };
+          }
+
+          // 일반 페이징 구조
+          if ('content' in old) {
+            return {
+              ...old,
+              content: old.content.map((post) =>
+                post.postId === postId ? { ...post, scrappedByMe: !scrapped } : post,
+              ),
+            };
+          }
+
+          return old;
+        },
+      );
+
+      return { prevDetail, prevLists };
     },
 
-    // 실패 시 롤백
     onError: (_err, variables, context) => {
-      const queryKey = postQueryKeys.detail(variables.postId);
-
-      if (context?.prevData) {
-        queryClient.setQueryData(queryKey, context.prevData);
+      if (context?.prevDetail) {
+        queryClient.setQueryData(postQueryKeys.detail(variables.postId), context.prevDetail);
+      }
+      if (context?.prevLists) {
+        context.prevLists.forEach(([queryKey, oldData]) => {
+          queryClient.setQueryData(queryKey, oldData);
+        });
       }
     },
 
-    // 성공/실패 관계없이 최종 서버 상태로 동기화
     onSettled: (_data, _error, variables) => {
-      const queryKey = postQueryKeys.detail(variables.postId);
-
-      void queryClient.invalidateQueries({ queryKey });
+      // 게시글 상세 무효화
+      void queryClient.invalidateQueries({ queryKey: postQueryKeys.detail(variables.postId) });
+      // 내가 스크랩한 게시글 무효화
+      void queryClient.invalidateQueries({ queryKey: postQueryKeys.scraps() });
     },
   });
 };

--- a/apps/web/src/features/post/post-like/ui/PostLikeBottomSheet.tsx
+++ b/apps/web/src/features/post/post-like/ui/PostLikeBottomSheet.tsx
@@ -40,7 +40,7 @@ export const PostLikeBottomSheet = ({
       <ModalSheet.Container className="!right-0 !left-0 mx-auto w-full sm:max-w-[min(100dvw,calc(100dvh*375/812))]">
         <ModalSheet.Content>
           <Sheet title="좋아요를 누른 사람">
-            <div className="flex flex-col">
+            <div className="flex flex-col pt-12">
               {/* 로딩 */}
               {isLoading && <div className="py-4 text-center text-gray-500">불러오는 중...</div>}
 


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 any가 사용되지 않았습니다
- [x] 스토리북에 추가했습니다 (해당 시)
- [x] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈

- #480
- close #465

## 📌 작업 목적

- 2차 QA 이슈를 해결합니다.

## 🔨 주요 작업 내용

- 좋아요 및 스크랩 정합성 유지
- 좋아요 한 목록 바텀시트, 댓글 컴포넌트 UI 피그마와 통일
- 멤버 뱃지 삭제
- 댓글 더보기 바텀시트 너비 수정 (비율 이상한 문제 해결)

## ⚠️ 기존 문제

- 좋아요 토글시 게시글 상세만 낙관적 업데이트가 되었고, 게시글 목록(게시판) 상태는 낙관적 업데이트가 되지 않음
- 스크랩 토글시 내가 스크랩한 게시글 캐시가 무효화되지 않음

## ☑️ 해결 방법

- 좋아요 : 게시글 목록도 낙관적 업데이트
- 스크랩 : 내가 스크랩한 게시글 캐시 무효화

## 🧪 테스트 방법

- 좋아요 토글 후 -> 좋아요 한 목록, 게시글 목록에서 최신 정보 업데이트가 되는지 확인
- 글 스크랩 후 내가 스크랩한 게시글 가기 -> 게시글 조회 후 스크랩 해제 -> 뒤로 가서 내가 스크랩한 게시글 목록에서 지워졌는지 확인
- 주소록에서 member인 회원인 뱃지가 안 보이는지 확인
- 댓글 더보기 바텀시트 너비가 앱 너비와 일치한지 확인

## 💬 논의할 점

- 스크랩은 게시글 목록 낙관적 업데이트가 필요 없긴 한데, 좋아요 하는 김에 일단 같이 해두었습니다!



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * 좋아요 및 스크랩 기능의 캐시 처리를 최적화하여 사용자 인터랙션에 대한 응답 속도 개선

* **Style**
  * 댓글 영역의 너비 제약 추가로 레이아웃 개선
  * 바텀 시트의 반응형 디자인 개선 (작은 화면에서의 표시 최적화)
  * 좋아요 목록 바텀 시트의 상단 여백 조정

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->