### PR TITLE
[FEAT] 어드민 멤버 권한 변경 기능 구현 

### DIFF
--- a/apps/admin/src/entities/member/ui/RoleBadge.tsx
+++ b/apps/admin/src/entities/member/ui/RoleBadge.tsx
@@ -1,20 +1,19 @@
-import { StatusBadge } from '@/shared/ui/StatusBadge';
+import { MemberRole } from '../model/types';
+import { StatusBadge, StatusBadgeVariant } from '@/shared/ui/StatusBadge';
 
-//TODO: MemberRole 타입으로 변경 필요
 interface RoleBadgeProps {
-  type: string;
+  type: MemberRole;
 }
 
-const ROLE_MAP: Record<string, { label: string; variant: 'pink' | 'purple' | 'green' }> = {
+const MEMBER_ROLE_MAP: Record<MemberRole, { label: string; variant: StatusBadgeVariant }> = {
+  ADMIN: { label: 'Admin', variant: 'neutral' },
   PRESIDENT: { label: 'President', variant: 'pink' },
   MANAGER: { label: 'Manager', variant: 'green' },
   MEMBER: { label: 'Member', variant: 'purple' },
 };
 
-const DEFAULT_ROLE = { label: 'Member', variant: 'purple' } as const;
-
 export const RoleBadge = ({ type }: RoleBadgeProps) => {
-  const { label, variant } = ROLE_MAP[type] ?? DEFAULT_ROLE;
+  const { label, variant } = MEMBER_ROLE_MAP[type];
 
   return <StatusBadge variant={variant}>{label}</StatusBadge>;
 };

--- a/apps/admin/src/features/member/role-change/api/updateMemberRole.ts
+++ b/apps/admin/src/features/member/role-change/api/updateMemberRole.ts
@@ -1,0 +1,20 @@
+import { MemberRole } from '@/entities/member/model/types';
+import { CommonResponse } from '@/shared/api/types';
+import { axiosInstance } from '@/shared/lib/axiosInstance';
+
+export async function updateMemberRole({
+  memberId,
+  role,
+}: {
+  memberId: number;
+  role: MemberRole;
+}): Promise<null> {
+  const response = await axiosInstance.patch<CommonResponse<null>>(
+    `/v1/admin/members/${memberId}/role`,
+    {
+      role,
+    },
+  );
+
+  return response.data.data;
+}

--- a/apps/admin/src/features/member/role-change/model/useUpdateMemberRoleMutation.ts
+++ b/apps/admin/src/features/member/role-change/model/useUpdateMemberRoleMutation.ts
@@ -1,0 +1,38 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { memberQueryKeys } from '@/entities/member/model/queries/memberQueryKeys';
+import type { Member, MemberBase, MemberRole } from '@/entities/member/model/types';
+import { updateMemberRole } from '../api/updateMemberRole';
+
+type UpdateMemberRoleParams = {
+  memberId: number;
+  role: MemberRole;
+};
+
+export const useUpdateMemberRoleMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<null, Error, UpdateMemberRoleParams>({
+    mutationKey: ['member', 'role', 'update'],
+    mutationFn: updateMemberRole,
+    onSuccess: (_data, params) => {
+      //멤버 상세 캐시 업데이트
+      queryClient.setQueryData<Member | undefined>(
+        memberQueryKeys.detail(params.memberId),
+        (data) => {
+          if (!data) return data;
+          return { ...data, role: params.role };
+        },
+      );
+      //멤버 기존 정보 캐시 업데이트
+      queryClient.setQueryData<MemberBase | undefined>(
+        memberQueryKeys.base(params.memberId),
+        (data) => (data ? { ...data, role: params.role } : data),
+      );
+    },
+    onError: (error) => {
+      console.error('[Member Role Update Error]', error.message);
+    },
+  });
+};

--- a/apps/admin/src/features/member/role-change/ui/ChangeRoleDialog.tsx
+++ b/apps/admin/src/features/member/role-change/ui/ChangeRoleDialog.tsx
@@ -1,8 +1,10 @@
 import { SolidButton } from '@surf/ui/button';
 import { useAlertStore } from '@surf/ui/store/alertStore';
+import { useToastStore } from '@surf/ui/store/toastStore';
 import { Wheel } from '@surf/ui/wheel-picker';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { openChangeMemberRoleConfirm } from '../model/openChangeMemberRoleConfirm';
+import { useUpdateMemberRoleMutation } from '../model/useUpdateMemberRoleMutation';
 import { MEMBER_ROLE_LABELS } from '@/entities/member/model/constants';
 import type { MemberRole } from '@/entities/member/model/types';
 
@@ -15,17 +17,29 @@ export interface ChangeRoleDialogProps {
   initialRole: MemberRole;
 }
 
-const MEMBER_ROLE_OPTIONS: readonly MemberRole[] = ['ADMIN', 'PRESIDENT', 'MANAGER', 'MEMBER'];
+const MEMBER_ROLE_OPTIONS: readonly MemberRole[] = ['MEMBER', 'MANAGER', 'PRESIDENT', 'ADMIN'];
+const MEMBER_ROLE_INDEX: Record<MemberRole, number> = {
+  MEMBER: 0,
+  MANAGER: 1,
+  PRESIDENT: 2,
+  ADMIN: 3,
+};
 
