### PR TITLE
[REFACTOR] 일정 데이트 피커 렌더링 구조 개선

### DIFF
--- a/apps/web/src/features/schedule/ui/ScheduleDateBottomSheet.tsx
+++ b/apps/web/src/features/schedule/ui/ScheduleDateBottomSheet.tsx
@@ -27,11 +27,16 @@ export const ScheduleDateBottomSheet = ({
   onSave,
 }: ScheduleDateBottomSheetProps) => {
   const [tempDate, setTempDate] = useState<Date>(initialDate || new Date());
+  const [mountPicker, setMountPicker] = useState(false);
 
   useEffect(() => {
-    if (isOpen) {
-      setTempDate(initialDate || new Date());
-    }
+    if (!isOpen) return;
+    setTempDate(initialDate || new Date());
+
+    // 바텀시트 먼저 렌더 → 다음 프레임에 picker 마운트
+    setMountPicker(false);
+    const id = requestAnimationFrame(() => setMountPicker(true));
+    return () => cancelAnimationFrame(id);
   }, [isOpen, initialDate]);
 
   const handleSave = () => {
@@ -62,7 +67,12 @@ export const ScheduleDateBottomSheet = ({
             }}
           >
             <div className="py-15">
-              <DateTimePicker value={tempDate} onChange={setTempDate} mode="all" />
+              {mountPicker ? (
+                <DateTimePicker value={tempDate} onChange={setTempDate} mode="all" />
+              ) : (
+                // 레이아웃 점프 방지용 placeholder
+                <div className="h-44" />
+              )}
             </div>
           </Sheet>
         </ModalSheet.Content>

--- a/packages/ui/components/wheel-picker/Wheel.tsx
+++ b/packages/ui/components/wheel-picker/Wheel.tsx
@@ -3,6 +3,33 @@
 import { KeenSliderOptions, useKeenSlider } from 'keen-slider/react';
 import React, { useRef, useMemo, useState } from 'react';
 
+type Props = {
+  value: number;
+  onChange: (val: number) => void;
+  length: number;
+  loop?: boolean;
+  perspective?: 'left' | 'right' | 'center';
+  setValue?: (relative: number, absolute: number) => string;
+  width: number;
+  disableHighlight?: boolean;
+  windowSize?: number; // value 기준으로 앞뒤 몇 개만 렌더할지. 예: 12면 총 25개
+};
+
+function clamp(n: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, n));
+}
+
+// loop에서 최소 거리(예: 0과 length-1은 거리 1로 취급)
+function circularDistance(i: number, a: number, n: number) {
+  const d = i - a;
+  const alt = d > 0 ? d - n : d + n;
+  return Math.abs(d) <= Math.abs(alt) ? d : alt;
+}
+
+function mod(n: number, m: number) {
+  return ((n % m) + m) % m;
+}
+
 export const Wheel = ({
   value,
   onChange,
@@ -12,16 +39,8 @@ export const Wheel = ({
   setValue,
   width,
   disableHighlight = false,
-}: {
-  value: number;
-  onChange: (val: number) => void;
-  length: number;
-  loop?: boolean;
-  perspective?: 'left' | 'right' | 'center';
-  setValue?: (relative: number, absolute: number) => string;
-  width: number;
-  disableHighlight?: boolean;
-}) => {
+  windowSize = 12,
+}: Props) => {
   const wheelSize = 20;
   const slideDegree = 360 / wheelSize;
   const slidesPerView = loop ? 9 : 1;
@@ -65,27 +84,42 @@ export const Wheel = ({
 
   const [sliderRef] = useKeenSlider<HTMLDivElement>(options);
 
-  function slideValues() {
-    const activeIndex = value;
-    const values: { style: React.CSSProperties; value: string }[] = [];
+  const windowedSlides = useMemo(() => {
+    if (length <= 0) return [];
 
-    for (let i = 0; i < length; i++) {
-      const distance = i - activeIndex;
-      const rotate = Math.abs(distance) > wheelSize / 2 ? 180 : distance * (360 / wheelSize) * -1;
-      const isActive = i === activeIndex;
+    // 렌더할 index 리스트 만들기
+    let indices: number[] = [];
 
-      const style = {
+    if (loop) {
+      const start = value - windowSize;
+      const end = value + windowSize;
+      for (let x = start; x <= end; x++) indices.push(mod(x, length));
+      // 중복 제거 (length가 작으면 window가 겹칠 수 있음)
+      indices = Array.from(new Set(indices));
+    } else {
+      const start = clamp(value - windowSize, 0, length - 1);
+      const end = clamp(value + windowSize, 0, length - 1);
+      for (let i = start; i <= end; i++) indices.push(i);
+    }
+
+    return indices.map((i) => {
+      const dist = loop ? circularDistance(i, value, length) : i - value;
+
+      // 멀리 있는 건 뒷면 처리 (원래 로직 유지)
+      const rotate = Math.abs(dist) > wheelSize / 2 ? 180 : dist * (360 / wheelSize) * -1;
+      const isActive = i === value;
+
+      const style: React.CSSProperties = {
         transform: `rotateX(${rotate}deg) translateZ(${radius}px)`,
         WebkitTransform: `rotateX(${rotate}deg) translateZ(${radius}px)`,
         color: isActive ? '#222' : '#c4c4c4',
       };
 
-      const valueLabel = setValue ? setValue(i, i) : String(i);
+      const label = setValue ? setValue(i, i) : String(i);
 
-      values.push({ style, value: valueLabel });
-    }
-    return values;
-  }
+      return { key: i, style, label };
+    });
+  }, [length, loop, value, windowSize, wheelSize, radius, setValue]);
 
   return (
     <div className={'wheel keen-slider wheel--perspective-' + perspective} ref={sliderRef}>
@@ -107,10 +141,11 @@ export const Wheel = ({
             }}
           />
         )}
+
         <div className="wheel__slides" style={{ width: width + 'px' }}>
-          {slideValues().map(({ style, value }, idx) => (
-            <div className="wheel__slide" style={{ ...style, zIndex: 2 }} key={idx}>
-              <span>{value}</span>
+          {windowedSlides.map(({ key, style, label }) => (
+            <div className="wheel__slide" style={{ ...style, zIndex: 2 }} key={key}>
+              <span>{label}</span>
             </div>
           ))}
         </div>


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 any가 사용되지 않았습니다
- [x] 스토리북에 추가했습니다 (해당 시)
- [x] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈

- close #524

## 📌 작업 목적

- 모바일 일정 생성 화면에서 데이트 피커를 클릭하면 화면 전환이 지연되는 문제가 있었습니다.
- 해당 문제의 원인을 파악하고 성능을 개선합니다.

## 🔨 주요 작업 내용

- 윈도우 스크롤
  - 공통 Wheel 컴포넌트를 윈도우 스크롤 방식으로 리팩토링했습니다.
  - 현재 선택된 인덱스를 기준으로 일정 범위(window)만 렌더링하도록 변경했습니다.
- 지연 렌더링
  - 바텀 시트와 DateTimePicker의 마운트 시점을 분리했습니다.
  - 바텀 시트를 먼저 렌더링한 뒤, 다음 프레임에서 Wheel을 마운트하도록 조정했습니다.

## ⚠️ 기존 문제

- 7년치 날짜가 한 번에 렌더링되어 초기 화면 렌더링 비용이 과도하게 발생했습니다.
- 바텀 시트와 Wheel 컴포넌트가 동시에 마운트되면서 메인 스레드 병목이 발생했고, 이로 인해 사용자가 화면 전환을 기다려야 하는 문제가 있었습니다.

## ☑️ 해결 방법

- 윈도우 스크롤 -> TBT, INP 개선
  - 화면에 보이는 인덱스를 기준으로 일정 범위만 렌더링하도록 변경했습니다.
  - 기본 윈도우 크기는 25개로 설정하여 DOM 생성 비용을 크게 줄였습니다.
- 지연 렌더링 -> INP 개선
  - 마운트 타이밍을 분산하여 입력 직후 바텀 시트가 즉시 표시되도록 개선했습니다.
  - 무거운 Wheel 렌더링을 다음 프레임으로 미뤄 입력 반응성(INP)을 향상시켰습니다.

 ### Lighthouse 성능 측정 결과 요약 (개발 서버 기준)

| 구분 | TBT 평균 (ms) | INP 평균 (ms) | 핵심 변화 요인 |
|---|---:|---:|---|
| **비포** | **8,100** | **6,030** | 전체 날짜 범위 렌더링, 대량 DOM 마운트 |
| **애프터 · 윈도우 스크롤** | **956** | **920** | 렌더링 범위 축소 (DOM 수 감소) |
| **애프터 · 지연 렌더링** | **8,162** | **672** | 마운트 타이밍 분산 (rAF) |
| **애프터 · 윈도우 스크롤 + 지연 렌더링** | **989** | **549** | 렌더링 양 감소 + 타이밍 분산 |

 - *TBT: 메인 스레드가 병목되어 사용자가 상호작용하지 못하는 시간, INP: 상호작용 후 다음 화면이 나오는 데 걸리는 시간
 - Lighthouse에서 빠른 환경, 느린 환경 랜덤으로 측정하는 추이를 관찰하였습니다.
- 따라서 각각의 환경에서 테스트 결과를 수집 후 평균을 내서 결과를 계산하였습니다.

## 🧪 테스트 방법

- Wheel 컴포넌트의 이전 캐시 데이터가 존재할 수 있으므로 `pnpm run build`
- `pnpm run dev:surf`
- 개발자 도구 (F12) Lighthouse - Timespan, Mobile 체크
- 일정 생성 화면에서 Start Timespan 클릭
- Interaction with Page가 뜨면 데이트 피커 클릭
- 데이트 피커가 렌더링되면 End Timespan

## 💬 논의할 점

- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩터링**
  * 날짜 선택기의 마운팅 로직을 개선하여 레이아웃 안정성을 강화했습니다.
  * 휠 피커 컴포넌트의 렌더링 효율을 최적화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->