### PR TITLE
[FIX] 아코디언 콘텐츠 높이 갱신이 배포 환경에서 동작하지 않는 버그 수정

### DIFF
--- a/apps/admin/src/app-pages/home/ui/HomePage.tsx
+++ b/apps/admin/src/app-pages/home/ui/HomePage.tsx
@@ -5,7 +5,7 @@ import { AppNavigation } from '@/widgets/navigation/ui/AppNavigation';
 
 export const HomePage = () => {
   return (
-    <div className="w-full flex-1 flex-col">
+    <div className="flex h-full min-h-0 w-full flex-1 flex-col">
       <AppHeader
         overrideHeader={{
           mode: HeaderMode.Logo,

--- a/apps/admin/src/widgets/navigation/ui/AppNavigation.tsx
+++ b/apps/admin/src/widgets/navigation/ui/AppNavigation.tsx
@@ -3,18 +3,20 @@ import { NAV_ITEMS } from '../model/config';
 
 export const AppNavigation = () => {
   return (
-    <main className="flex h-full w-full flex-col justify-center gap-16 px-13">
-      {NAV_ITEMS.map((item) => {
-        return (
-          <Link
-            key={item.id}
-            href={item.path}
-            className="border-border-quinary rounded-3 w-full border px-15 py-11 text-center"
-          >
-            <span className="text-title-title2 text-center">{item.label}</span>
-          </Link>
-        );
-      })}
+    <main className="min-h-0 w-full flex-1 overflow-y-auto px-13 py-16">
+      <div className="flex min-h-full flex-col justify-center gap-16">
+        {NAV_ITEMS.map((item) => {
+          return (
+            <Link
+              key={item.id}
+              href={item.path}
+              className="border-border-quinary rounded-3 w-full border px-15 py-11 text-center"
+            >
+              <span className="text-title-title2 text-center">{item.label}</span>
+            </Link>
+          );
+        })}
+      </div>
     </main>
   );
 };

--- a/packages/ui/components/accordion/Accordion.tsx
+++ b/packages/ui/components/accordion/Accordion.tsx
@@ -36,10 +36,11 @@ export const Accordion = ({
     if (isOpen) {
       setMaxHeight(`${el.scrollHeight}px`);
 
+      const inner = el.firstElementChild;
       const observer = new ResizeObserver(() => {
         setMaxHeight(`${el.scrollHeight}px`);
       });
-      observer.observe(el);
+      if (inner) observer.observe(inner);
 
       return () => observer.disconnect();
     } else {


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 코드에 any가 사용되지 않았습니다
- [ ] 스토리북에 추가했습니다 (해당 시)
- [ ] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈

- close #569 

## 📌 작업 목적

- 배포 환경에서 아코디언 콘텐츠 높이 갱신이 배포 환경에서 동작하지 않는 버그 수정

## 🔨 주요 작업 내용

- Accordion 컴포넌트 높이 갱신 로직 수정
- 어드민 홈 화면 스크롤 되도록 수정 

## ⚠️ 기존 문제 (선택)

ResizeObserver는 관찰 대상의 렌더링된 크기 변화에만 반응한다. wrapper div는 maxHeight로 크기가 고정되어 있어, 내부 콘텐츠가 늘어나도 콜백이 실행되지 않았다.

개발 환경(React StrictMode)에서 정상 동작 되었던 이유는 스트릭트 모드에 의해 useEffect가 두 번 실행되기 때문이다.
두 번째 실행 시점에 올바른 scrollHeight를 읽어 정상 동작하는 것처럼 보였으나, 배포 환경에서는 한 번만 실행되어 최초 읽기가 잘못된 경우 보정 불가.

## ☑️ 해결 방법 (선택)

ResizeObserver의 관찰 대상을 maxHeight 제약이 걸린 wrapper div에서 내부 첫 번째 자식 요소(inner)로 변경.

**변경 전**
observer.observe(el);  // el = maxHeight가 적용된 wrapper

**변경 후**
const inner = el.firstElementChild;
if (inner) observer.observe(inner);  // inner = 높이 제약 없는 자식

## 🧪 테스트 방법

- 어드민 멤버 관리 화면에서 아코디언 높이가 정상적으로 갱신되는지 확인 


## 🙋🏻 참고 자료

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 아코디언 컴포넌트의 크기 조정 동작을 개선했습니다.

* **스타일**
  * 홈페이지 및 네비게이션 레이아웃을 최적화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->