### PR TITLE
[FIX] 헤더 스타일 수정

### DIFF
--- a/packages/ui/components/header/Header.tsx
+++ b/packages/ui/components/header/Header.tsx
@@ -70,7 +70,7 @@ export type HeaderProps = (
 const renderLeftIcon = (hasLeftIcon?: boolean, onClickBack?: () => void) =>
   hasLeftIcon && (
     <button
-      className="cursor-pointer border-none bg-transparent p-8"
+      className="-m-8 shrink-0 border-none bg-transparent p-8"
       onClick={onClickBack}
       type="button"
     >
@@ -90,7 +90,7 @@ const renderRightIcons = (icons: MaxThree<HeaderIcon> = []) => (
         icon.label && (
           <button
             key={idx}
-            className="relative cursor-pointer border-none bg-transparent p-8"
+            className="relative -m-8 shrink-0 border-none bg-transparent p-8"
             onClick={icon.onClickIcon}
             type="button"
           >

--- a/packages/ui/components/header/Header.tsx
+++ b/packages/ui/components/header/Header.tsx
@@ -80,7 +80,7 @@ const renderLeftIcon = (hasLeftIcon?: boolean, onClickBack?: () => void) =>
 
 const renderTitle = (title?: string) =>
   title ? (
-    <div className="text-title-title1 text-foreground-normal leading-14! flex-1">{title}</div>
+    <div className="text-title-title1 text-foreground-normal leading-14! ml-8 flex-1">{title}</div>
   ) : null;
 
 const renderRightIcons = (icons: MaxThree<HeaderIcon> = []) => (


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 코드에 any가 사용되지 않았습니다
- [ ] 스토리북에 추가했습니다 (해당 시)
- [ ] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈

- close #526 

## 📌 작업 목적

- 헤더 padding 2중으로 잡히는 문제 해결

## 🔨 주요 작업 내용

- 헤더 UI 수정

## ⚠️ 기존 문제 (선택)

- 아이콘 터치 영역이 잡혀서 padding이 두 번 들어감

## ☑️ 해결 방법 (선택)

- `-margin-8` 사용

## 🧪 테스트 방법

- 실행 후 헤더 개발자 도구로 ui 확인

## 📷 실행 영상 또는 스크린샷
- before
<img width="460" height="72" alt="image" src="https://github.com/user-attachments/assets/d300c1f4-2152-4d0d-962a-30fd59225594" />

- after
<img width="475" height="45" alt="image" src="https://github.com/user-attachments/assets/a3a7497b-2cc4-4172-b0a1-a1a6f3075e58" />
