### PR TITLE
[CHORE] 기수별 멤버 아코디언에 높이 정책 추가

### DIFF
--- a/apps/admin/src/features/member-by-generation/model/useMembersByGenerationInfiniteQuery.ts
+++ b/apps/admin/src/features/member-by-generation/model/useMembersByGenerationInfiniteQuery.ts
@@ -12,7 +12,7 @@ import {
 import { getMemberListByGeneration } from '../api/getMemberListByGeneration';
 import type { MemberListParams } from '../api/types';
 
-const MEMBER_BY_GENERATION_PAGE_SIZE = 5;
+const MEMBER_BY_GENERATION_PAGE_SIZE = 20;
 
 /**
  * 기수별 멤버 목록 조회 필터

--- a/apps/admin/src/features/member-by-generation/ui/MemberGenerationAccordion.tsx
+++ b/apps/admin/src/features/member-by-generation/ui/MemberGenerationAccordion.tsx
@@ -3,7 +3,7 @@
 import { useInfiniteScroll } from '@surf/hooks';
 import { Accordion } from '@surf/ui/accordion';
 import { useRef, useState } from 'react';
-import type { ReactNode } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
 import { useMemberBaseListQuery } from '@/entities/member/model/queries/useMemberBaseListQuery';
 import type { MemberBase } from '@/entities/member/model/types';
 
@@ -27,8 +27,11 @@ export const MemberGenerationAccordion = ({
   renderItem,
   contentMaxHeight,
 }: Props) => {
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(defaultOpen ?? false);
   const contentRef = useRef<HTMLDivElement>(null);
+  const contentStyle: CSSProperties | undefined = contentMaxHeight
+    ? { maxHeight: contentMaxHeight }
+    : undefined;
 
   //아코디언이 열리면 데이터 fetch
   const { memberIds, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
@@ -58,7 +61,7 @@ export const MemberGenerationAccordion = ({
 
   return (
     <Accordion title={label ?? `${generation}기`} onToggle={onToggle} defaultOpen={defaultOpen}>
-      <div ref={contentRef} className="overflow-y-auto" style={{ maxHeight: contentMaxHeight }}>
+      <div ref={contentRef} className="overflow-y-auto" style={contentStyle}>
         <MemberList
           members={members}
           isLoading={open && (isLoading || !isHydrated)}

--- a/apps/admin/src/features/member-by-generation/ui/MemberGenerationAccordion.tsx
+++ b/apps/admin/src/features/member-by-generation/ui/MemberGenerationAccordion.tsx
@@ -16,16 +16,18 @@ type Props = {
   keyword?: string;
   defaultOpen?: boolean;
   renderItem: (m: MemberBase) => ReactNode;
+  contentMaxHeight?: string;
 };
 
 export const MemberGenerationAccordion = ({
   generation,
   label,
   keyword,
-  defaultOpen = false,
+  defaultOpen,
   renderItem,
+  contentMaxHeight,
 }: Props) => {
-  const [open, setOpen] = useState<boolean>(defaultOpen);
+  const [open, setOpen] = useState(false);
   const contentRef = useRef<HTMLDivElement>(null);
 
   //아코디언이 열리면 데이터 fetch
@@ -56,7 +58,7 @@ export const MemberGenerationAccordion = ({
 
   return (
     <Accordion title={label ?? `${generation}기`} onToggle={onToggle} defaultOpen={defaultOpen}>
-      <div ref={contentRef} className="max-h-[36vh] overflow-y-auto">
+      <div ref={contentRef} className="overflow-y-auto" style={{ maxHeight: contentMaxHeight }}>
         <MemberList
           members={members}
           isLoading={open && (isLoading || !isHydrated)}

--- a/apps/admin/src/test/setup.ts
+++ b/apps/admin/src/test/setup.ts
@@ -1,6 +1,18 @@
 import '@testing-library/jest-dom/vitest';
 import { server } from './mocks/server';
 
+if (!globalThis.ResizeObserver) {
+  class ResizeObserverMock implements ResizeObserver {
+    observe() {}
+
+    unobserve() {}
+
+    disconnect() {}
+  }
+
+  globalThis.ResizeObserver = ResizeObserverMock;
+}
+
 if (!globalThis.IntersectionObserver) {
   type IOCallback = IntersectionObserverCallback;
 

--- a/apps/admin/src/widgets/member-directory/ui/MemberGenerationAccordionList.tsx
+++ b/apps/admin/src/widgets/member-directory/ui/MemberGenerationAccordionList.tsx
@@ -9,6 +9,8 @@ import { useBottomSheetStore } from '@/shared/store/bottomSheetStore';
 export interface MemberGenerationAccordionListProps {
   keyword: string;
 }
+
+const ACCORDIAN_MAX_HEIGHT = '36vh';
 export const MemberGenerationAccordionList = ({ keyword }: MemberGenerationAccordionListProps) => {
   //기수 목록 조회
   const { data: generations } = useMemberGenerationListQuery();
@@ -39,6 +41,7 @@ export const MemberGenerationAccordionList = ({ keyword }: MemberGenerationAccor
           generation={generation}
           label={`${generation}기`}
           keyword={keyword}
+          contentMaxHeight={ACCORDIAN_MAX_HEIGHT}
           renderItem={(m) => (
             <SelectableMemberCard
               name={m.name}


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 코드에 any가 사용되지 않았습니다
- [ ] 스토리북에 추가했습니다 (해당 시)
- [ ] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈

- close #564 

## 📌 작업 목적

- 기수별 멤버 아코디언에 높이 정책을 동적으로 주입받도록 변경 

## 🔨 주요 작업 내용

- `MemberGenerationAccordion`에 하드코딩되어 있던 maxHeight 제거, 최대 높이를 동적으로 주입받도록 변경
- 기수별 멤버 페이지 사이즈 기능 요구사항에 맞게 20명으로 변경

## ⚠️ 기존 문제 (선택)
- MemberGenerationAccordion에 maxHeight이 하드코딩 되어 있어 화면 전체를 차지해야하는 그룹 관리 화면에서도 maxHeight이 적용되는 이슈 발생 

<img width="300"  alt="image" src="https://github.com/user-attachments/assets/15c3f41e-a5bb-48a9-b885-99857f10bf61" />

## ☑️ 해결 방법 (선택)

- `MemberGenerationAccordion`에 하드코딩되어 있던 maxHeight 제거, 최대 높이를 동적으로 주입받도록 변경


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 세대별 멤버 목록의 페이지당 로드 항목 수를 5개에서 20개로 증가하여 페이지네이션 효율성 개선
  * 멤버 아코디언의 내용 영역 높이 제어가 유연해져 다양한 레이아웃에 대응 가능
  * 아코디언은 이제 사용자가 직접 열었을 때만 내용을 로드하도록 동작하여 불필요한 로드 감소
* **테스트**
  * 테스트 환경에 ResizeObserver 폴리필을 추가해 관련 컴포넌트 테스트 안정성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->