### PR TITLE
[CHORE] 홈 이벤트 로그 추가

### DIFF
--- a/apps/web/src/app-pages/home/ui/HomePageClient.tsx
+++ b/apps/web/src/app-pages/home/ui/HomePageClient.tsx
@@ -12,11 +12,16 @@ import { useGetNotifications } from '@/entities/notification/model/useGetNotific
 import { AnnouncementBar } from '@/entities/schedule/ui/announcement-bar/AnnouncementBar';
 import type { HeroCardProps } from '@/features/home-theme/ui/hero-card/HeroCard';
 import { HeroCard } from '@/features/home-theme/ui/hero-card/HeroCard';
+import { trackHomeEvent } from '@/features/home-tracking/lib/trackHomeEvent';
+import { HOME_EVENTS } from '@/features/home-tracking/model/constants';
+import { usePageName } from '@/shared/analytics/lib/getPageName';
 import { PAGE_ROUTES } from '@/shared/config/path';
 import { AppHeader } from '@/widgets/header/ui/AppHeader';
 
 export const HomePageClient = ({ heroProps }: { heroProps: HeroCardProps }) => {
   const router = useRouter();
+  const trackRef = useRef(false);
+  const pageName = usePageName();
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const [isHeaderSolid, setIsHeaderSolid] = useState(false);
 
@@ -49,6 +54,12 @@ export const HomePageClient = ({ heroProps }: { heroProps: HeroCardProps }) => {
     }
     router.push(link);
   };
+
+  useEffect(() => {
+    if (trackRef.current) return;
+    trackRef.current = true;
+    trackHomeEvent(HOME_EVENTS.PAGE_VIEW, { page_name: pageName });
+  }, [pageName]);
 
   useEffect(() => {
     const el = scrollRef.current;

--- a/apps/web/src/app-pages/home/ui/HomePageClient.tsx
+++ b/apps/web/src/app-pages/home/ui/HomePageClient.tsx
@@ -53,6 +53,7 @@ export const HomePageClient = ({ heroProps }: { heroProps: HeroCardProps }) => {
       console.log(`${label} 클릭 - ${link}로 이동`);
     }
     router.push(link);
+    trackHomeEvent(HOME_EVENTS.SHORTCUT_CLICK, { target: label });
   };
 
   useEffect(() => {

--- a/apps/web/src/features/home-tracking/lib/trackHomeEvent.ts
+++ b/apps/web/src/features/home-tracking/lib/trackHomeEvent.ts
@@ -1,0 +1,4 @@
+import { createDomainTracker } from '@/shared/lib/createDomainTracker';
+import { HomeEventPropsMap } from '../model/constants';
+
+export const trackHomeEvent = createDomainTracker<HomeEventPropsMap>();

--- a/apps/web/src/features/home-tracking/model/constants.ts
+++ b/apps/web/src/features/home-tracking/model/constants.ts
@@ -1,0 +1,15 @@
+/**
+ *  이벤트 이름
+ */
+export const HOME_EVENTS = {
+  PAGE_VIEW: 'page_view',
+  SHORTCUT_CLICK: 'shortcut_click',
+} as const;
+
+/**
+ * 이벤트별 속성 타입 매핑
+ */
+export type HomeEventPropsMap = {
+  [HOME_EVENTS.PAGE_VIEW]: { page_name: string };
+  [HOME_EVENTS.SHORTCUT_CLICK]: { target: string };
+};


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 any가 사용되지 않았습니다
- [x] 스토리북에 추가했습니다 (해당 시)
- [x] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈
- close #506 

## 📌 작업 목적
- 홈 이벤트 로그 추가

## 🔨 주요 작업 내용
- page_view
- shortcut_click

## 🧪 테스트 방법
1. amplitude 사이트 접속 + 로컬 사이트 접속
2. page_view와 각각의 shortcut 클릭 시 shortcut 클릭 이벤트가 찍히는지 확인

## ✔️ 설치 라이브러리
-

## 📷 실행 영상 또는 스크린샷
-

## 💬 논의할 점
-

## 🙋🏻 참고 자료
-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 홈 페이지의 사용자 상호작용 추적이 추가되었습니다.
  * 페이지 방문 및 바로가기 클릭 이벤트를 분석하여 서비스 개선에 활용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->