### PR TITLE
[FEAT] 어드민 가입 신청 목록 API 변경사항 반영

### DIFF
--- a/apps/admin/src/app-pages/signup-request/ui/SignupRequestPage.tsx
+++ b/apps/admin/src/app-pages/signup-request/ui/SignupRequestPage.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { TextInput } from '@surf/ui/text-input';
-import { useState } from 'react';
+import { Suspense, useState } from 'react';
 
 import { useDebouncedValue } from '@/shared/hooks/useDebouncedValue';
+import { ErrorBoundary } from '@/shared/ui/ErrorBoundary';
 import { SignupRequestListWidget } from '@/widgets/signup-request/ui/SignupRequestListWidget';
 
 /**
@@ -25,8 +26,14 @@ export const SignupRequestPage = () => {
           onChange={(value) => setKeyword(value)}
         />
       </div>
-      {/* 회원가입 요청 리스트 위젯, 승인/거절 액션 수행 */}
-      <SignupRequestListWidget keyword={debouncedKeyword} />
+      {/* 회원가입 요청 리스트 위젯, 승인/거절 액션 수행 
+        TODO: 에러/로딩 컴포넌트 적용 필요
+      */}
+      <ErrorBoundary fallback={<div>error</div>}>
+        <Suspense fallback={<div>loading...</div>}>
+          <SignupRequestListWidget keyword={debouncedKeyword} />
+        </Suspense>
+      </ErrorBoundary>
     </main>
   );
 };

--- a/apps/admin/src/entities/member/api/types.ts
+++ b/apps/admin/src/entities/member/api/types.ts
@@ -1,7 +1,9 @@
 import type { components } from '@/shared/api/__generated__/openapi';
 import { CommonResponse } from '@/shared/api/types';
 
-export type MemberInformationResDTO = components['schemas']['MemberInformationResDTO'];
+type Schemas = components['schemas'];
+
+export type MemberInformationResDTO = Schemas['MemberInformationResDTO'];
 
 /**
  * 멤버 정보 조회 응답

--- a/apps/admin/src/entities/member/model/mapper.ts
+++ b/apps/admin/src/entities/member/model/mapper.ts
@@ -2,7 +2,6 @@ import type { MemberInformationResDTO } from '../api/types';
 
 import type { Career, Member, MemberStatus, MemberTrack, TrackPart } from './types';
 
-type ApiTrack = NonNullable<MemberInformationResDTO['trackList']>[number];
 type ApiCareer = NonNullable<MemberInformationResDTO['careerList']>[number];
 type ApiDate = NonNullable<ApiCareer['startDate']>;
 
@@ -14,7 +13,7 @@ export const MEMBER_STATUS_MAP: Record<string, MemberStatus> = {
   WITHDRAWN: 'reject',
 };
 
-function toMemberStatus(status?: MemberInformationResDTO['memberStatus']): MemberStatus {
+export function toMemberStatus(status?: string): MemberStatus {
   if (!status) {
     return 'waiting';
   }
@@ -22,7 +21,7 @@ function toMemberStatus(status?: MemberInformationResDTO['memberStatus']): Membe
   return MEMBER_STATUS_MAP[status] ?? 'waiting';
 }
 
-function toMemberTrack(track: ApiTrack): MemberTrack {
+export function toMemberTrack(track: { generation?: number; part?: string }): MemberTrack {
   return {
     generation: track.generation ?? 0,
     part: (track.part ?? 'BACKEND') as TrackPart,

--- a/apps/admin/src/entities/member/model/queries/useMemberInfoQuery.ts
+++ b/apps/admin/src/entities/member/model/queries/useMemberInfoQuery.ts
@@ -1,29 +1,26 @@
 'use client';
 
-import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
+import { useSuspenseQuery, type UseSuspenseQueryOptions } from '@tanstack/react-query';
 import { getMemberInfo } from '../../api/getMemberInfo';
-import type { MemberInfoResponse } from '../../api/types';
 import { toMemberDetail } from '../mapper';
 import type { Member } from '../types';
 import { memberQueryKeys } from './memberQueryKeys';
-import { Nullable } from '@/shared/types/nullable';
 
 type UseMemberInfoQueryOptions = Omit<
-  UseQueryOptions<MemberInfoResponse, Error, MemberInfoQueryData>,
-  'queryKey' | 'queryFn' | 'enabled'
+  UseSuspenseQueryOptions<Member, Error, Member>,
+  'queryKey' | 'queryFn'
 >;
-
-type MemberInfoQueryData = Nullable<Member>;
 
 /**
  * 멤버 상세 정보 조회 훅
  */
