### PR TITLE
[Chore] 서버 DTO 업데이트 깃허브 액션 워크플로우 추가

### DIFF
--- a/.github/workflows/update-openapi-types.yml
+++ b/.github/workflows/update-openapi-types.yml
@@ -1,0 +1,80 @@
+name: Update OpenAPI Types (Admin)
+
+on:
+  workflow_dispatch:
+    inputs:
+      api_docs_url:
+        description: 'OpenAPI JSON URL (비우면 repo variable 사용)'
+        required: false
+        default: ''
+      output_file:
+        description: 'Generated types output file'
+        required: true
+        default: 'apps/admin/src/shared/api/__generated__/openapi.d.ts'
+      base_branch:
+        description: 'Base branch to run on'
+        required: true
+        default: 'develop'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: openapi-types-admin
+  cancel-in-progress: true
+
+jobs:
+  update-openapi:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.base_branch }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Ensure output dir
+        run: mkdir -p "$(dirname "${{ inputs.output_file }}")"
+
+      - name: Generate OpenAPI types
+        run: |
+          API_URL="${{ inputs.api_docs_url }}"
+          if [ -z "$API_URL" ]; then API_URL="${{ vars.ADMIN_OPENAPI_URL }}"; fi
+
+          if [ -z "$API_URL" ]; then
+            echo "❌ OpenAPI URL is empty. Provide inputs.api_docs_url or set vars.ADMIN_OPENAPI_URL."
+            exit 1
+          fi
+
+          npx -y openapi-typescript@7.10.1 "$API_URL" -o "${{ inputs.output_file }}"
+
+      - name: Check changes
+        id: diff
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create PR
+        if: steps.diff.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          base: ${{ inputs.base_branch }}
+          commit-message: 'chore: 서버 타입 업데이트'
+          title: '[Chore] 서버 타입 업데이트'
+          body: |
+            ## 📌 작업 목적
+            - OpenAPI 스펙을 기준으로 타입 파일을 재생성
+            - 대상 파일: `${{ inputs.output_file }}`
+
+          branch: 'chore/update-openapi-types'
+          delete-branch: true
+          add-paths: |
+            ${{ inputs.output_file }}


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 코드에 any가 사용되지 않았습니다
- [ ] 스토리북에 추가했습니다 (해당 시)
- [ ] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈

- close #517 

## 📌 작업 목적

Swagger(OpenAPI) 스펙 변경 시 `openapi-typescript`로 생성되는 타입 파일을 수동으로 갱신하고,
변경 사항이 있을 때만 자동 PR로 올릴 수 있도록 워크플로우를 추가했습니다.

## 🔨 주요 작업 내용

- `.github/workflows/update-openapi-types-admin.yml` 추가
- GitHub Actions `workflow_dispatch`로 수동 실행 지원
- 실행 시 OpenAPI JSON URL을 입력하거나, 비워두면 `vars.ADMIN_OPENAPI_URL`을 사용
- 타입 생성 후 변경이 있는 경우에만 `chore/update-openapi-types` 브랜치로 PR 자동 생성


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * OpenAPI 타입 자동 업데이트 워크플로우 추가: 관리자가 수동으로 트리거하여 API 문서에서 타입 정의를 생성하고 변경 사항을 자동으로 풀 리퀘스트로 제출합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->