### PR TITLE
[FIX] 뒤로가기시 알림탭 보존 및 일정/예약 데이터 초기화 문제 해결

### DIFF
--- a/apps/web/src/app-pages/home/ui/HomePageClient.tsx
+++ b/apps/web/src/app-pages/home/ui/HomePageClient.tsx
@@ -63,7 +63,7 @@ export const HomePageClient = ({ heroProps }: { heroProps: HeroCardProps }) => {
           <AnnouncementBar
             title={homeData?.announcementTitle ?? 'Title'}
             date={homeData?.announcementDate ?? '00.00'}
-            category="regular" // TODO: 카테고리 데이터 필요 {homeData?.announcementCategory ?? 'regular'}
+            category="regular" // 정규 행사만 보여줌
             onClick={() => {
               if (!deepLink) {
                 if (process.env.NODE_ENV === 'development') {

--- a/apps/web/src/app-pages/home/ui/HomePageClient.tsx
+++ b/apps/web/src/app-pages/home/ui/HomePageClient.tsx
@@ -63,7 +63,7 @@ export const HomePageClient = ({ heroProps }: { heroProps: HeroCardProps }) => {
           <AnnouncementBar
             title={homeData?.announcementTitle ?? 'Title'}
             date={homeData?.announcementDate ?? '00.00'}
-            category="regular" // 카테고리 데이터 필요 {homeData?.announcementCategory ?? 'regular'}
+            category="regular" // TODO: 카테고리 데이터 필요 {homeData?.announcementCategory ?? 'regular'}
             onClick={() => {
               if (!deepLink) {
                 if (process.env.NODE_ENV === 'development') {

--- a/apps/web/src/app-pages/notification/ui/NotificationPage.tsx
+++ b/apps/web/src/app-pages/notification/ui/NotificationPage.tsx
@@ -3,8 +3,8 @@
 import { HeaderMode } from '@surf/ui/header';
 import { useToastStore } from '@surf/ui/store/toastStore';
 import { Tab } from '@surf/ui/tab';
-import { useRouter } from 'next/navigation';
-import { useState, useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useEffect } from 'react';
 import type { NotificationTab } from '@/entities/notification/model/notificationTab';
 import { useGetNotifications } from '@/entities/notification/model/useGetNotifications';
 import { useReadNotification } from '@/entities/notification/model/useReadNotification';
@@ -20,7 +20,8 @@ const tabItems = [
 
 export const NotificationPage = () => {
   const router = useRouter();
-  const [currentTab, setCurrentTab] = useState<NotificationTab>('ALL');
+  const searchParams = useSearchParams();
+  const currentTab = (searchParams.get('tab') as NotificationTab) || 'ALL';
   const showToast = useToastStore((state) => state.show);
 
   useEffect(() => {
@@ -32,14 +33,16 @@ export const NotificationPage = () => {
   }, [showToast]);
 
   const { data, isLoading } = useGetNotifications(currentTab);
-  const { mutate: readNotification, isPending } = useReadNotification();
+  const { mutate: readNotification } = useReadNotification();
 
   const handleBack = () => {
     router.back();
   };
 
   const handleTabChange = (value: string) => {
-    setCurrentTab(value as NotificationTab);
+    const newParams = new URLSearchParams(searchParams.toString());
+    newParams.set('tab', value);
+    router.replace(`?${newParams.toString()}`);
   };
 
   const handleNotificationClick = (id: number, deepLink: string, isRead: boolean) => {
@@ -57,7 +60,7 @@ export const NotificationPage = () => {
 
   const renderContent = () => {
     // 로딩 중일 때(임시)
-    if (isLoading || isPending) {
+    if (isLoading) {
       return <div className="p-20 text-center text-gray-500">로딩 중...</div>;
     }
 
@@ -74,10 +77,6 @@ export const NotificationPage = () => {
           {emptyMessages[currentTab]}
         </div>
       );
-    }
-
-    if (isPending) {
-      return <div className="p-20 text-center text-gray-500">로딩 중...</div>;
     }
 
     // 데이터가 있을 때

--- a/apps/web/src/app-pages/notification/ui/NotificationPage.tsx
+++ b/apps/web/src/app-pages/notification/ui/NotificationPage.tsx
@@ -5,14 +5,17 @@ import { useToastStore } from '@surf/ui/store/toastStore';
 import { Tab } from '@surf/ui/tab';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect } from 'react';
-import type { NotificationTab } from '@/entities/notification/model/notificationTab';
+import {
+  NOTIFICATION_TABS,
+  type NotificationTab,
+} from '@/entities/notification/model/notificationTab';
 import { useGetNotifications } from '@/entities/notification/model/useGetNotifications';
 import { useReadNotification } from '@/entities/notification/model/useReadNotification';
 import { NotificationList } from '@/entities/notification/ui/NotificationList';
 import NotificationEmpty from '@/shared/assets/icons/empty-space/notification-empty.svg';
 import { AppHeader } from '@/widgets/header/ui/AppHeader';
 
-const tabItems = [
+const tabItems: { value: NotificationTab; label: string }[] = [
   { value: 'ALL', label: '전체' },
   { value: 'ACTIVITY', label: '활동' },
   { value: 'SCHEDULE', label: '일정' },
@@ -21,7 +24,11 @@ const tabItems = [
 export const NotificationPage = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const currentTab = (searchParams.get('tab') as NotificationTab) || 'ALL';
+  const tabParam = searchParams.get('tab');
+  const currentTab: NotificationTab =
+    tabParam && (NOTIFICATION_TABS as readonly string[]).includes(tabParam)
+      ? (tabParam as NotificationTab)
+      : 'ALL';
   const showToast = useToastStore((state) => state.show);
 
   useEffect(() => {

--- a/apps/web/src/entities/calendar/ui/CalendarBadge/CalendarBadge.tsx
+++ b/apps/web/src/entities/calendar/ui/CalendarBadge/CalendarBadge.tsx
@@ -1,8 +1,10 @@
+import { ScheduleCategory } from '@/entities/schedule/model/types';
+
 type CalendarBadgeProps = {
-  variation: 'regular' | 'operation' | 'other';
+  variation: ScheduleCategory;
 };
 
-const BADGE_STYLE = {
+const BADGE_STYLE: Record<ScheduleCategory, { text: string; color: string }> = {
   regular: {
     text: '정규행사',
     color:

--- a/apps/web/src/entities/post/api/postApi.ts
+++ b/apps/web/src/entities/post/api/postApi.ts
@@ -7,6 +7,7 @@ import type {
   PostDetailResponse,
   PostScheduleResponse,
 } from './types';
+import { getValidCategory } from '@/entities/schedule/model/constants';
 
 export const postApi = {
   getMyPosts: async (params: Partial<PostApiRequest>): Promise<PostListApiResponse> => {
@@ -51,7 +52,11 @@ export const postApi = {
       const { data } = await axiosInstance.get<PostScheduleResponse>(
         `/v1/user/post/${postId}/schedule`,
       );
-      return data.data;
+      const rawData = data.data;
+      return {
+        ...rawData,
+        category: getValidCategory(rawData.category),
+      };
     } catch (error) {
       console.error('Error fetching post schedule:', error);
       throw error;

--- a/apps/web/src/entities/schedule/model/constants.ts
+++ b/apps/web/src/entities/schedule/model/constants.ts
@@ -15,3 +15,14 @@ export const CATEGORY_MAP = SCHEDULE_CATEGORIES.reduce(
   (acc, { value, label }) => ({ ...acc, [label]: value }),
   {} as Record<string, ScheduleCategory>,
 );
+
+// 유효한 value들만 모은 배열 ( ['regular', 'operation', 'other'] )
+const VALID_CATEGORY_VALUES = SCHEDULE_CATEGORIES.map((c) => c.value);
+
+/** 서버 데이터가 유효한 ScheduleCategory인지 확인하는 가드 함수 */
+export const getValidCategory = (value: string | undefined): ScheduleCategory => {
+  if (value && VALID_CATEGORY_VALUES.includes(value as ScheduleCategory)) {
+    return value as ScheduleCategory;
+  }
+  return 'regular'; // 유효하지 않거나 없으면 기본값 반환
+};

--- a/apps/web/src/features/post/post-form/model/usePostInitialization.ts
+++ b/apps/web/src/features/post/post-form/model/usePostInitialization.ts
@@ -66,12 +66,9 @@ export const usePostInitialization = ({
     // 예약 정보 계산
     let initialReserved = false;
     let initialReservedAt: Date | null = null;
-    if (postDetail?.postedAt) {
-      const postedDate = new Date(postDetail.postedAt);
-      if (postedDate > new Date()) {
-        initialReserved = true;
-        initialReservedAt = postedDate;
-      }
+    if (postDetail?.isReserved && postDetail?.reservedAt) {
+      initialReserved = true;
+      initialReservedAt = new Date(postDetail.reservedAt);
     }
 
     // 일정 정보 매핑

--- a/apps/web/src/features/schedule/edit/api/getSingleSchedule.ts
+++ b/apps/web/src/features/schedule/edit/api/getSingleSchedule.ts
@@ -1,12 +1,23 @@
 import { axiosInstance } from '@/shared/lib/axiosInstance';
 import { SingleScheduleResponse, SingleSchedule } from './types';
+import { getValidCategory } from '@/entities/schedule/model/constants';
 
 export const getSingleSchedule = async (scheduleId: number): Promise<SingleSchedule> => {
-  const response = await axiosInstance.get<SingleScheduleResponse>(
-    `/v1/admin/calendar/schedules/${scheduleId}`,
-  );
-  // TODO: 로그 삭제 예정
-  console.log('getSingleSchedule response:', response);
+  try {
+    const response = await axiosInstance.get<SingleScheduleResponse>(
+      `/v1/admin/calendar/schedules/${scheduleId}`,
+    );
 
-  return response.data.data;
+    const rawData = response.data.data;
+
+    // 서버 데이터를 신뢰할 수 있는 데이터로 변환하여 반환
+    return {
+      ...rawData,
+      category: getValidCategory(rawData.category),
+    };
+  } catch (error) {
+    // 에러 발생 시 콘솔에 상세 내용을 찍고 에러를 다시 던집니다.
+    console.error(`Error fetching single schedule (ID: ${scheduleId}):`, error);
+    throw error;
+  }
 };

--- a/apps/web/src/features/schedule/model/useScheduleFormInit.ts
+++ b/apps/web/src/features/schedule/model/useScheduleFormInit.ts
@@ -3,7 +3,6 @@ import { useCreatePostScheduleStore } from '../create-post-schedule/model/useCre
 import { useGetSingleSchedule } from '../edit/model/useGetSingleSchedule';
 import { toFormLocation } from '../create/api/mapper';
 import { ScheduleFormData } from '../create/model/types';
-import { CATEGORY_MAP } from '@/entities/schedule/model/constants';
 
 type InitProps = {
   entryPoint: 'calendar' | 'post';
@@ -54,7 +53,7 @@ export const useScheduleFormInit = ({
         startDate: new Date(serverData.startAt),
         endDate: new Date(serverData.endAt),
         location: toFormLocation(serverData.location),
-        category: CATEGORY_MAP[serverData.category] || 'regular',
+        category: serverData.category || 'regular',
       } as ScheduleFormData;
     }
     return null;


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 any가 사용되지 않았습니다
- [x] 스토리북에 추가했습니다 (해당 시)
- [x] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈

- close #480

## 📌 작업 목적

- 2차 QA 이슈를 해결합니다.

## 🔨 주요 작업 내용

- 알림 탭 정보 쿼리 파라미터 저장
- 게시글 예약 초기화 로직 백엔드 응답에 맞추어 수정
- 캘린더 카테고리 초기화 컨벤션에 맞추어 수정

## ⚠️ 기존 문제

- 알림 탭 정보를 내부 useState로만 관리하고 있어서 경로를 기억할 수 없었습니다.
- 게시글 예약 초기화 로직에서 백엔드 응답을 활용하지 않고 있었습니다.
- 캘린더 카테고리 초기화에서 불필요한 매핑을 하고 있었습니다.

## ☑️ 해결 방법

- 알림 탭 정보를 쿼리 파라미터로 저장하였습니다.
- 게시글 예약 초기화를 `isReserved`, `reservedAt` 필드를 활용했습니다.
- 불필요한 매핑을 삭제하고, 단건 일정, 게시글 일정 조회 api에서 유효한 카테고리인지 검사 후 데이터를 반환하도록 했습니다.

## 🧪 테스트 방법

- 알림 활동/일정 탭에서 게시글 접속 후 뒤로가기 하면 탭 경로가 일치하는지 확인
- 게시글 예약 후 수정시 자신이 예약한 시간으로 나오는지 확인
- 캘린더에서 "정규행사"가 아닌 일정 수정시 카테고리가 기존과 일치하는지 확인 

## 💬 논의할 점

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 알림 페이지의 탭 선택이 URL에 저장되어 공유 및 복원이 가능합니다.
  * 일정 카테고리 데이터의 유효성 검사를 강화하여 안정성을 개선했습니다.
  * 예약된 게시물 상태 처리 로직을 개선했습니다.

* **버그 픽스 / 안정성**
  * 서버에서 받아온 일정·게시물 카테고리를 런타임에서 검증하고 기본값을 적용해 데이터 일관성 개선.
  * 단일 일정 조회 시 에러 처리와 로깅을 추가해 실패 상황 대응 향상.

* **리팩터**
  * 일정 배지의 카테고리 타입 검증을 명확히 해 런타임 입력 검증을 보강했습니다.

* **문서화**
  * 주석을 한국어로 정비하여 가독성 개선.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->