-export function useMemberInfoQuery(memberId?: number, options?: UseMemberInfoQueryOptions) {
-  return useQuery<MemberInfoResponse, Error, MemberInfoQueryData>({
-    queryKey: memberQueryKeys.detail(memberId ?? -1),
-    queryFn: () => getMemberInfo(memberId!),
-    enabled: !!memberId,
-    select: (response) => (response.data ? toMemberDetail(response.data, memberId!) : null),
+export function useMemberInfoQuery(memberId: number, options?: UseMemberInfoQueryOptions) {
+  return useSuspenseQuery<Member, Error, Member>({
+    queryKey: memberQueryKeys.detail(memberId),
+    queryFn: async () => {
+      const response = await getMemberInfo(memberId);
+      return toMemberDetail(response.data, memberId);
+    },
     ...(options ?? {}),
   });
 }

--- a/apps/admin/src/features/signup-request/api/types.ts
+++ b/apps/admin/src/features/signup-request/api/types.ts
@@ -10,6 +10,11 @@ export interface Track {
 }
 
 /**
+ * 멤버 상태
+ */
+export type MemberStatus = 'REGISTERING' | 'WAITING' | 'APPROVED' | 'REJECTED' | 'WITHDRAWN';
+
+/**
  * 가입 신청 아이템
  */
 export interface SignupRequestItem {
@@ -19,6 +24,7 @@ export interface SignupRequestItem {
   profileImageUrl: string;
   trackList: Track[];
   createdAt: string;
+  memberStatus: MemberStatus;
 }
 
 /**
@@ -26,6 +32,7 @@ export interface SignupRequestItem {
  */
 export interface SignupRequestListData extends PageMeta {
   content: SignupRequestItem[];
+  totalMemberCount: number;
 }
 
 /**

--- a/apps/admin/src/features/signup-request/api/types.ts
+++ b/apps/admin/src/features/signup-request/api/types.ts
@@ -10,11 +10,6 @@ export interface Track {
 }
 
 /**
- * 멤버 상태
- */
-export type MemberStatus = 'REGISTERING' | 'WAITING' | 'APPROVED' | 'REJECTED' | 'WITHDRAWN';
-
-/**
  * 가입 신청 아이템
  */
 export interface SignupRequestItem {
@@ -24,7 +19,7 @@ export interface SignupRequestItem {
   profileImageUrl: string;
   trackList: Track[];
   createdAt: string;
-  memberStatus: MemberStatus;
+  memberStatus: string;
 }
 
 /**

--- a/apps/admin/src/features/signup-request/model/mapper.test.ts
+++ b/apps/admin/src/features/signup-request/model/mapper.test.ts
@@ -1,17 +1,19 @@
+import { SignupRequestItem } from '../api/types';
 import { toSignupRequestMember } from './mapper';
 
 describe('toSignupRequestMember', () => {
-  test('API DTO 필드를 도메인 모델로 매핑한다', () => {
-    const dto = {
-      memberId: 10,
-      username: '테스트유저',
-      university: '고려대학교',
-      profileImageUrl: 'https://example.com/avatar.png',
-      trackList: [{ generation: 17, part: 'WEB_FRONTEND' as const }],
-      createdAt: '2026-01-21T12:00:00.000Z',
-    };
+  const baseDto: SignupRequestItem = {
+    memberId: 10,
+    username: '테스트유저',
+    university: '고려대학교',
+    profileImageUrl: 'https://example.com/avatar.png',
+    trackList: [{ generation: 17, part: 'WEB_FRONTEND' }],
+    createdAt: '2026-01-21T12:00:00.000Z',
+    memberStatus: 'WAITING',
+  };
 
-    const member = toSignupRequestMember(dto);
+  test('API DTO 필드를 도메인 모델로 매핑한다', () => {
+    const member = toSignupRequestMember(baseDto);
 
     expect(member).toEqual({
       id: 10,
@@ -22,5 +24,13 @@ describe('toSignupRequestMember', () => {
       registeredAt: '2026-01-21T12:00:00.000Z',
       status: 'waiting',
     });
+  });
+
+  test('memberStatus를 도메인 MemberStatus로 변환한다', () => {
+    expect(toSignupRequestMember({ ...baseDto, memberStatus: 'APPROVED' }).status).toBe('approve');
+    expect(toSignupRequestMember({ ...baseDto, memberStatus: 'REJECTED' }).status).toBe('reject');
+    expect(toSignupRequestMember({ ...baseDto, memberStatus: 'REGISTERING' }).status).toBe(
+      'waiting',
+    );
   });
 });

--- a/apps/admin/src/features/signup-request/model/mapper.ts
+++ b/apps/admin/src/features/signup-request/model/mapper.ts
@@ -1,19 +1,6 @@
-import { MemberTrack } from '@/entities/member/model/types';
+import { toMemberStatus, toMemberTrack } from '@/entities/member/model/mapper';
 import { SignupRequestMember } from '@/entities/signup-request/model/types';
-import { SignupRequestItem, Track } from '../api/types';
-
-/**
- * API Track DTO → 도메인 MemberTrack 변환
- *
- * @param trackDto - API Track DTO
- * @returns 도메인 MemberTrack
- */
-function toMemberTrack(trackDto: Track): MemberTrack {
-  return {
-    generation: trackDto.generation,
-    part: trackDto.part,
-  };
-}
+import { SignupRequestItem } from '../api/types';
 
 /**
  * API SignupRequestItem DTO → 도메인 SignupRequestMember 변환
@@ -27,12 +14,12 @@ function toMemberTrack(trackDto: Track): MemberTrack {
  */
 export function toSignupRequestMember(dto: SignupRequestItem): SignupRequestMember {
   return {
-    id: dto.memberId, // memberId → id
-    name: dto.username, // username → namex
+    id: dto.memberId,
+    name: dto.username,
     university: dto.university,
     profileImageUrl: dto.profileImageUrl,
-    tracks: dto.trackList.map(toMemberTrack), // trackList → tracks
+    tracks: dto.trackList.map(toMemberTrack),
     registeredAt: dto.createdAt,
-    status: 'waiting', // 초기값 설정 (서버에서 제공하지 않음)
+    status: toMemberStatus(dto.memberStatus),
   };
 }

--- a/apps/admin/src/features/signup-request/model/queries/signupRequestQueryKeys.ts
+++ b/apps/admin/src/features/signup-request/model/queries/signupRequestQueryKeys.ts
@@ -6,16 +6,6 @@ export interface SignupRequestFilters {
   pageSize?: number;
 }
 
-export function normalizeSignupRequestFilters(filters: SignupRequestFilters): SignupRequestFilters {
-  const normalized = { ...filters };
-
-  if (!normalized.keyword) {
-    delete normalized.keyword;
-  }
-
-  return normalized;
-}
-
 /**
  * 가입 신청 관련 Query Keys
  *

--- a/apps/admin/src/features/signup-request/model/queries/signupRequestQueryOptions.ts
+++ b/apps/admin/src/features/signup-request/model/queries/signupRequestQueryOptions.ts
@@ -6,11 +6,7 @@ import {
   InfiniteSelectResult,
   PageWithContent,
 } from '@/shared/lib/tanstack-query/infiniteQueryUtils';
-import {
-  signupRequestQueryKeys,
-  SignupRequestFilters,
-  normalizeSignupRequestFilters,
-} from './signupRequestQueryKeys';
+import { signupRequestQueryKeys, SignupRequestFilters } from './signupRequestQueryKeys';
 
 import { toSignupRequestMember } from '../mapper';
 import { SIGNUP_REQUEST_PAGE_SIZE, SIGNUP_REQUEST_STALE_TIME } from '../constants';
@@ -36,8 +32,6 @@ export function signupRequestQueryOptions({
   filters,
   fetcher = getSignupRequestListClient,
 }: SignupRequestQueryOptionsParams) {
-  const normalizedFilters = normalizeSignupRequestFilters(filters);
-
   return infiniteQueryOptions<
     PageWithContent<SignupRequestMember>,
     Error,
@@ -45,26 +39,27 @@ export function signupRequestQueryOptions({
     ReturnType<typeof signupRequestQueryKeys.list>,
     number
   >({
-    queryKey: signupRequestQueryKeys.list(normalizedFilters),
+    queryKey: signupRequestQueryKeys.list(filters),
 
     queryFn: async ({ pageParam = 0 }) => {
       const params: SignupRequestListParams = {
         pageNum: pageParam,
-        pageSize: normalizedFilters.pageSize || SIGNUP_REQUEST_PAGE_SIZE,
+        pageSize: filters.pageSize || SIGNUP_REQUEST_PAGE_SIZE,
       };
 
       // keyword가 있을 때만 파라미터에 추가
-      if (normalizedFilters.keyword) {
-        params.keyword = normalizedFilters.keyword;
+      if (filters.keyword) {
+        params.keyword = filters.keyword;
       }
 
       const response = await fetcher(params);
-      const { content, ...pageMeta } = response.data;
+      const { content, totalMemberCount, ...pageMeta } = response.data;
 
       // queryFn에서 매핑: 캐시에 Domain Model로 저장
       return {
         ...pageMeta,
         content: content.map(toSignupRequestMember),
+        totalCount: totalMemberCount,
       };
     },
 

--- a/apps/admin/src/features/signup-request/model/queries/signupRequestQueryOptions.ts
+++ b/apps/admin/src/features/signup-request/model/queries/signupRequestQueryOptions.ts
@@ -66,6 +66,7 @@ export function signupRequestQueryOptions({
     initialPageParam: 0,
     getNextPageParam: getNextPageNumber,
     select: createInfiniteDataSelector<SignupRequestMember>(),
+    throwOnError: true,
     staleTime: SIGNUP_REQUEST_STALE_TIME,
   });
 }

--- a/apps/admin/src/features/signup-request/model/useSignupStatusActions.ts
+++ b/apps/admin/src/features/signup-request/model/useSignupStatusActions.ts
@@ -3,8 +3,6 @@
 import { useAlertStore } from '@surf/ui/store/alertStore';
 import { useToastStore } from '@surf/ui/store/toastStore';
 import { useUpdateSignupRequestStatusMutation } from './useUpdateRequestStatusMutation';
-import type { SignupRequestFilters } from './queries/signupRequestQueryKeys';
-
 /** 가입 신청 상태 변경 타입 */
 export type SignupStatusAction = 'approve' | 'reject';
 
@@ -41,8 +39,6 @@ const ALERT_CONFIGS: Record<SignupStatusAction, AlertConfig> = {
 type UseSignupStatusActionsParams = {
   /** 상태 변경 대상 회원 ID 목록 */
   memberIds: number[];
-  /** 목록 필터 (캐시 업데이트용) */
-  filters?: SignupRequestFilters;
   /** 상태 변경 성공 시 콜백 */
   onSuccess?: () => void;
 };
@@ -53,7 +49,6 @@ type UseSignupStatusActionsParams = {
  */
 export const useSignupStatusActions = ({
   memberIds,
-  filters,
   onSuccess,
 }: UseSignupStatusActionsParams) => {
   const { mutate, isPending } = useUpdateSignupRequestStatusMutation();
@@ -73,7 +68,6 @@ export const useSignupStatusActions = ({
       {
         memberIds,
         nextStatus: action,
-        filters,
       },
       {
         onSuccess: () => {

--- a/apps/admin/src/features/signup-request/model/useUpdateRequestStatusMutation.test.tsx
+++ b/apps/admin/src/features/signup-request/model/useUpdateRequestStatusMutation.test.tsx
@@ -35,7 +35,6 @@ describe('useUpdateSignupRequestStatusMutation', () => {
       await result.current.mutateAsync({
         memberIds: [1],
         nextStatus: 'approve',
-        filters: {},
       });
     });
 

--- a/apps/admin/src/features/signup-request/model/useUpdateRequestStatusMutation.ts
+++ b/apps/admin/src/features/signup-request/model/useUpdateRequestStatusMutation.ts
@@ -4,18 +4,14 @@ import { InfiniteData, useMutation, useQueryClient } from '@tanstack/react-query
 import type { SignupRequestMember } from '@/entities/signup-request/model/types';
 import type { PageWithContent } from '@/shared/lib/tanstack-query/infiniteQueryUtils';
 import type { CommonResponse } from '@/shared/api/types';
-import {
-  signupRequestQueryKeys,
-  SignupRequestFilters,
-  normalizeSignupRequestFilters,
-} from './queries/signupRequestQueryKeys';
+import { signupRequestQueryKeys } from './queries/signupRequestQueryKeys';
+import { memberQueryKeys } from '@/entities/member/model/queries/memberQueryKeys';
 import { updateSignupRequest } from '../api/updateSignupRequest';
 import { MemberStatus } from '@/entities/member/model/types';
 
 type UpdateSignupRequestStatusParams = {
   memberIds: number[];
   nextStatus: MemberStatus;
-  filters?: SignupRequestFilters;
 };
 
 export const useUpdateSignupRequestStatusMutation = () => {
@@ -25,12 +21,9 @@ export const useUpdateSignupRequestStatusMutation = () => {
     mutationKey: ['signup-request', 'update'],
     mutationFn: (params) => updateSignupRequest(params.memberIds, params.nextStatus),
     onSuccess: (_data, params) => {
-      const normalizedFilters = normalizeSignupRequestFilters(params.filters ?? {});
-      const queryKey = signupRequestQueryKeys.list(normalizedFilters);
-
       const idSet = new Set(params.memberIds);
-      queryClient.setQueryData<InfiniteData<PageWithContent<SignupRequestMember>, number>>(
-        queryKey,
+      queryClient.setQueriesData<InfiniteData<PageWithContent<SignupRequestMember>, number>>(
+        { queryKey: signupRequestQueryKeys.lists() },
         (data) => {
           if (!data) {
             return data;
@@ -47,11 +40,13 @@ export const useUpdateSignupRequestStatusMutation = () => {
           };
         },
       );
+
+      params.memberIds.forEach((memberId) => {
+        void queryClient.invalidateQueries({ queryKey: memberQueryKeys.detail(memberId) });
+      });
     },
     onError: (error) => {
-      if (error instanceof Error) {
-        console.error('[Signup Request Status Update Error]', error.message);
-      }
+      console.error('[Signup Request Status Update Error]', error.message);
     },
   });
 };

--- a/apps/admin/src/features/signup-request/ui/SignupRequestBottomSheet.tsx
+++ b/apps/admin/src/features/signup-request/ui/SignupRequestBottomSheet.tsx
@@ -23,6 +23,7 @@ export type SignupRequestBottomSheetProps = {
   onClose: () => void;
   /** 조회할 회원 ID */
   memberId: number;
+  showAction: boolean;
 };
 
 /**
@@ -33,6 +34,7 @@ export const SignupRequestBottomSheet = ({
   isOpen,
   onClose,
   memberId,
+  showAction,
 }: SignupRequestBottomSheetProps) => {
   return (
     <ModalSheet isOpen={isOpen} onClose={onClose}>
@@ -51,7 +53,7 @@ export const SignupRequestBottomSheet = ({
                   <div className="text-body-body6 text-foreground-secondary">로딩중...</div>
                 }
               >
-                <MemberInfoContent memberId={memberId} onClose={onClose} />
+                <MemberInfoContent memberId={memberId} showAction={showAction} onClose={onClose} />
               </Suspense>
             </ErrorBoundary>
           </Sheet>
@@ -63,12 +65,17 @@ export const SignupRequestBottomSheet = ({
 
 /**
  * 회원 정보 및 승인/거절 액션을 표시하는 내부 컴포넌트
- * @description Suspense와 ErrorBoundary 내부에서 사용되며, 회원 데이터를 페칭하고 상태 변경 기능을 제공합니다.
  */
-const MemberInfoContent = ({ memberId, onClose }: { memberId: number; onClose: () => void }) => {
-  const { data: member } = useMemberInfoQuery(memberId, {
-    throwOnError: true,
-  });
+const MemberInfoContent = ({
+  memberId,
+  showAction,
+  onClose,
+}: {
+  memberId: number;
+  showAction: boolean;
+  onClose: () => void;
+}) => {
+  const { data: member } = useMemberInfoQuery(memberId);
 
   const queryClient = useQueryClient();
 
@@ -82,17 +89,13 @@ const MemberInfoContent = ({ memberId, onClose }: { memberId: number; onClose: (
     },
   });
 
-  if (!member) {
-    return <div className="text-body-body6 text-foreground-secondary">회원 정보가 없습니다.</div>;
-  }
-
   return (
     <>
       <div className="flex size-full flex-col gap-[0.375rem] py-13">
         <RequestStatusBadge status={member.status} />
         <MemberDetail member={member} />
       </div>
-      {member.status === 'waiting' && (
+      {member.status === 'waiting' && showAction && (
         <div className="mt-13 flex w-full flex-row gap-13">
           <SolidButton size="l" variant="danger" isDisabled={isPending} onClick={openRejectAlert}>
             거절하기

--- a/apps/admin/src/shared/lib/tanstack-query/infiniteQueryUtils.ts
+++ b/apps/admin/src/shared/lib/tanstack-query/infiniteQueryUtils.ts
@@ -6,6 +6,7 @@ import { PageMeta } from '@/shared/api/types';
  */
 export interface PageWithContent<T> extends PageMeta {
   content: T[];
+  totalCount?: number;
 }
 
 /**
@@ -63,7 +64,7 @@ export function createInfiniteDataSelector<T>(): (
       pages: data.pages,
       pageParams: data.pageParams,
       items,
-      totalCount: data.pages[0]?.numberOfElements ?? 0,
+      totalCount: data.pages[0]?.totalCount ?? 0,
       isLast: lastPage?.isLast ?? true,
     };
   };

--- a/apps/admin/src/test/factories/signupRequest.ts
+++ b/apps/admin/src/test/factories/signupRequest.ts
@@ -27,6 +27,7 @@ function createMockSignupRequestItem(index: number): SignupRequestItem {
     profileImageUrl: 'https://example.com/profile.png',
     trackList: [{ generation: 15, part: 'BACKEND' }],
     createdAt: '2026-01-20T10:00:00.000Z',
+    memberStatus: 'WAITING',
   };
 }
 
@@ -58,6 +59,7 @@ export function createMockSignupRequestList(
       pageSize,
       numberOfElements: content.length,
       isLast,
+      totalMemberCount: totalElements,
     },
   };
 }

--- a/apps/admin/src/widgets/signup-request/ui/SignupRequestListWidget.test.tsx
+++ b/apps/admin/src/widgets/signup-request/ui/SignupRequestListWidget.test.tsx
@@ -18,7 +18,7 @@ describe('SignupRequestListWidget', () => {
     const user = userEvent.setup();
     renderWithProviders(<SignupRequestListWidget keyword="" />);
 
-    await screen.findByText('전체 20');
+    await screen.findByText('전체 40');
     await user.click(screen.getByRole('button', { name: '선택하기' }));
 
     const checkbox = await screen.findByLabelText('테스트유저1 선택');

--- a/apps/admin/src/widgets/signup-request/ui/SignupRequestListWidget.tsx
+++ b/apps/admin/src/widgets/signup-request/ui/SignupRequestListWidget.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Suspense, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { SignupRequestListContent } from './SignupRequestListContent';
 import { useSignupRequestList } from '@/features/signup-request/model/queries/useSignupRequestList';
 import {
@@ -11,7 +11,6 @@ import { useSignupStatusActions } from '@/features/signup-request/model/useSignu
 import { RequestListTopBar } from '@/features/signup-request/ui/RequestListTopBar';
 import { useBottomSheetStore } from '@/shared/store/bottomSheetStore';
 import { BottomActionBar } from '@/shared/ui/BottomActionBar';
-import { ErrorBoundary } from '@/shared/ui/ErrorBoundary';
 
 interface SignupRequestListWidgetProps {
   keyword: string;
@@ -45,11 +44,13 @@ export const SignupRequestListWidget = ({ keyword }: SignupRequestListWidgetProp
   const statuses = getSelectedStatuses(members, selectedIds);
   const { selectedCount, canApprove, canReject } = getSelectionPolicy(statuses);
 
+  //회원가입 상태 처리 액션 훅
   const { openApproveAlert, openRejectAlert, isPending } = useSignupStatusActions({
     memberIds: Array.from(selectedIds),
     onSuccess: handleReset,
   });
 
+  //멤버 선택 핸들러
   const handleToggleSelect = (memberId: number) => {
     setSelectedIds((prev) => {
       const next = new Set(prev);
@@ -62,6 +63,7 @@ export const SignupRequestListWidget = ({ keyword }: SignupRequestListWidgetProp
     });
   };
 
+  //상세 바텀시트 오픈 핸들러
   const handleOpenDetail = (memberId: number) => {
     openBottomSheet({
       type: 'signup',
@@ -97,22 +99,18 @@ export const SignupRequestListWidget = ({ keyword }: SignupRequestListWidgetProp
         onClickCancel={handleReset}
       />
       {/* 회원가입 요청 멤버 리스트*/}
-      <ErrorBoundary fallback={<div>error</div>}>
-        <Suspense fallback={<div>loading...</div>}>
-          <SignupRequestListContent
-            members={members}
-            isSelectionEnabled={mode === 'select'}
-            selectedIds={selectedIds}
-            onToggleSelect={handleToggleSelect}
-            onClickMore={handleOpenDetail}
-            hasNextPage={hasNextPage}
-            isFetchingNextPage={isFetchingNextPage}
-            onLoadMore={() => {
-              void fetchNextPage();
-            }}
-          />
-        </Suspense>
-      </ErrorBoundary>
+      <SignupRequestListContent
+        members={members}
+        isSelectionEnabled={mode === 'select'}
+        selectedIds={selectedIds}
+        onToggleSelect={handleToggleSelect}
+        onClickMore={handleOpenDetail}
+        hasNextPage={hasNextPage}
+        isFetchingNextPage={isFetchingNextPage}
+        onLoadMore={() => {
+          void fetchNextPage();
+        }}
+      />
       {mode === 'select' && selectedCount > 0 && <BottomActionBar actions={bottomActions} />}
     </div>
   );

--- a/apps/admin/src/widgets/signup-request/ui/SignupRequestListWidget.tsx
+++ b/apps/admin/src/widgets/signup-request/ui/SignupRequestListWidget.tsx
@@ -33,9 +33,13 @@ export const SignupRequestListWidget = ({ keyword }: SignupRequestListWidgetProp
 
   const openBottomSheet = useBottomSheetStore((s) => s.open);
 
-  useEffect(() => {
-    setMode('view');
+  const handleReset = () => {
     setSelectedIds(new Set());
+    setMode('view');
+  };
+
+  useEffect(() => {
+    handleReset();
   }, [keyword]);
 
   const statuses = getSelectedStatuses(members, selectedIds);
@@ -43,10 +47,7 @@ export const SignupRequestListWidget = ({ keyword }: SignupRequestListWidgetProp
 
   const { openApproveAlert, openRejectAlert, isPending } = useSignupStatusActions({
     memberIds: Array.from(selectedIds),
-    filters,
-    onSuccess: () => {
-      setSelectedIds(new Set());
-    },
+    onSuccess: handleReset,
   });
 
   const handleToggleSelect = (memberId: number) => {
@@ -93,10 +94,7 @@ export const SignupRequestListWidget = ({ keyword }: SignupRequestListWidgetProp
         selectCount={selectedCount}
         totalCount={totalCount}
         onClickSelect={() => setMode('select')}
-        onClickCancel={() => {
-          setMode('view');
-          setSelectedIds(new Set());
-        }}
+        onClickCancel={handleReset}
       />
       {/* 회원가입 요청 멤버 리스트*/}
       <ErrorBoundary fallback={<div>error</div>}>

--- a/apps/admin/src/widgets/signup-request/ui/SignupRequestListWidget.tsx
+++ b/apps/admin/src/widgets/signup-request/ui/SignupRequestListWidget.tsx
@@ -69,6 +69,7 @@ export const SignupRequestListWidget = ({ keyword }: SignupRequestListWidgetProp
       type: 'signup',
       props: {
         memberId,
+        showAction: mode === 'view',
       },
     });
   };


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 코드에 any가 사용되지 않았습니다
- [ ] 스토리북에 추가했습니다 (해당 시)
- [ ] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈

- close #512 

## 📌 작업 목적

- 어드민 가입 신청 목록 조회 시 API 응답에 totalCount와 memberStatus가 추가되어 로직에 반영했습니다. 

## 🔨 주요 작업 내용

- 어드민 가입 신청 목록 API 응답 수정 및 쿼리 훅 리팩토링 
- 체크 활성화 상태에서 바텀시트 오픈 시 액션 비활성화 처리 


## 🧪 테스트 방법

- 어드민 회원 승인 화면에서 전체 회원 수가 잘 반영되어있는지 확인
- 체크 활성화 상태에서 바텀시트 오픈 시 승인/거절 액션이 보이지 않는지 확인 
