### PR TITLE
[FIX] 홈 화면 QA

### DIFF
--- a/apps/web/src/app-pages/home/ui/HomePageClient.tsx
+++ b/apps/web/src/app-pages/home/ui/HomePageClient.tsx
@@ -31,21 +31,14 @@ export const HomePageClient = ({ heroProps }: { heroProps: HeroCardProps }) => {
   const { data: notifications } = useGetNotifications('ALL');
   const hasUnread = notifications?.some((noti) => !noti.isRead);
 
-  const fallbackCarouselImages = [
-    { src: '/images/home/conference.svg', alt: 'Conference Banner' },
-    { src: '/images/home/17th.svg', alt: '17th Banner' },
-    { src: '/images/home/sprint.svg', alt: 'Sprint Banner' },
-  ];
-
   const carouselImages = (() => {
-    if (!homeData?.carouselImages?.length) return fallbackCarouselImages;
-    const normalized = homeData.carouselImages
+    const normalized = (homeData?.carouselImages ?? [])
       .filter((img) => Boolean(img.src))
       .map((img) => ({
         ...img,
         linkUrl: img.linkUrl === null ? undefined : img.linkUrl,
       }));
-    return normalized.length > 0 ? normalized : fallbackCarouselImages;
+    return normalized;
   })();
 
   const handleShortcutClick = (link: string, label: string) => {

--- a/packages/ui/components/carousel/Carousel.tsx
+++ b/packages/ui/components/carousel/Carousel.tsx
@@ -63,7 +63,7 @@ export const Carousel = ({ images, className = '', autoPlayMs = 0 }: Props) => {
         className,
       ].join(' ')}
     >
-      {/* 1) 이미지 */}
+      {/* 이미지 */}
       <div
         className="flex h-full w-full transition-transform duration-500 ease-in-out"
         style={{ transform: `translateX(-${index * 100}%)` }}
@@ -99,10 +99,7 @@ export const Carousel = ({ images, className = '', autoPlayMs = 0 }: Props) => {
         })}
       </div>
 
-      {/* 2) dim */}
-      <div className="from-background-carousel-start to-background-carousel-end pointer-events-none absolute inset-0 z-10 bg-gradient-to-b" />
-
-      {/* 3)controlls, pagination */}
+      {/* controlls, pagination */}
       {total > 1 && (
         <>
           <button

--- a/packages/ui/components/shortcut/Shortcut.tsx
+++ b/packages/ui/components/shortcut/Shortcut.tsx
@@ -8,7 +8,7 @@ interface ShortcutProps {
 export const Shortcut = ({ type, label, imageSrc, onClick }: ShortcutProps) => {
   if (type === 'circle') {
     return (
-      <button className="flex w-full flex-col items-center gap-7" onClick={onClick}>
+      <button type="button" className="flex w-full flex-col items-center gap-7" onClick={onClick}>
         <div className="bg-background-normal h-[2.5rem] w-[2.5rem] overflow-hidden rounded-full">
           <img src={imageSrc} alt={label} className="h-full w-full object-cover" />
         </div>
@@ -20,6 +20,7 @@ export const Shortcut = ({ type, label, imageSrc, onClick }: ShortcutProps) => {
   // rectangle
   return (
     <button
+      type="button"
       className="bg-background-normal-lighter rounded-5 border-border-secondary flex aspect-[7/10] w-full flex-col items-start overflow-hidden border shadow-[var(--effect-shadow-lifted-x-normal,0)_var(--effect-shadow-lifted-y-normal,0)_var(--effect-shadow-lifted-blur,20px)_var(--effect-shadow-lifted-spread,6px)_rgba(0,0,0,0.04)]"
       onClick={onClick}
     >

--- a/packages/ui/components/shortcut/Shortcut.tsx
+++ b/packages/ui/components/shortcut/Shortcut.tsx
@@ -20,14 +20,14 @@ export const Shortcut = ({ type, label, imageSrc, onClick }: ShortcutProps) => {
   // rectangle
   return (
     <button
-      className="bg-background-normal-lighter rounded-5 border-border-secondary flex w-full flex-col items-start overflow-hidden border shadow-[var(--effect-shadow-lifted-x-normal,0)_var(--effect-shadow-lifted-y-normal,0)_var(--effect-shadow-lifted-blur,20px)_var(--effect-shadow-lifted-spread,6px)_rgba(0,0,0,0.04)]"
+      className="bg-background-normal-lighter rounded-5 border-border-secondary flex aspect-[7/10] w-full flex-col items-start overflow-hidden border shadow-[var(--effect-shadow-lifted-x-normal,0)_var(--effect-shadow-lifted-y-normal,0)_var(--effect-shadow-lifted-blur,20px)_var(--effect-shadow-lifted-spread,6px)_rgba(0,0,0,0.04)]"
       onClick={onClick}
     >
       {/* Label 영역 */}
       <div className="text-foreground-normal text-body-body5 px-13 pt-13">{label}</div>
 
       {/* 이미지 영역 */}
-      <div className="bg-background-normal-lighter w-full flex-1">
+      <div className="bg-background-normal-lighter rounded-b-5 aspect-[21/22] w-full flex-1">
         <img src={imageSrc} alt={label} className="h-full w-full object-cover" />
       </div>
     </button>


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 코드에 any가 사용되지 않았습니다
- [ ] 스토리북에 추가했습니다 (해당 시)
- [ ] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈

- close #566

## 📌 작업 목적

- 홈 화면 수정

## 🔨 주요 작업 내용

- 케러셀 dim 삭제
- 숏컷 radius 반영

## ⚠️ 기존 문제 (선택)

- 캐러셀에서 기본 사진이 보이고 이후 api response로 받은 배너가 보여 기본값을 지웠습니다. 또한 dim은 너무 어두워 빼기로 하였습니다.
- square shortcut에서 이미지 radius와 bg radius가 달라 맞지 않는 부분이 있었습니다.

## ☑️ 해결 방법 (선택)

- 디자인 사항을 반영하였습니다

## 🧪 테스트 방법

- 홈 화면 이동해서 확인

## ✔️ 설치 라이브러리

-

## 📷 실행 영상 또는 스크린샷

-

## 💬 논의할 점

-

## 🙋🏻 참고 자료

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일 개선**
  * 캐러셀 그래디언트 오버레이 제거로 더 깔끔한 시각 경험 제공
  * 단축키 버튼에 정확한 종횡비 제약 추가로 일관된 크기와 모양 유지
  * 이미지 컨테이너 하단 둥글림 처리로 세련된 외관 개선

* **버그 수정**
  * 캐러셀 이미지 미제공 시 자동으로 표시되던 기본 이미지 기능 제거

<!-- end of auto-generated comment: release notes by coderabbit.ai -->