### PR TITLE
[FEAT] 어드민 가입 신청 회원 검색 디바운스 처리

### DIFF
--- a/apps/admin/src/app-pages/signup-request/ui/SignupRequestPage.tsx
+++ b/apps/admin/src/app-pages/signup-request/ui/SignupRequestPage.tsx
@@ -3,6 +3,7 @@
 import { TextInput } from '@surf/ui/text-input';
 import { useState } from 'react';
 
+import { useDebouncedValue } from '@/shared/hooks/useDebouncedValue';
 import { SignupRequestListWidget } from '@/widgets/signup-request/ui/SignupRequestListWidget';
 
 /**
@@ -10,6 +11,7 @@ import { SignupRequestListWidget } from '@/widgets/signup-request/ui/SignupReque
  */
 export const SignupRequestPage = () => {
   const [keyword, setKeyword] = useState('');
+  const debouncedKeyword = useDebouncedValue(keyword, 300);
 
   return (
     <main className="flex h-full w-full flex-col">
@@ -24,7 +26,7 @@ export const SignupRequestPage = () => {
         />
       </div>
       {/* 회원가입 요청 리스트 위젯, 승인/거절 액션 수행 */}
-      <SignupRequestListWidget keyword={keyword} />
+      <SignupRequestListWidget keyword={debouncedKeyword} />
     </main>
   );
 };

--- a/apps/admin/src/shared/hooks/useDebouncedValue.ts
+++ b/apps/admin/src/shared/hooks/useDebouncedValue.ts
@@ -57,11 +57,13 @@ export function useDebouncedValue<T>(
     if (leading && !timeoutRef.current) {
       setDebouncedValue(value);
       lastUpdateTime.current = Date.now();
+      timeoutRef.current = null;
     }
 
     // 기존 타이머 정리
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
     }
 
     // maxWait 처리
@@ -83,7 +85,7 @@ export function useDebouncedValue<T>(
     }
 
     // trailing 타이머 설정
-    timeoutRef.current = setTimeout(() => {
+    const timeoutId = setTimeout(() => {
       setDebouncedValue(value);
       lastUpdateTime.current = Date.now();
       timeoutRef.current = null;
@@ -94,13 +96,16 @@ export function useDebouncedValue<T>(
         maxWaitTimeoutRef.current = null;
       }
     }, delay);
+    timeoutRef.current = timeoutId;
 
     return () => {
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
       }
       if (maxWaitTimeoutRef.current) {
         clearTimeout(maxWaitTimeoutRef.current);
+        maxWaitTimeoutRef.current = null;
       }
     };
   }, [value, delay, leading, maxWait]);