-export const ChangeRoleDialog = ({ isOpen, onClose, initialRole }: ChangeRoleDialogProps) => {
-  const initialRoleIndex = useMemo(() => {
-    const idx = MEMBER_ROLE_OPTIONS.findIndex((role) => role === initialRole);
-    return idx >= 0 ? idx : 0;
-  }, [initialRole]);
+export const ChangeRoleDialog = ({
+  isOpen,
+  onClose,
+  memberId,
+  initialRole,
+}: ChangeRoleDialogProps) => {
+  const initialRoleIndex = MEMBER_ROLE_INDEX[initialRole];
 
   const [selectedIdx, setSelectedIdx] = useState(initialRoleIndex);
+
+  const { mutate, isPending } = useUpdateMemberRoleMutation();
+
   const openAlert = useAlertStore((s) => s.open);
   const closeAlert = useAlertStore((s) => s.close);
+  const showToast = useToastStore((s) => s.show);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -33,6 +47,7 @@ export const ChangeRoleDialog = ({ isOpen, onClose, initialRole }: ChangeRoleDia
   }, [isOpen, initialRoleIndex]);
 
   const selectedRole = MEMBER_ROLE_OPTIONS[selectedIdx] ?? MEMBER_ROLE_OPTIONS[0];
+  const hasRoleChanged = selectedRole !== initialRole;
 
   const setRoleLabel = useCallback((_relative: number, absolute: number): string => {
     const role = MEMBER_ROLE_OPTIONS[absolute];
@@ -40,7 +55,28 @@ export const ChangeRoleDialog = ({ isOpen, onClose, initialRole }: ChangeRoleDia
   }, []);
 
   const handleChangeRole = () => {
-    //TODO: role 변경 API 호출 로직 추가
+    if (isPending || !hasRoleChanged) return;
+
+    mutate(
+      { memberId, role: selectedRole },
+      {
+        onSuccess: () => {
+          showToast('회원 등급이 변경되었습니다.');
+          onClose();
+        },
+        onError: (error) => {
+          showToast(error.message);
+        },
+      },
+    );
+  };
+  const handleOpenConfirm = () => {
+    openChangeMemberRoleConfirm({
+      openAlert,
+      closeAlert,
+      role: selectedRole,
+      onConfirm: handleChangeRole,
+    });
   };
 
   if (!isOpen) return null;
@@ -77,15 +113,8 @@ export const ChangeRoleDialog = ({ isOpen, onClose, initialRole }: ChangeRoleDia
           <SolidButton
             size="l"
             variant="primary"
-            onClick={() =>
-              openChangeMemberRoleConfirm({
-                openAlert,
-                closeAlert,
-                role: selectedRole,
-                onConfirm: handleChangeRole,
-              })
-            }
-            isDisabled={initialRoleIndex === selectedIdx}
+            onClick={handleOpenConfirm}
+            isDisabled={!hasRoleChanged || isPending}
           >
             선택하기
           </SolidButton>

--- a/apps/admin/src/shared/ui/StatusBadge.tsx
+++ b/apps/admin/src/shared/ui/StatusBadge.tsx
@@ -1,10 +1,12 @@
-export type StatusBadgeVariant = 'pink' | 'purple' | 'green';
+export type StatusBadgeVariant = 'pink' | 'purple' | 'green' | 'neutral';
 const VARIANT_STYLE = {
   pink: 'bg-background-badge-pink text-foreground-badge-pink shadow-[inset_0_0_10px_0_var(--background-tag-pink-darker,rgba(255,112,172,0.1))]',
   purple:
     'bg-background-badge-purple text-foreground-badge-purple shadow-[inset_0_0_10px_0_var(--background-tag-purple-darker,rgba(144,81,254,0.1))]',
   green:
     'bg-background-badge-green text-foreground-badge-green shadow-[inset_0_0_10px_0_var(--background-tag-green-darker,rgba(0,201,90,0.1))]',
+  neutral:
+    'bg-tertiary-lighter text-foreground-normal-lighter shadow-[inset_0_0_10px_0_var(--background-tag-pink-darker,rgba(0,201,90,0.1))]',
 } as const;
 
 /**

--- a/apps/admin/src/widgets/member-directory/ui/MemberGenerationAccordionList.tsx
+++ b/apps/admin/src/widgets/member-directory/ui/MemberGenerationAccordionList.tsx
@@ -1,7 +1,9 @@
 import { Avatar } from '@surf/ui/avatar';
+import { SurfIcon } from '@surf/ui/icon';
 import { RoleBadge } from '@/entities/member/ui/RoleBadge';
 import { SelectableMemberCard } from '@/entities/member/ui/SelectableMemberCard';
 import { MemberGenerationAccordion } from '@/features/member-by-generation/ui/MemberGenerationAccordion';
+import { useBottomSheetStore } from '@/shared/store/bottomSheetStore';
 
 export interface MemberGenerationAccordionListProps {
   generations: number[];
@@ -11,6 +13,17 @@ export const MemberGenerationAccordionList = ({
   generations,
   keyword,
 }: MemberGenerationAccordionListProps) => {
+  const openBottomSheet = useBottomSheetStore((state) => state.open);
+
+  const handleOpenMemberSheet = (memberId: number) => {
+    openBottomSheet({
+      type: 'member',
+      props: {
+        memberId,
+      },
+    });
+  };
+
   if (generations.length === 0)
     return (
       <div className="flex h-full flex-col items-center justify-center gap-12">
@@ -32,8 +45,27 @@ export const MemberGenerationAccordionList = ({
               tracks={m.tracks}
               checked={false}
               onToggle={() => {}}
-              leftSlot={<Avatar size="s" alt="테이비 프로필 이미지" src={m.profileImageUrl} />}
-              rightSlot={<RoleBadge type={m.role} />}
+              leftSlot={
+                <div className="relative">
+                  <Avatar src={m.profileImageUrl} size="m" />
+                  {/**TODO: 퇴출/제명 상태에 따라 색 변경 필요  */}
+                  <div
+                    className={`bg-background-primary absolute -right-4 -bottom-4 h-10 w-10 rounded-full`}
+                  />
+                </div>
+              }
+              rightSlot={
+                <>
+                  <RoleBadge type={m.role} />
+                  <button
+                    type="button"
+                    onClick={() => handleOpenMemberSheet(m.id)}
+                    aria-label={`${m.name} 상세 보기`}
+                  >
+                    <SurfIcon name="ChevronRight" />
+                  </button>
+                </>
+              }
             />
           )}
         />

