### PR TITLE
[FIX] 기수 목록 변경된 API 스펙 적용 및 useInfiniteScroll root prop 제거

### DIFF
--- a/apps/admin/src/features/member-by-generation/ui/MemberGenerationAccordion.tsx
+++ b/apps/admin/src/features/member-by-generation/ui/MemberGenerationAccordion.tsx
@@ -2,7 +2,7 @@
 
 import { useInfiniteScroll } from '@surf/hooks';
 import { Accordion } from '@surf/ui/accordion';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 import { useMemberBaseListQuery } from '@/entities/member/model/queries/useMemberBaseListQuery';
 import type { MemberBase } from '@/entities/member/model/types';
@@ -19,7 +19,7 @@ type Props = {
 
 export const MemberGenerationAccordion = ({ generation, label, keyword, renderItem }: Props) => {
   const [open, setOpen] = useState(false);
-  const [contentRoot, setContentRoot] = useState<HTMLDivElement | null>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
 
   //아코디언이 열리면 데이터 fetch
   const { memberIds, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
@@ -32,17 +32,16 @@ export const MemberGenerationAccordion = ({ generation, label, keyword, renderIt
 
   const onToggle = (nextOpen: boolean) => {
     // 다시 열 때 이전 스크롤 위치가 유지되면 footer가 바로 보일 수 있어 상단으로 리셋
-    if (nextOpen && contentRoot) {
-      contentRoot.scrollTop = 0;
+    if (nextOpen && contentRef.current) {
+      contentRef.current.scrollTop = 0;
     }
     setOpen(nextOpen);
   };
 
   const triggerRef = useInfiniteScroll({
-    enabled: open && Boolean(contentRoot),
-    root: contentRoot,
+    enabled: open,
     isFetching: isFetchingNextPage,
-    hasNextPage: open && Boolean(hasNextPage),
+    hasNextPage: Boolean(hasNextPage),
     onLoadMore: () => {
       void fetchNextPage();
     },
@@ -50,7 +49,7 @@ export const MemberGenerationAccordion = ({ generation, label, keyword, renderIt
 
   return (
     <Accordion title={label ?? `${generation}기`} onToggle={onToggle}>
-      <div ref={setContentRoot} className="max-h-[36vh] overflow-y-auto">
+      <div ref={contentRef} className="max-h-[36vh] overflow-y-auto">
         <MemberList
           members={members}
           isLoading={open && (isLoading || !isHydrated)}

--- a/apps/admin/src/widgets/member-directory/api/getMemberGenerationInfoClient.ts
+++ b/apps/admin/src/widgets/member-directory/api/getMemberGenerationInfoClient.ts
@@ -7,9 +7,7 @@ import { AdminTotalMemberListResDTO, MemberGenerationInfoResponse } from './type
  * @returns 전체 회원수 + 기수 목록 응답
  */
 export async function getMemberGenerationInfoClient(): Promise<AdminTotalMemberListResDTO> {
-  const response = await axiosInstance.get<MemberGenerationInfoResponse>(
-    '/v1/manager/members-count/generation',
-  );
+  const response = await axiosInstance.get<MemberGenerationInfoResponse>('/v1/manager/generations');
 
   return response.data.data;
 }

--- a/apps/admin/src/widgets/member-directory/api/getMemberGenerationInfoServer.ts
+++ b/apps/admin/src/widgets/member-directory/api/getMemberGenerationInfoServer.ts
@@ -8,9 +8,8 @@ import { MemberGenerationInfoResponse, AdminTotalMemberListResDTO } from './type
  * @returns 전체 회원수 + 기수 목록 응답
  */
 export async function getMemberGenerationInfoServer(): Promise<AdminTotalMemberListResDTO> {
-  const response = await serverFetchWithCookies<MemberGenerationInfoResponse>(
-    '/v1/manager/members-count/generation',
-  );
+  const response =
+    await serverFetchWithCookies<MemberGenerationInfoResponse>('/v1/manager/generations');
 
   return response.data;
 }

--- a/apps/admin/src/widgets/member-directory/api/types.ts
+++ b/apps/admin/src/widgets/member-directory/api/types.ts
@@ -6,7 +6,6 @@ export interface GenerationResDTO {
 }
 
 export interface AdminTotalMemberListResDTO {
-  totalMemberCount?: number; //전체 회원 수
   generations?: GenerationResDTO[]; //기수 리스트
 }
 

--- a/apps/admin/src/widgets/member-directory/model/mapper.ts
+++ b/apps/admin/src/widgets/member-directory/model/mapper.ts
@@ -1,10 +1,10 @@
 import { AdminTotalMemberListResDTO } from '../api/types';
-import { MemberDirectoryInfo } from './types';
+import { MemberGenerationList } from './types';
 
 /**
  * API DTO -> 도메인 모델 변환
  */
-export function toMemberGenerationList(dto: AdminTotalMemberListResDTO): MemberDirectoryInfo {
+export function toMemberGenerationList(dto: AdminTotalMemberListResDTO): MemberGenerationList {
   const picked = (dto?.generations ?? []).filter(
     (item): item is { generation: number } => typeof item?.generation === 'number',
   );
@@ -12,15 +12,7 @@ export function toMemberGenerationList(dto: AdminTotalMemberListResDTO): MemberD
   //  number[]로 변환
   const generations = picked.map((item) => item.generation);
 
-  if (process.env.NODE_ENV !== 'production') {
-    const dropped = (dto.generations?.length ?? 0) - generations.length;
-    if (dto.totalMemberCount === undefined || dropped > 0) {
-      console.warn('[member-directory] unexpected DTO shape', dto);
-    }
-  }
-
   return {
-    totalMemberCount: dto.totalMemberCount ?? 0,
     generations,
   };
 }

--- a/apps/admin/src/widgets/member-directory/model/queries/memberGenerationListQueryOptions.ts
+++ b/apps/admin/src/widgets/member-directory/model/queries/memberGenerationListQueryOptions.ts
@@ -1,7 +1,7 @@
 import { queryOptions } from '@tanstack/react-query';
 
 import { toMemberGenerationList } from '../mapper';
-import { MemberDirectoryInfo } from '../types';
+import { MemberGenerationList } from '../types';
 
 import { getMemberGenerationInfoClient } from '../../api/getMemberGenerationInfoClient';
 import { AdminTotalMemberListResDTO } from '../../api/types';
@@ -19,7 +19,7 @@ interface MemberGenerationListQueryOptionsParams {
 export function memberGenerationListQueryOptions({
   fetcher = getMemberGenerationInfoClient,
 }: MemberGenerationListQueryOptionsParams = {}) {
-  return queryOptions<MemberDirectoryInfo, Error, MemberDirectoryInfo>({
+  return queryOptions<MemberGenerationList, Error, MemberGenerationList>({
     queryKey: memberQueryKeys.directory(),
     queryFn: async () => {
       const dto = await fetcher();

--- a/apps/admin/src/widgets/member-directory/ui/MemberDirectoryWidget.tsx
+++ b/apps/admin/src/widgets/member-directory/ui/MemberDirectoryWidget.tsx
@@ -26,7 +26,7 @@ export const MemberDirectoryWidget = ({ keyword }: MemberDirectoryWidgetProps) =
       {/* 멤버 디렉토리 상단 바 */}
       <SelectableListTopBar
         mode={mode}
-        totalCount={data.totalMemberCount}
+        totalCount={0} //TODO: 멤버 카운트 API 연동 필요
         selectedCount={selectedCount}
         onEnterSelectMode={enterSelectMode}
         onExitSelectMode={exitSelectMode}

--- a/packages/hooks/useInfiniteScroll.ts
+++ b/packages/hooks/useInfiniteScroll.ts
@@ -6,7 +6,6 @@ type Props = {
   enabled?: boolean;
   hasNextPage?: boolean;
   isFetching?: boolean;
-  root?: Element | null;
   onLoadMore: () => void;
 };
 
@@ -14,7 +13,6 @@ export function useInfiniteScroll({
   enabled = true,
   hasNextPage = false,
   isFetching = false,
-  root = null,
   onLoadMore,
 }: Props) {
   const ref = useRef<HTMLDivElement | null>(null);
@@ -28,21 +26,18 @@ export function useInfiniteScroll({
     if (!ref.current) return;
     const target = ref.current;
 
-    const observer = new IntersectionObserver(
-      (entries) => {
-        const [entry] = entries;
-        if (!entry) return;
-        if (entry.isIntersecting) {
-          callback();
-        }
-      },
-      { root },
-    );
+    const observer = new IntersectionObserver((entries) => {
+      const [entry] = entries;
+      if (!entry) return;
+      if (entry.isIntersecting) {
+        callback();
+      }
+    });
 
     observer.observe(target);
 
     return () => observer.unobserve(target);
-  }, [callback, root]);
+  }, [callback]);
 
   return ref;
 }


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 코드에 any가 사용되지 않았습니다
- [ ] 스토리북에 추가했습니다 (해당 시)
- [ ] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈

- related #534 

## 📌 작업 목적

- 기수 목록 변경된 API 스펙 적용 및 useInfiniteScroll root prop 제거

## 🔨 주요 작업 내용

- 기수 목록 조회 API 경로가 변경되어 오류날 가능성이 있는 코드 수정 
- useInfiniteScroll root prop 제거

## ⚠️ 기존 문제 (선택)

### useInfiniteScroll에 root prop을 추가했던 이유

useInfiniteScroll에서 IntersectionObserver의 root를 스크롤 컨테이너(overflow-y-auto div)로 지정하면, 해당 컨테이너 기준으로 trigger 요소의 가시성을 판단할 수 있어 더 정확할 것이라 판단하여 추가했습니다.

## ☑️ 해결 방법 (선택)

### root prop을 제거한 이유

`overflow-y-auto`가 적용된 고정 높이 컨테이너 내부에서는 넘친 요소가 화면에서도 보이지 않기 때문에, `root: null`(viewport 기준)과 `root: 스크롤 컨테이너` 기준의 가시성 판정 결과가 동일합니다. 불필요한 root prop을 제거하고, 이에 따라 컴포넌트에서 useState로 관리하던 contentRoot도 useRef로 단순화했습니다.


## 💬 논의할 점

### 변경된 API 스펙 내용

✅ 기존 스펙
/v1/manager/members-count/generation
- 승인된 or 가입 대기중인 멤버 전체 수 + 전체 기수 정보
/v1/manager/registration-list
- 회원가입 명단 + 승인 or 거절된 전체 멤버 수

✅ 변경 스펙
/v1/manager/generations
- 전체 기수 정보만 내려줌
/v1/manager/registration-list
- 회원가입 명단만 내려줌
/v1/user/members-count
- memberStatus에 따른 전체 회원 수 조회
- 멤버 관리/회원가입 요청 화면에서 카운트 공통 재사용 목적

> 현재 PR에서는 오류 방지를 위해 기수 목록 조회 API 경로 변경 + 응답에서 totalMemberCount 필드만 제거하였으며, 추후 작업에서 리팩토링 진행할 계획입니다 ❕