--- a/apps/admin/src/shared/hooks/useDebouncedValue.ts
+++ b/apps/admin/src/shared/hooks/useDebouncedValue.ts
@@ -1,0 +1,109 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+export interface DebouncedValueOptions {
+  /** 첫 변경 시 즉시 반영 (기본: false) */
+  leading?: boolean;
+  /** 최대 대기 시간 - 이 시간이 지나면 강제 반영 */
+  maxWait?: number;
+}
+
+/**
+ * 값의 변경을 디바운스하여 반환하는 훅
+ *
+ * @param value - 디바운스할 값
+ * @param delay - 디바운스 지연 시간 (ms, 기본: 300)
+ * @param options - 디바운스 옵션
+ * @returns 디바운스된 값
+ *
+ * @example
+ * // 기본 사용 (trailing)
+ * const debouncedKeyword = useDebouncedValue(keyword, 300);
+ *
+ * @example
+ * // 첫 입력 즉시 반영
+ * const debouncedKeyword = useDebouncedValue(keyword, 300, { leading: true });
+ *
+ * @example
+ * // 연속 입력해도 2초마다 중간 결과 반영
+ * const debouncedKeyword = useDebouncedValue(keyword, 300, { maxWait: 2000 });
+ */
+export function useDebouncedValue<T>(
+  value: T,
+  delay = 300,
+  options: DebouncedValueOptions = {},
+): T {
+  const { leading = false, maxWait } = options;
+
+  const [debouncedValue, setDebouncedValue] = useState(value);
+  const isFirstRender = useRef<boolean>(true);
+  const lastUpdateTime = useRef<number>(Date.now());
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const maxWaitTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    // 첫 렌더링 시 leading 옵션 처리
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      if (leading) {
+        setDebouncedValue(value);
+        lastUpdateTime.current = Date.now();
+      }
+      return;
+    }
+
+    // leading: 값이 변경되고 이전 타이머가 없으면 즉시 반영
+    if (leading && !timeoutRef.current) {
+      setDebouncedValue(value);
+      lastUpdateTime.current = Date.now();
+    }
+
+    // 기존 타이머 정리
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+
+    // maxWait 처리
+    if (maxWait && !maxWaitTimeoutRef.current) {
+      const elapsed = Date.now() - lastUpdateTime.current;
+      const remainingMaxWait = Math.max(0, maxWait - elapsed);
+
+      maxWaitTimeoutRef.current = setTimeout(() => {
+        setDebouncedValue(value);
+        lastUpdateTime.current = Date.now();
+        maxWaitTimeoutRef.current = null;
+
+        // trailing 타이머도 정리
+        if (timeoutRef.current) {
+          clearTimeout(timeoutRef.current);
+          timeoutRef.current = null;
+        }
+      }, remainingMaxWait);
+    }
+
+    // trailing 타이머 설정
+    timeoutRef.current = setTimeout(() => {
+      setDebouncedValue(value);
+      lastUpdateTime.current = Date.now();
+      timeoutRef.current = null;
+
+      // maxWait 타이머 정리
+      if (maxWaitTimeoutRef.current) {
+        clearTimeout(maxWaitTimeoutRef.current);
+        maxWaitTimeoutRef.current = null;
+      }
+    }, delay);
+
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+      if (maxWaitTimeoutRef.current) {
+        clearTimeout(maxWaitTimeoutRef.current);
+      }
+    };
+  }, [value, delay, leading, maxWait]);
+
+  return debouncedValue;
+}


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 코드에 any가 사용되지 않았습니다
- [ ] 스토리북에 추가했습니다 (해당 시)
- [ ] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈

- close #481 

## 📌 작업 목적

- 어드민 가입 신청 목록에서 키워드 검색 진행 시 디바운싱 적용하여 API 호출 최적화

## 🔨 주요 작업 내용

- 값의 변경을 디바운스하여 반환하는`useDebouncedValue` 훅 추가
- 어드민 가입 신청 목록 검색 시 300ms 디바운스로 API 호출 최적화


## 🧪 테스트 방법

- 어드민 가입 신청 목록에서 검색이 끝나면 


## 📷 실행 영상 또는 스크린샷

https://github.com/user-attachments/assets/454d5107-b8a8-44b2-89c1-938b3ceb2fb7

## 💬 논의할 점: useDebounceValue 훅 설명

### 개요
값의 변경을 디바운스하여 반환하는 커스텀 훅. 검색 입력 등에서 불필요한 API 호출을 줄이는 데 활용.

### 시그니처

```
function useDebouncedValue<T>(
  value: T,
  delay?: number,           // 기본값: 300ms
  options?: DebouncedValueOptions
): T
```
### 옵션
| 옵션 | 타입 | 기본값 | 설명 |
|---|---|----|----|
| leading | boolean | false | 첫 변경 시 즉시 반영 |
| maxWait | number | - | 최대 대기 시간 |

### 사용 예시
```
// 1. 기본 사용 (trailing) - 입력 종료 후 300ms 뒤 반영
const debouncedKeyword = useDebouncedValue(keyword, 300);

// 2. leading - 첫 입력 즉시 반영 + 이후 디바운스
const debouncedKeyword = useDebouncedValue(keyword, 300, { leading: true });

// 3. maxWait - 연속 입력해도 최대 2초마다 중간 결과 반영
const debouncedKeyword = useDebouncedValue(keyword, 300, { maxWait: 2000 });
```
### 동작 방식

```
[trailing 모드 - 기본]
입력: a---b---c---------
출력: ----------------c  (마지막 입력 후 delay 경과 시)

[leading 모드]
입력: a---b---c---------
출력: a---------------c  (첫 입력 즉시 + 마지막 입력 후)

[maxWait 모드]
입력: a--b--c--d--e--f--g--------
출력: --------d--------g  (maxWait마다 강제 반영)

```




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 검색 키워드에 지연 처리 기능을 추가하여 검색 성능 최적화
  * 설정 가능한 옵션을 통해 선행 실행 및 최대 대기 시간 제어 기능 지원

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->