--- a/apps/admin/src/widgets/member-management-sheet/MemberManagementSheet.tsx
+++ b/apps/admin/src/widgets/member-management-sheet/MemberManagementSheet.tsx
@@ -2,7 +2,7 @@ import { Sheet } from '@surf/ui/sheet';
 import { useAlertStore } from '@surf/ui/store/alertStore';
 import { useEffect, useState } from 'react';
 import { Sheet as ModalSheet } from 'react-modal-sheet';
-import { Member } from '@/entities/member/model/types';
+import { useMemberInfoQuery } from '@/entities/member/model/queries/useMemberInfoQuery';
 import { MemberProfileSummary } from '@/entities/member/ui/MemberProfileSummary';
 import { openExpelMemberConfirm } from '@/features/member/expel/model/openExpelMemberConfirm';
 import { MemberRoleChangeField } from '@/features/member/role-change/ui/MemberRoleChangeField';
@@ -27,33 +27,7 @@ export const MemberManagementSheet = ({
   onClose,
   memberId,
 }: MemberManagementSheetProps) => {
-  // TODO: memberId를 이용한 실제 멤버 조회 API 연동 필요
-  const member: Member = {
-    email: 'test@example.com',
-    name: '홍길동',
-    role: 'MEMBER',
-    phoneNumber: '01012341234',
-    status: 'approve',
-    tracks: [
-      {
-        generation: 12,
-        part: 'BACKEND',
-      },
-      {
-        generation: 11,
-        part: 'DESIGN',
-      },
-    ],
-    activityScore: 0,
-    careers: [],
-    profileImageUrl: '',
-    university: '000대',
-    graduateSchool: '',
-    id: 1,
-    isActive: true,
-    link: '',
-    registeredAt: '25.01.12',
-  };
+  const { data: member } = useMemberInfoQuery(memberId);
 
   const [isChangeRoleOpen, setIsChangeRoleOpen] = useState(false);
 


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 코드에 any가 사용되지 않았습니다
- [ ] 스토리북에 추가했습니다 (해당 시)
- [ ] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈

- close #541 

## 📌 작업 목적

- 멤버 관리 화면에서 특정 멤버 권한 변경 API 연동 및 기능 구현

## 🔨 주요 작업 내용

- 멤버 권한 변경 API 연동
- RoleDialog 에서 권한 변경 처리
- 변경 성공 후 멤버 상세,(detail) 멤버 기본정보(base) 캐시 최신 상태 업데이트

## 🧪 테스트 방법

- 어드민 전체 멤버 관리 메뉴 접속 후, 특정 멤버 카드 클릭 -> 바텀시트 오픈
- 멤버 역할 셀렉트 필드 클릭 후 변경할 권한 선택 -> 멤버 바텀시트, 멤버 카드에 새로운 권한이 잘 반영되는지 확인 


## 📷 실행 영상 또는 스크린샷

https://github.com/user-attachments/assets/6ff85c8c-d106-4462-aac0-b9f15310ee8f



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 구성원 역할 변경 기능이 추가되었으며, 확인 대화상자와 함께 제공됩니다.
  * 구성원 디렉토리에서 개별 구성원의 상세 정보에 접근할 수 있는 인터랙티브 UI가 추가되었습니다.

* **개선 사항**
  * 구성원 디렉토리의 역할 배지 표시 및 상호작용 개선.
  * 관리 인터페이스에서 실제 구성원 데이터를 로드하도록 업데이트되었습니다.
  * 역할 변경 시 토스트 알림으로 성공/오류 피드백이 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->