### PR TITLE
[DOCS] AGENTS.md, CLAUDE.md, 서브 에이전트 문서 생성

### DIFF
--- a/.claude/commands/gen-test.md
+++ b/.claude/commands/gen-test.md
@@ -1,0 +1,148 @@
+# gen-test
+
+대상 파일의 테스트 코드를 자동 생성합니다.
+
+## 사용법
+
+```
+/gen-test <파일경로> [파일경로2] ...
+```
+
+## 실행 흐름
+
+대상 파일이 여러 개면 Task 툴로 병렬 실행.
+각 Task는 아래 흐름을 독립적으로 수행.
+
+### 1. 컨텍스트 로드
+
+각 Task 시작 시 반드시 아래 문서를 먼저 읽는다:
+- @docs/testing.md
+- @docs/conventions.md
+
+### 2. 파일 분류 및 생성 여부 판단
+
+대상 파일을 읽고 아래 기준으로 분류:
+
+| 파일 패턴 | 테스트 종류 | 생성 위치 |
+|-----------|------------|-----------|
+| `app-pages/**/ui/*.tsx` | 통합 테스트 | `app-pages/**/__tests__/*.integration.test.tsx` |
+| `features/**/ui/*.tsx` | 인터랙션 있으면 RTL 단위 테스트, 없으면 생성 안 함 | `features/**/__tests__/*.test.tsx` |
+| `features/**/model/use*.ts` | 훅 단위 테스트 | `features/**/__tests__/*.test.ts` |
+| `features/**/model/mappers.ts` | 순수 함수 단위 테스트 | `features/**/__tests__/mappers.test.ts` |
+| `shared/lib/*.ts` | 순수 함수 단위 테스트 | `shared/lib/__tests__/*.test.ts` |
+
+**생성하지 않는 파일:**
+- `*/api/*.ts` — 훅 레벨에서 커버됨
+- `*/model/use*Store.ts` — 통합 테스트에서 커버됨
+- `*/index.ts` — re-export 파일
+
+`features/**/ui/*.tsx` 판단 기준:
+- `onClick`, `onSubmit` 등 이벤트 핸들러 + 상태 변화 있음 → RTL 테스트 생성
+- props만 받아 렌더링 → 생성 안 함, 아래 메시지 출력:
+  ```
+  ⏭ PostCard.tsx — 순수 표시용 컴포넌트. Storybook으로 위임.
+  ```
+
+### 3. 테스트 작성 기준
+
+**통합 테스트 (`app-pages`)**
+- `renderWithProviders` 사용
+- 사용자 시나리오 기반: `userEvent`로 조작 → 화면 변화 검증
+- API 훅은 `vi.mock`으로 모킹
+- Zustand store 초기화는 `beforeEach`에서 `resetForm()` 호출
+
+**컴포넌트 단위 테스트 (`features/**/ui`)**
+- `renderWithProviders` 사용
+- 인터랙션 → 화면 변화 검증 (mutate 호출 횟수 검증 금지)
+- 의존하는 훅은 `vi.mock`으로 모킹
+
+**훅 단위 테스트 (`model/use*.ts`)**
+- 뮤테이션 훅: `mutateAsync` 호출 후 `onSuccess` / `onError` 분기 검증
+- 쿼리 훅: `queryKey`, `queryFn` 반환값 검증
+- `renderHook` + `createWrapper()` 사용
+
+**순수 함수 (`mappers`, `shared/lib`)**
+- 입력 → 출력 검증만
+- 모킹 없음
+- 엣지 케이스 포함: null 필드, 빈 배열, 경계값
+
+### 4. 공통 금지 사항
+
+testing.md "테스트하지 않는 것" 섹션을 반드시 준수:
+- CSS 클래스명 검증 금지
+- 컴포넌트 내부 state 직접 접근 금지
+- 함수 호출 횟수 등 구현 세부사항 검증 금지
+- UI 스냅샷 테스트 금지
+
+### 5. 테스트 실행
+
+생성된 테스트 파일을 즉시 실행:
+
+```bash
+pnpm vitest run <생성된 테스트 파일 경로>
+```
+
+### 6. 실패 감지 및 수정
+
+실패한 테스트가 있으면 아래 순서로 처리:
+
+**원인 분류:**
+
+| 원인 | 판단 기준 | 조치 |
+|------|-----------|------|
+| 모킹 누락/잘못됨 | `Cannot read properties of undefined` 등 | 모킹 대상 및 반환값 수정 |
+| 잘못된 쿼리셀렉터 | `Unable to find role` / `Unable to find label` | `getByRole`, `getByLabelText` 등 셀렉터 수정 |
+| 비동기 처리 누락 | `not wrapped in act(...)` 경고 | `await`, `waitFor` 추가 |
+| 테스트 케이스 자체가 잘못됨 | 실제 컴포넌트 동작과 기대값 불일치 | 대상 파일 재분석 후 케이스 재작성 |
+| 소스 코드 버그 | 테스트는 올바른데 구현이 잘못됨 | 수정하지 않고 보고만 함 |
+
+**수정 제한:**
+- 테스트 코드만 수정한다. 소스 코드는 절대 수정하지 않는다.
+- 소스 코드 버그로 판단되면 수정 없이 보고만 한다.
+- 최대 3회 재시도. 3회 후에도 실패하면 중단하고 보고한다.
+
+### 7. 재실행 및 통과 확인
+
+수정 후 동일 명령으로 재실행. 전체 통과 확인:
+
+```bash
+pnpm vitest run <테스트 파일 경로>
+```
+
+### 8. 완료 보고
+
+**정상 케이스:**
+```
+✅ app-pages/post/__tests__/post-page.integration.test.tsx 생성 (3개 케이스) — 통과
+✅ features/post/__tests__/LikeButton.test.tsx 생성 (2개 케이스) — 통과
+⏭ features/post/ui/PostCard.tsx — 순수 표시용 컴포넌트. Storybook으로 위임.
+```
+
+**수정 후 통과:**
+```
+✅ features/post/__tests__/mappers.test.ts 생성 (5개 케이스)
+  └ 1회 수정: getByText → getByRole('cell')로 셀렉터 변경 후 통과
+```
+
+**소스 코드 버그 감지:**
+```
+⚠️ features/post/__tests__/useDeletePost.test.ts — 테스트 통과 불가
+  └ 원인: onError에서 useToastStore 미사용, useAlertStore 직접 호출 중
+  └ 수정 필요: features/post/model/useDeletePost.ts line 24
+  └ 참고: conventions.md 에러 처리 섹션
+```
+
+**3회 재시도 초과:**
+```
+❌ features/post/__tests__/PostForm.test.tsx — 3회 시도 후 실패
+  └ 마지막 오류: [에러 메시지]
+  └ 원인 추정: [분석 내용]
+  └ 직접 확인 필요
+```
+
+## 범위 외
+
+- 테스트 생성 및 수정만 한다. 소스 코드는 절대 수정하지 않는다.
+- 코드 리뷰는 하지 않는다 → `/review` 커맨드 사용
+
+

--- a/.claude/commands/gen-test.md
+++ b/.claude/commands/gen-test.md
@@ -4,7 +4,7 @@
 
 ## 사용법
 
-```
+```bash
 /gen-test <파일경로> [파일경로2] ...
 ```
 
@@ -17,26 +17,27 @@
 
 각 Task 시작 시 반드시 아래 문서를 먼저 읽는다:
 - @docs/testing.md
-- @docs/conventions.md
+- @docs/code-convention.md
 
 ### 2. 파일 분류 및 생성 여부 판단
 
-대상 파일을 읽고 아래 기준으로 분류:
+대상 파일 경로에서 앱 루트(`apps/web` 또는 `apps/admin`)를 먼저 확인한 뒤 아래 기준으로 분류한다.  
+이하 표에서 `<APP_ROOT>`는 `apps/web` 또는 `apps/admin`을 의미한다.
 
 | 파일 패턴 | 테스트 종류 | 생성 위치 |
 |-----------|------------|-----------|
-| `app-pages/**/ui/*.tsx` | 통합 테스트 | `app-pages/**/__tests__/*.integration.test.tsx` |
-| `features/**/ui/*.tsx` | 인터랙션 있으면 RTL 단위 테스트, 없으면 생성 안 함 | `features/**/__tests__/*.test.tsx` |
-| `features/**/model/use*.ts` | 훅 단위 테스트 | `features/**/__tests__/*.test.ts` |
-| `features/**/model/mappers.ts` | 순수 함수 단위 테스트 | `features/**/__tests__/mappers.test.ts` |
-| `shared/lib/*.ts` | 순수 함수 단위 테스트 | `shared/lib/__tests__/*.test.ts` |
+| `<APP_ROOT>/src/app-pages/**/ui/*.tsx` | 통합 테스트 | `<APP_ROOT>/src/app-pages/**/__tests__/*.integration.test.tsx` |
+| `<APP_ROOT>/src/features/**/ui/*.tsx` | 인터랙션 있으면 RTL 단위 테스트, 없으면 생성 안 함 | `<APP_ROOT>/src/features/**/__tests__/*.test.tsx` |
+| `<APP_ROOT>/src/features/**/model/use*.ts` | 훅 단위 테스트 | `<APP_ROOT>/src/features/**/__tests__/*.test.ts` |
+| `<APP_ROOT>/src/features/**/model/mappers.ts` | 순수 함수 단위 테스트 | `<APP_ROOT>/src/features/**/__tests__/mappers.test.ts` |
+| `<APP_ROOT>/src/shared/lib/*.ts` | 순수 함수 단위 테스트 | `<APP_ROOT>/src/shared/lib/__tests__/*.test.ts` |
 
 **생성하지 않는 파일:**
 - `*/api/*.ts` — 훅 레벨에서 커버됨
 - `*/model/use*Store.ts` — 통합 테스트에서 커버됨
 - `*/index.ts` — re-export 파일
 
-`features/**/ui/*.tsx` 판단 기준:
+`<APP_ROOT>/src/features/**/ui/*.tsx` 판단 기준:
 - `onClick`, `onSubmit` 등 이벤트 핸들러 + 상태 변화 있음 → RTL 테스트 생성
 - props만 받아 렌더링 → 생성 안 함, 아래 메시지 출력:
   ```
@@ -76,11 +77,24 @@ testing.md "테스트하지 않는 것" 섹션을 반드시 준수:
 
 ### 5. 테스트 실행
 
-생성된 테스트 파일을 즉시 실행:
+대상 파일의 경로에서 어느 앱인지 판별한 뒤 `--filter`를 명시해 실행한다.
+
+**앱 판별 규칙:**
+
+| 파일 경로 패턴 | filter |
+|----------------|--------|
+| `apps/web/...` 포함 | `surf-web` |
+| `apps/admin/...` 포함 | `surf-admin` |
 
 ```bash
-pnpm vitest run <생성된 테스트 파일 경로>
+# surf-web 예시
+pnpm --filter surf-web vitest run <생성된 테스트 파일의 apps/web/ 기준 상대 경로>
+
+# surf-admin 예시
+pnpm --filter surf-admin vitest run <생성된 테스트 파일의 apps/admin/ 기준 상대 경로>
 ```
+
+> **주의:** `pnpm vitest run <경로>`만 사용하면 루트에서 실행되어 어느 workspace를 대상으로 하는지 모호해진다. 반드시 `--filter`를 붙인다.
 
 ### 6. 실패 감지 및 수정
 
@@ -103,38 +117,38 @@ pnpm vitest run <생성된 테스트 파일 경로>
 
 ### 7. 재실행 및 통과 확인
 
-수정 후 동일 명령으로 재실행. 전체 통과 확인:
+수정 후 5단계와 동일한 `--filter` 명령으로 재실행. 전체 통과 확인:
 
 ```bash
-pnpm vitest run <테스트 파일 경로>
+pnpm --filter <surf-web|surf-admin> vitest run <테스트 파일 경로>
 ```
 
 ### 8. 완료 보고
 
 **정상 케이스:**
 ```
-✅ app-pages/post/__tests__/post-page.integration.test.tsx 생성 (3개 케이스) — 통과
-✅ features/post/__tests__/LikeButton.test.tsx 생성 (2개 케이스) — 통과
-⏭ features/post/ui/PostCard.tsx — 순수 표시용 컴포넌트. Storybook으로 위임.
+✅ apps/web/src/app-pages/post/__tests__/post-page.integration.test.tsx 생성 (3개 케이스) — 통과
+✅ apps/web/src/features/post/__tests__/LikeButton.test.tsx 생성 (2개 케이스) — 통과
+⏭ apps/web/src/features/post/ui/PostCard.tsx — 순수 표시용 컴포넌트. Storybook으로 위임.
 ```
 
 **수정 후 통과:**
 ```
-✅ features/post/__tests__/mappers.test.ts 생성 (5개 케이스)
+✅ apps/web/src/features/post/__tests__/mappers.test.ts 생성 (5개 케이스)
   └ 1회 수정: getByText → getByRole('cell')로 셀렉터 변경 후 통과
 ```
 
 **소스 코드 버그 감지:**
 ```
-⚠️ features/post/__tests__/useDeletePost.test.ts — 테스트 통과 불가
+⚠️ apps/web/src/features/post/__tests__/useDeletePost.test.ts — 테스트 통과 불가
   └ 원인: onError에서 useToastStore 미사용, useAlertStore 직접 호출 중
-  └ 수정 필요: features/post/model/useDeletePost.ts line 24
+  └ 수정 필요: apps/web/src/features/post/model/useDeletePost.ts line 24
   └ 참고: conventions.md 에러 처리 섹션
 ```
 
 **3회 재시도 초과:**
 ```
-❌ features/post/__tests__/PostForm.test.tsx — 3회 시도 후 실패
+❌ apps/web/src/features/post/__tests__/PostForm.test.tsx — 3회 시도 후 실패
   └ 마지막 오류: [에러 메시지]
   └ 원인 추정: [분석 내용]
   └ 직접 확인 필요

--- a/.claude/commands/publish-components.md
+++ b/.claude/commands/publish-components.md
@@ -33,6 +33,7 @@ Playwright 스크린샷 리포트를 만듭니다.
 ```json
 {
   "componentName": "PostCard",
+  "targetApp": "web",
   "variants": ["default", "hover", "disabled"],
   "props": [
     { "name": "title", "type": "string" },
@@ -54,6 +55,8 @@ Playwright 스크린샷 리포트를 만듭니다.
 3. 전달받은 화면 설명과 @docs/component-patterns.md 레이어 판단 기준을
    함께 참고해 적합한 레이어 제안
 4. `packages/ui`에서 재사용 가능한 컴포넌트 목록 확인
+5. `targetApp` 결정: 화면 설명이나 Figma 컨텍스트에서 대상 앱(`web` / `admin`)을 판별.
+   명확하지 않으면 승인 요청 시 함께 확인한다.
 
 **산출물:** `publish-output/spec.json`
 
@@ -62,7 +65,9 @@ Playwright 스크린샷 리포트를 만듭니다.
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 컴포넌트명: PostCard
+대상 앱: apps/web  (변경하려면 알려주세요)
 제안 레이어: entities/post
+생성 경로: apps/web/src/entities/post/ui/PostCard.tsx
 이유: Post 도메인 데이터를 표시하는 순수 표시용 컴포넌트.
       인터랙션 없음, API 연동 없음.
 
@@ -91,21 +96,27 @@ Playwright 스크린샷 리포트를 만듭니다.
 
 **작업:**
 
-1. 승인된 레이어 기준으로 FSD 폴더 구조 생성:
+1. `spec.json`의 `targetApp` 값(`web` / `admin`)을 읽어 앱 루트를 결정한다:
+   - `web` → `apps/web/src`
+   - `admin` → `apps/admin/src`
+
+   이하 경로는 모두 결정된 앱 루트(`<APP_ROOT>`) 아래에 생성한다.
+
+2. 승인된 레이어 기준으로 FSD 폴더 구조 생성:
 
 ```
 # entities인 경우
-entities/<domain>/ui/<ComponentName>.tsx
-entities/<domain>/index.ts
+<APP_ROOT>/entities/<domain>/ui/<ComponentName>.tsx
+<APP_ROOT>/entities/<domain>/index.ts
 
 # features인 경우
-features/<feature-name>/ui/<ComponentName>.tsx
-features/<feature-name>/model/  (API 연동 있을 경우)
-features/<feature-name>/index.ts
+<APP_ROOT>/features/<feature-name>/ui/<ComponentName>.tsx
+<APP_ROOT>/features/<feature-name>/model/  (API 연동 있을 경우)
+<APP_ROOT>/features/<feature-name>/index.ts
 
 # widgets인 경우
-widgets/<widget-name>/ui/<ComponentName>.tsx
-widgets/<widget-name>/index.ts
+<APP_ROOT>/widgets/<widget-name>/ui/<ComponentName>.tsx
+<APP_ROOT>/widgets/<widget-name>/index.ts
 ```
 
 2. 컴포넌트 작성 기준:
@@ -124,7 +135,7 @@ className="border-[#E2E8F0]"
 3. 기존 파일 처리:
    - **컴포넌트 파일**이 이미 존재하면 덮어쓰지 않고 중단:
      ```
-     ⛔ entities/post/ui/PostCard.tsx 이미 존재합니다.
+     ⛔ apps/web/src/entities/post/ui/PostCard.tsx 이미 존재합니다.
         덮어쓰려면 명시적으로 알려주세요.
      ```
    - **`index.ts`**가 이미 존재하면 덮어쓰지 않고 새 export만 추가(append):
@@ -145,9 +156,9 @@ className="border-[#E2E8F0]"
 
 **작업:**
 
-1. story 파일 생성 위치:
+1. story 파일 생성 위치 (`spec.json`의 `targetApp` 기준):
 ```
-<layer>/<name>/ui/<ComponentName>.stories.tsx
+apps/{targetApp}/src/<layer>/<name>/ui/<ComponentName>.stories.tsx
 ```
 
 2. story 작성 기준:
@@ -180,7 +191,7 @@ export const Hovered: Story = {
 };
 ```
 
-**산출물:** `<layer>/<name>/ui/<ComponentName>.stories.tsx`
+**산출물:** `apps/{targetApp}/src/<layer>/<name>/ui/<ComponentName>.stories.tsx`
 
 ---
 
@@ -231,11 +242,11 @@ open publish-output/report.html
    └ ⚠️ 토큰 미매핑 1건: border-color #E2E8F0
 
 ✅ Agent 2 — 컴포넌트 생성 완료
-   └ entities/post/ui/PostCard.tsx
-   └ entities/post/index.ts
+   └ apps/web/src/entities/post/ui/PostCard.tsx
+   └ apps/web/src/entities/post/index.ts
 
 ✅ Agent 3 — Storybook 생성 완료
-   └ entities/post/ui/PostCard.stories.tsx
+   └ apps/web/src/entities/post/ui/PostCard.stories.tsx
    └ 3개 story: Default, Hovered, Disabled
 
 ✅ Agent 4 — 스크린샷 리포트 생성 완료

--- a/.claude/commands/publish-components.md
+++ b/.claude/commands/publish-components.md
@@ -1,0 +1,250 @@
+# publish-component
+
+Figma 디자인을 분석해 컴포넌트 코드, Storybook story를 생성하고
+Playwright 스크린샷 리포트를 만듭니다.
+
+## 사용법
+/publish-component <Figma 노드 URL> "<화면/컴포넌트 설명>"
+
+예시:
+/publish-component https://www.figma.com/file/xxx/Design?node-id=123:456 "게시글 목록에서 반복 사용되는 카드 컴포넌트. 제목, 카테고리 뱃지, 좋아요 수를 표시함"
+
+설명에 포함하면 좋은 내용:
+- 어떤 페이지/화면에서 사용되는지
+- 어떤 데이터를 표시하는지
+- 사용자 인터랙션이 있는지 (클릭, 입력 등)
+
+## 실행 흐름
+
+4개의 Task를 순차적으로 실행.
+**Agent 1 완료 후 반드시 사용자 승인을 받고 Agent 2로 진행.**
+
+---
+
+### Agent 1 — Figma 분석 & 레이어 제안
+
+**도구:** Figma MCP
+
+**작업:**
+
+1. 전달받은 노드 URL에서 컴포넌트 정보를 읽는다
+2. 아래 스펙을 구조화된 JSON으로 추출한다:
+
+```json
+{
+  "componentName": "PostCard",
+  "variants": ["default", "hover", "disabled"],
+  "props": [
+    { "name": "title", "type": "string" },
+    { "name": "category", "type": "string" },
+    { "name": "likeCount", "type": "number" }
+  ],
+  "tokens": {
+    "bg": "bg-background-normal",
+    "text": "text-foreground-static-black",
+    "radius": "rounded-lg",
+    "padding": "px-4 py-3"
+  },
+  "unmappedTokens": [
+    { "property": "border-color", "figmaValue": "#E2E8F0", "note": "디자인 토큰 미매핑" }
+  ]
+}
+```
+
+3. 전달받은 화면 설명과 @docs/component-patterns.md 레이어 판단 기준을
+   함께 참고해 적합한 레이어 제안
+4. `packages/ui`에서 재사용 가능한 컴포넌트 목록 확인
+
+**산출물:** `publish-output/spec.json`
+
+**승인 요청 — Agent 2 진행 전 반드시 출력:**
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+컴포넌트명: PostCard
+제안 레이어: entities/post
+이유: Post 도메인 데이터를 표시하는 순수 표시용 컴포넌트.
+      인터랙션 없음, API 연동 없음.
+
+재사용할 packages/ui 컴포넌트:
+  - Card, Badge, Avatar
+
+⚠️ 토큰 미매핑 1건
+  - border-color: #E2E8F0 → 디자인 시스템 확인 필요
+
+레이어나 구성을 변경하려면 알려주세요.
+계속 진행할까요?
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+사용자가 승인하면 Agent 2 진행.
+레이어 변경 요청이 오면 spec.json 수정 후 재출력.
+
+---
+
+### Agent 2 — 컴포넌트 설계 & 생성
+
+**컨텍스트 로드:**
+- @docs/component-patterns.md
+- @docs/code-convention.md
+- `publish-output/spec.json`
+
+**작업:**
+
+1. 승인된 레이어 기준으로 FSD 폴더 구조 생성:
+
+```
+# entities인 경우
+entities/<domain>/ui/<ComponentName>.tsx
+entities/<domain>/index.ts
+
+# features인 경우
+features/<feature-name>/ui/<ComponentName>.tsx
+features/<feature-name>/model/  (API 연동 있을 경우)
+features/<feature-name>/index.ts
+
+# widgets인 경우
+widgets/<widget-name>/ui/<ComponentName>.tsx
+widgets/<widget-name>/index.ts
+```
+
+2. 컴포넌트 작성 기준:
+   - `packages/ui` 컴포넌트 우선 조합
+   - Props 타입은 `type`으로 선언, 파일 상단에 위치
+   - named export 사용
+   - Tailwind 토큰 기반 클래스 사용 (`cn()` 유틸 활용)
+   - `'use client'`는 이벤트 핸들러/hook이 있을 때만 추가
+   - 토큰 미매핑 항목은 임의값 + TODO 주석으로 표시:
+
+```tsx
+// TODO: 디자인 토큰 미매핑 — border-color #E2E8F0 확인 필요
+className="border-[#E2E8F0]"
+```
+
+3. 기존 파일 처리:
+   - **컴포넌트 파일**이 이미 존재하면 덮어쓰지 않고 중단:
+     ```
+     ⛔ entities/post/ui/PostCard.tsx 이미 존재합니다.
+        덮어쓰려면 명시적으로 알려주세요.
+     ```
+   - **`index.ts`**가 이미 존재하면 덮어쓰지 않고 새 export만 추가(append):
+     ```ts
+     // 기존 내용 유지, 아래 줄만 추가
+     export { PostCard } from './ui/PostCard';
+     ```
+
+**산출물:** 컴포넌트 파일, `index.ts`
+
+---
+
+### Agent 3 — Storybook 생성
+
+**컨텍스트 로드:**
+- Agent 2 생성 컴포넌트 파일
+- `publish-output/spec.json`
+
+**작업:**
+
+1. story 파일 생성 위치:
+```
+<layer>/<name>/ui/<ComponentName>.stories.tsx
+```
+
+2. story 작성 기준:
+   - spec.json의 variants를 각각 독립 story로 생성
+   - `args`를 Figma 스펙 기반으로 채움
+   - `meta.title`은 FSD 레이어 경로 기준
+
+```tsx
+import type { Meta, StoryObj } from '@storybook/react';
+import { PostCard } from './PostCard';
+
+const meta: Meta<typeof PostCard> = {
+  title: 'entities/PostCard',
+  component: PostCard,
+};
+export default meta;
+
+type Story = StoryObj<typeof PostCard>;
+
+export const Default: Story = {
+  args: {
+    title: '서프 게시글 제목',
+    category: '자유',
+    likeCount: 12,
+  },
+};
+
+export const Hovered: Story = {
+  args: { ...Default.args },
+};
+```
+
+**산출물:** `<layer>/<name>/ui/<ComponentName>.stories.tsx`
+
+---
+
+### Agent 4 — 스크린샷 리포트 생성
+
+**작업:**
+
+1. Storybook 서버 실행:
+```bash
+pnpm storybook:surf --ci
+```
+
+2. Playwright로 각 story variant 스크린샷 촬영:
+```
+publish-output/screenshots/<ComponentName>/
+├── Default.png
+├── Hovered.png
+└── Disabled.png
+```
+
+3. Figma MCP로 각 variant 디자인 이미지 export:
+```
+publish-output/figma/<ComponentName>/
+├── Default.png
+├── Hovered.png
+└── Disabled.png
+```
+
+4. HTML 리포트 생성 (`publish-output/report.html`):
+   - variant별 Figma / 구현 스크린샷 좌우 나란히 배치
+   - 토큰 미매핑 항목은 리포트 상단 경고 배너로 표시
+   - 각 variant에 메모 입력란 제공 (사람이 검토 내용 기록용)
+
+5. 리포트 자동 오픈:
+```bash
+open publish-output/report.html
+```
+
+**산출물:** `publish-output/report.html`
+
+---
+
+## 최종 완료 보고
+
+```
+✅ Agent 1 — 스펙 추출 완료
+   └ variants: Default, Hovered, Disabled
+   └ ⚠️ 토큰 미매핑 1건: border-color #E2E8F0
+
+✅ Agent 2 — 컴포넌트 생성 완료
+   └ entities/post/ui/PostCard.tsx
+   └ entities/post/index.ts
+
+✅ Agent 3 — Storybook 생성 완료
+   └ entities/post/ui/PostCard.stories.tsx
+   └ 3개 story: Default, Hovered, Disabled
+
+✅ Agent 4 — 스크린샷 리포트 생성 완료
+   └ publish-output/report.html 오픈됨
+   └ 사람 검증 필요: 3개 variant
+```
+
+## 범위 외
+
+- 디자인과 구현 차이를 자동으로 수정하지 않는다 — 리포트 확인 후 직접 수정
+- 소스 코드 리뷰는 하지 않는다 → `/review` 커맨드 사용
+- 테스트 생성은 하지 않는다 → `/gen-test` 커맨드 사용

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -4,7 +4,7 @@
 
 ## 사용법
 
-```
+```bash
 /review <파일경로> [파일경로2] ...
 /review --staged        # git staging area 전체 대상
 ```
@@ -23,7 +23,7 @@ git diff --cached --name-only --diff-filter=ACM
 ### 1. 컨텍스트 로드
 
 각 Task 시작 시 반드시 아래 문서를 먼저 읽는다:
-- @docs/conventions.md
+- @docs/code-convention.md
 - @docs/component-patterns.md
 - 테스트 파일(`*.test.ts`, `*.test.tsx`)인 경우 @docs/testing.md 추가 로드
 

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,0 +1,110 @@
+# review
+
+변경된 코드를 컨벤션 기준으로 검증하고 리뷰합니다.
+
+## 사용법
+
+```
+/review <파일경로> [파일경로2] ...
+/review --staged        # git staging area 전체 대상
+```
+
+`--staged` 사용 시 아래 명령으로 대상 파일 목록을 먼저 확인:
+
+```bash
+git diff --cached --name-only --diff-filter=ACM
+```
+
+## 실행 흐름
+
+대상 파일이 여러 개면 Task 툴로 병렬 실행.
+각 Task는 아래 흐름을 독립적으로 수행.
+
+### 1. 컨텍스트 로드
+
+각 Task 시작 시 반드시 아래 문서를 먼저 읽는다:
+- @docs/conventions.md
+- @docs/component-patterns.md
+- 테스트 파일(`*.test.ts`, `*.test.tsx`)인 경우 @docs/testing.md 추가 로드
+
+### 2. Phase 1 — 규칙 검증 (Pass / Fail)
+
+아래 항목은 위반 시 ❌로 명시. 선택이 아닌 수정 필요:
+
+**Export / Import**
+- [ ] named export 사용 (Next.js page 파일 제외)
+- [ ] Props 타입을 `interface` 아닌 `type`으로 선언
+- [ ] feature 내부 경로 직접 접근 금지 — `index.ts` 경유 여부
+- [ ] Import 순서: 외부 라이브러리 → 내부 (레이어 순서: app → shared)
+
+**타입**
+- [ ] DTO 네이밍 규칙 준수 (`*Request`, `*Response`, `*DTO`)
+- [ ] DTO → UI 타입 변환이 `mappers.ts` 외 다른 곳에서 발생하는지
+
+**에러 처리**
+- [ ] API 함수에서 의미 없는 `try/catch` re-throw 금지
+- [ ] Mutation `onError`에서 `useToastStore` 사용 여부
+- [ ] 토스트: `useToastStore` (`@surf/ui/store/toastStore`)
+- [ ] 확인 다이얼로그: `useAlertStore` (`@surf/ui/store/alertStore`)
+
+**컴포넌트**
+- [ ] 불필요한 `'use client'` 선언 — hook/이벤트 없는 컴포넌트
+- [ ] Next.js page 파일에 로직 포함 여부 (app-pages 위임만 해야 함)
+- [ ] `serverFetchJsonGuarded` 사용 시 타입 가드 함수 `*/api/guards.ts`에 위치하는지
+
+**Tailwind**
+- [ ] 임의값(`bg-[#FEE500]`) 사용 — 디자인 토큰 존재 여부 확인 후 판단
+
+**테스트 파일 한정**
+- [ ] CSS 클래스명 검증 금지
+- [ ] 컴포넌트 내부 state 직접 접근 금지
+- [ ] 함수 호출 횟수 등 구현 세부사항 검증 금지
+- [ ] 스냅샷 테스트 금지
+- [ ] `renderWithProviders` 사용 여부 (직접 `render` 사용 금지)
+- [ ] store 초기화 `beforeEach`에서 처리 여부
+
+### 3. Phase 2 — 코드 리뷰 (제안)
+
+규칙 외 개선 가능한 부분을 제안. 강제 아님:
+
+- 가독성: 네이밍이 역할을 명확히 드러내는지, 단일 책임 원칙 위반 여부
+- 누락된 엣지 케이스: null/undefined 방어, 빈 배열, 경계값 처리
+- 성능: 불필요한 리렌더링, 과도한 `useEffect`, 무거운 연산의 메모이제이션 누락
+- 접근성: ARIA 속성 누락, 키보드 내비게이션 불가한 인터랙티브 요소
+
+### 4. 출력 형식
+
+파일별로 아래 형식으로 출력:
+
+```
+## PostCard.tsx
+
+### 검증 결과
+✅ 모든 규칙 통과
+
+### 리뷰 제안
+💡 `likeCount`가 undefined일 경우 방어 로직 없음 (line 12)
+💡 버튼에 aria-label 누락 — 스크린리더에서 의미 전달 안 됨 (line 18)
+
+---
+
+## useDeletePost.ts
+
+### 검증 결과
+❌ [conventions.md / 에러 처리] onError에서 useToastStore 미사용
+   → useAlertStore 직접 호출 중 (line 24)
+   → 수정: useToastStore(@surf/ui/store/toastStore)로 교체
+
+❌ [conventions.md / 에러 처리] API 함수에서 의미 없는 try/catch re-throw
+   → deletePost.ts line 8
+   → 수정: catch 블록 제거
+
+### 리뷰 제안
+💡 삭제 성공 후 queryClient.invalidateQueries 호출 누락 — 목록 캐시 갱신 안 됨
+```
+
+## 범위 외
+
+- 코드 자동 수정은 하지 않는다 — 수정 방향 제시만
+- 테스트 코드 생성은 하지 않는다 → `/gen-test` 커맨드 사용
+- 빌드/번들 최적화, 성능 프로파일링은 다루지 않는다

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+See [CLAUDE.md](CLAUDE.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,28 @@
+# Surf FE
+
+Turborepo monorepo. 주 앱: `apps/web` (surf-web).
+
+## Commands
+
+```bash
+# surf-web
+pnpm dev:surf        # 개발 서버
+pnpm build:surf      # 프로덕션 빌드
+pnpm lint:surf       # ESLint
+pnpm test:web        # Vitest
+pnpm storybook:surf  # Storybook
+
+# surf-admin
+pnpm dev:admin       # 개발 서버
+pnpm build:admin     # 프로덕션 빌드
+pnpm lint:admin      # ESLint
+pnpm test:admin      # Vitest
+pnpm storybook:admin # Storybook
+```
+
+## Docs
+
+- 기술 스택, 디렉토리 구조 → @docs/overview.md
+- 코딩 컨벤션, 네이밍, import 순서 → @docs/code-convention.md
+- 컴포넌트 설계 패턴 (예시 포함) → @docs/component-patterns.md
+- 테스트 전략, 모킹 패턴 → @docs/testing.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,3 +26,22 @@ pnpm storybook:admin # Storybook
 - 코딩 컨벤션, 네이밍, import 순서 → @docs/code-convention.md
 - 컴포넌트 설계 패턴 (예시 포함) → @docs/component-patterns.md
 - 테스트 전략, 모킹 패턴 → @docs/testing.md
+
+## Agents
+
+작업 유형에 따라 아래 커맨드를 사용:
+
+| 상황 | 커맨드 |
+|------|--------|
+| 파일 작성/수정 후 컨벤션 검증 | `/review <파일경로>` |
+| PR 올리기 전 staged 파일 전체 검증 | `/review --staged` |
+| 테스트 파일 생성 | `/gen-test <파일경로>` |
+| Figma 디자인 → 컴포넌트 퍼블리싱 | `/publish-component <Figma URL> "<화면 설명>"` |
+
+## Rules
+
+- 코드 생성 시 @docs/code-convention.md 규칙을 항상 준수
+- 새 컴포넌트 생성 시 @docs/component-patterns.md 폴더 구조 및 레이어 판단 기준 따름
+- 테스트 생성 시 @docs/testing.md 패턴 따름
+- 소스 코드 수정 시 테스트 파일은 건드리지 않음 — 테스트 수정은 `/gen-test`로 별도 진행
+- 컴포넌트 생성 전 packages/ui 재사용 가능한 컴포넌트 먼저 확인

--- a/docs/code-convention.md
+++ b/docs/code-convention.md
@@ -1,4 +1,4 @@
-# Frontend Convetions
+# Frontend Conventions
 
 본 문서는 Surf 프로젝트의 **브랜치 / 커밋 / 코드 스타일** 규칙을 정의합니다.  
 기수가 바뀌더라도 일관성 있는 코드 품질과 협업 효율성을 유지하기 위함입니다.

--- a/docs/code-convention.md
+++ b/docs/code-convention.md
@@ -1,128 +1,174 @@
-# 🌊 Surf 프론트엔드 코드 컨벤션
+# Frontend Convetions
 
 본 문서는 Surf 프로젝트의 **브랜치 / 커밋 / 코드 스타일** 규칙을 정의합니다.  
 기수가 바뀌더라도 일관성 있는 코드 품질과 협업 효율성을 유지하기 위함입니다.
 
 ---
 
-## 🌲 Branch Convention
+## 브랜치 컨벤션
 
-### 1. Branch Naming Rules
-- 기본 규칙: **브랜치 Type/작업 내용**
-- 작업 내용은 간결하고 명확하게 작성합니다.
+### 브랜치 네이밍
 
-#### Examples
+기본 규칙: `타입/작업-내용`
 
-feat/login-api
-fix/navbar-overlap-210
-
-### 2. Branch Types
-
-- **feat/** → 새로운 기능 개발  
-  e.g. `feat/login-api-123`
-- **fix/** → 버그 수정  
-  e.g. `fix/navbar-overlap-210`
-- **hotfix/** → 운영 중 긴급 버그 수정 (main에 직접 패치)  
-  e.g. `hotfix/prod-payment-error-555`
-- **refactor/** → 리팩토링 (동작 변경 없음, 구조/성능 개선)  
-  e.g. `refactor/user-service-98`
-- **ui/** → UI, CSS 스타일 작업  
-  e.g. `ui/homepage-header-45`
-- **docs/** → 문서 작업  
-  e.g. `docs/contribution-guide-12`
-- **chore/** → 빌드/설정/배포/의존성 업데이트  
-  e.g. `chore/update-eslint-config-77`
-- **test/** → 테스트 코드 추가/수정  
-  e.g. `test/user-service-coverage-331`
-- **release/** → 배포 준비 브랜치  
-  e.g. `release/v1.0.0`
+| 타입 | 설명 | 예시 |
+|------|------|------|
+| `feat/` | 새로운 기능 개발 | `feat/login-api-123` |
+| `fix/` | 버그 수정 | `fix/navbar-overlap-210` |
+| `hotfix/` | 운영 중 긴급 버그 수정 (main 직접 패치) | `hotfix/prod-payment-error-555` |
+| `refactor/` | 리팩토링 (동작 변경 없음) | `refactor/user-service-98` |
+| `ui/` | UI, CSS 스타일 작업 | `ui/homepage-header-45` |
+| `docs/` | 문서 작업 | `docs/contribution-guide-12` |
+| `chore/` | 빌드/설정/배포/의존성 | `chore/update-eslint-config-77` |
+| `test/` | 테스트 코드 추가/수정 | `test/user-service-coverage-331` |
+| `release/` | 배포 준비 브랜치 | `release/v1.0.0` |
 
 ---
 
-## 📩 Commit Convention
+## 커밋 컨벤션
 
-### 1. Commit Message Rules
+기본 규칙: `타입: 작업 내용 (#이슈번호 선택)`
 
-- 기본 규칙: **기능 Type: 작업 내용 (#이슈번호 선택)**
-
-#### Examples
-
+```
 feat: 로그인 API 연동 (#39)
+```
 
-### 2. Commit Types
-
-1. **feat**: 새로운 기능 추가 → `feat: 회원가입 기능 추가`
-2. **fix**: 버그 수정 → `fix: 비밀번호 유효성 검사 버그 수정`
-3. **refactor**: 리팩토링 (구조/성능 개선) → `refactor: 유저 서비스 모듈 구조 리팩토링`
-4. **style**: 코드 스타일 변경 (UI/포맷 관련, 기능 영향 없음) → `style: 로그인 버튼 색상 변경`
-5. **format**: 코드 포맷팅 (prettier, eslint 등) → `format: prettier 규칙 적용`
-6. **docs**: 문서 작업 → `docs: README에 실행 방법 추가`
-7. **chore**: 환경 설정/빌드/배포/의존성 → `chore: ESLint, Prettier 초기 세팅`
-8. **add**: 신규 파일/라이브러리 추가 → `add: date-fns 라이브러리 추가`
-9. **del**: 불필요한 코드/파일 제거 → `del: legacy API 모듈 제거`
-10. **test**: 테스트 코드 추가/수정 → `test: 유저 서비스 단위 테스트 보강`
-
----
-
-## 👩🏻‍💻 Code Convention
-
-### 1. Naming Convention
-- **camelCase**
-  - 함수명, 변수명, 파일명 → `getUserInfo`, `userList`
-- **PascalCase**
-  - 클래스명, 인터페이스명, React 컴포넌트명 → `UserService`, `LoginForm`
-- **UPPER_SNAKE_CASE**
-  - 상수, 매크로, 환경변수, DB 속성 → `MAX_RETRY_COUNT`, `DB_USER_NAME`
-- **kebab-case**
-  - URL, CSS 클래스명, 폴더명 → `/user-profile`, `.main-header`
+| 타입 | 설명 | 예시 |
+|------|------|------|
+| `feat` | 새로운 기능 추가 | `feat: 회원가입 기능 추가` |
+| `fix` | 버그 수정 | `fix: 비밀번호 유효성 검사 버그 수정` |
+| `refactor` | 리팩토링 | `refactor: 유저 서비스 모듈 구조 리팩토링` |
+| `style` | UI/포맷 관련 (기능 영향 없음) | `style: 로그인 버튼 색상 변경` |
+| `format` | 코드 포맷팅 (prettier, eslint) | `format: prettier 규칙 적용` |
+| `docs` | 문서 작업 | `docs: README에 실행 방법 추가` |
+| `chore` | 환경 설정/빌드/배포/의존성 | `chore: ESLint, Prettier 초기 세팅` |
+| `add` | 신규 파일/라이브러리 추가 | `add: date-fns 라이브러리 추가` |
+| `del` | 불필요한 코드/파일 제거 | `del: legacy API 모듈 제거` |
+| `test` | 테스트 코드 추가/수정 | `test: 유저 서비스 단위 테스트 보강` |
 
 ---
 
-### 2. 코드 작성 원칙
+## 네이밍 컨벤션
 
-#### 📖 가독성
-- 변수와 함수는 역할이 명확히 드러나게 네이밍합니다.
-- 파일/컴포넌트는 단일 책임 원칙(SRP)을 지향합니다.
-
-#### 🛡️ 안정성
-- 예외 처리를 반드시 포함합니다 (`try/catch`, 조건문 가드).
-- Null/Undefined 방어 로직을 작성합니다.
-
-#### 🧪 테스트 용이성
-- 단위 테스트/통합 테스트 작성이 쉬운 구조를 유지합니다.
-- 중요한 로직은 Vitest + React Testing Library 기반 테스트를 권장합니다. // 추후 논의 필요
-- Storybook을 통한 UI 테스트를 병행합니다.
-
-#### 🔧 유지보수성
-- 반복되는 로직은 유틸 함수/공통 컴포넌트로 분리합니다.
-- 팀 코드 컨벤션과 일관된 구조를 따릅니다.
-
-#### 🌐 브라우저 호환성
-- 최신 브라우저 및 주요 환경(Chrome, Safari, Edge, iOS, Android)에서 테스트합니다.
-- CSS/JS 최신 문법을 사용하되, 필요한 경우 폴리필을 고려합니다.
-
-#### ♿ 접근성
-- ARIA 속성을 준수합니다.
-- 키보드 내비게이션과 스크린리더 접근성을 보장합니다.
-- 대비비율(WCAG 2.1 AA 이상)을 충족합니다.
+| 케이스 | 적용 대상 | 예시 |
+|--------|-----------|------|
+| `camelCase` | 함수, 변수, 파일명 | `getUserInfo`, `userList`, `usePostForm.ts` |
+| `PascalCase` | 컴포넌트, 클래스, 인터페이스, 타입 | `LoginForm`, `PostDetail` |
+| `UPPER_SNAKE_CASE` | 상수, 환경변수 | `MAX_RETRY_COUNT`, `NEXT_PUBLIC_API_URL` |
+| `kebab-case` | 폴더명, URL | `post-form/`, `/user-profile` |
 
 ---
 
-## 🧩 API 관련 Convention
+## Export / Import
 
-### 1. 타입 분리 규칙
-- `entities/*/api/types.ts`, `features/*/api/types.ts`: API DTO만 정의합니다. (`*Request`, `*Response`, `*DTO`)
-- `entities/*/model/types.ts`, `features/*/model/types.ts`: UI 도메인 타입만 정의합니다. (뷰 모델, UI 상태, 폼 데이터 등)
-- API DTO -> UI 도메인 변환은 `*/model/mappers.ts`에서 처리합니다.
+### Export
 
-### 2. 폴더 역할 분리
-- `*/api`: API 호출만 포함합니다. (fetch/axios, guards, api types)
-- `*/model`: 훅/매퍼/도메인 로직만 포함합니다. (hooks, mappers, queryKeys, domain types, stores)
+컴포넌트는 **named export**. default export는 Next.js page 파일에서만 사용.
 
-### 3. 네이밍 예시
-- API DTO: `UserProfileApiResponse`, `UpdateProfileRequest`
+```tsx
+// ✅
+export const PostCard = () => { ... };
+
+// ❌ (page 파일 제외)
+export default function PostCard() { ... }
+```
+
+### Import 순서
+
+ESLint로 강제됨. 외부 라이브러리 → 내부 (레이어 순서: app → shared).
+
+```tsx
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+import { PostCard } from '@/entities/post/ui/PostCard';
+import { cn } from '@/shared/lib/cn';
+```
 
 ---
 
-✍️ **참고**  
-본 규칙은 기수 변경 시에도 동일하게 적용되며, 필요에 따라 추가/수정될 수 있습니다.
+## 타입 분리 규칙
+
+
+```
+features/post/
+├── api/
+│   └── types.ts   # API DTO만: PostApiResponse, CreatePostRequest
+└── model/
+    └── types.ts   # UI 도메인 타입: PostFormState, PostFilter
+```
+
+- API DTO → UI 타입 변환은 `*/model/mappers.ts`에서만 처리
+- DTO 네이밍: `*Request`, `*Response`, `*DTO`
+
+---
+
+## Tailwind
+
+- 토큰 기반 클래스 사용: `bg-background-normal`, `text-foreground-static-black`
+- 임의 값(`bg-[#FEE500]`)은 디자인 토큰이 없을 때만 허용
+- `cn()` 유틸로 조건부 클래스 조합
+
+```tsx
+// ✅
+<div className={cn('flex items-center', isActive && 'text-primary')} />
+```
+
+---
+
+## 에러 처리
+
+**API 함수 (`*/api/*.ts`)**: `try/catch` 없이 그냥 던지게 둔다. 변환 목적이 없는 catch는 작성하지 않는다.
+
+```ts
+// ✅
+export async function deletePostSchedule(postId: number, scheduleId: number): Promise<void> {
+  await axiosInstance.delete(`/v1/posts/${postId}/schedules/${scheduleId}`);
+}
+
+// ❌ — 잡았다가 그냥 re-throw하면 onError에서 이중 로깅만 발생
+export async function deletePostSchedule(postId: number, scheduleId: number): Promise<void> {
+  try {
+    await axiosInstance.delete(`/v1/posts/${postId}/schedules/${scheduleId}`);
+  } catch (error) {
+    console.error('...', error);
+    throw error;
+  }
+}
+```
+
+예외적으로 HTTP 상태 코드를 도메인 에러로 변환해야 할 때만 catch 허용:
+
+```ts
+// ✅ 변환 목적이 있을 때
+} catch (error) {
+  if (axios.isAxiosError(error) && error.response?.status === 404) {
+    throw new PostNotFoundError(postId);
+  }
+  throw error;
+}
+```
+
+**Mutation 훅 (`*/model/use*.ts`)**: 로깅과 사용자 피드백은 `onError` 한 곳에서만 처리.  
+토스트는 `useToastStore` (`@surf/ui/store/toastStore`), 확인 다이얼로그는 `useAlertStore` (`@surf/ui/store/alertStore`) 사용.
+
+```ts
+import { useToastStore } from '@surf/ui/store/toastStore';
+
+const showToast = useToastStore((s) => s.show);
+
+return useMutation({
+  mutationFn: logout,
+  onSuccess: () => showToast('로그아웃 되었습니다.'),
+  onError: (error) => {
+    console.error('로그아웃 실패:', error);
+    showToast('로그아웃에 실패했습니다. 잠시 후 다시 시도해주세요.');
+  },
+});
+```
+
+**서버 컴포넌트**: `serverFetchJsonGuarded`가 throw하면 Next.js `not-found.tsx` / `error.tsx`로 위임.
+
+---
+
+✍️ 본 규칙은 기수 변경 시에도 동일하게 적용되며, 필요에 따라 추가/수정될 수 있습니다.

--- a/docs/component-patterns.md
+++ b/docs/component-patterns.md
@@ -1,0 +1,249 @@
+# Component Patterns
+
+## 폴더 구조
+
+feature/entity 내 슬라이스 예시:
+
+```
+features/post/
+├── api/
+│   ├── types.ts        # DTO 타입
+│   ├── guards.ts       # 타입 가드 함수
+│   └── postApi.ts      # fetch 함수
+├── model/
+│   ├── types.ts        # UI 도메인 타입
+│   ├── mappers.ts      # DTO → UI 변환
+│   ├── usePost.ts      # TanStack Query 훅
+│   └── usePostStore.ts # Zustand store
+├── ui/
+│   └── PostCard.tsx    # 컴포넌트
+└── index.ts            # public API (re-export)
+```
+
+## Public API (index.ts)
+
+외부 레이어에서 feature/entity 내부 경로에 직접 접근하지 않는다.  
+반드시 `index.ts`를 통해서만 import.
+
+```ts
+// features/post/index.ts
+export { PostCard } from './ui/PostCard';
+export { usePost } from './model/usePost';
+export type { PostDetail } from './model/types';
+```
+
+```ts
+// ✅ 외부 레이어에서 사용할 때
+import { PostCard, usePost } from '@/features/post';
+
+// ❌ 내부 경로 직접 접근
+import { PostCard } from '@/features/post/ui/PostCard';
+```
+
+## 서버 vs 클라이언트 컴포넌트
+
+**기본값은 서버 컴포넌트.** `'use client'`는 아래 경우에만 추가:
+
+- `useState`, `useEffect`, `useRef` 등 React hook 사용
+- 이벤트 핸들러 직접 사용 (`onClick` 등)
+- 브라우저 API 접근 (`window`, `localStorage`)
+- TanStack Query의 `useQuery` / Zustand store 사용
+
+```tsx
+// ✅ 서버 컴포넌트 — 데이터 fetch 후 props로 전달
+import { serverFetchJsonGuarded } from '@/shared/api/serverFetchJsonGuarded';
+
+const PostListPage = async () => {
+  const posts = await serverFetchJsonGuarded('/posts', isPostListResponse);
+  return <PostList posts={posts} />;
+};
+
+export default PostListPage;
+```
+
+```tsx
+// ✅ 클라이언트 컴포넌트 — 상호작용 필요
+'use client';
+
+import { useState } from 'react';
+
+export const LikeButton = ({ postId, initialCount }: LikeButtonProps) => {
+  const [liked, setLiked] = useState(false);
+  return (
+    <button onClick={() => setLiked((v) => !v)}>
+      {liked ? '♥' : '♡'} {initialCount}
+    </button>
+  );
+};
+```
+
+## Props 타입 선언
+
+컴포넌트 파일 내 `type`으로 선언. 외부에서 재사용이 필요한 경우만 `export`.
+
+```tsx
+// ✅
+type PostCardProps = {
+  postId: number;
+  title: string;
+  writer: string;
+  likeCount: number;
+};
+
+export const PostCard = ({ postId, title, writer, likeCount }: PostCardProps) => {
+  ...
+};
+```
+
+```tsx
+// ❌ interface 사용, 불필요한 export
+export interface IPostCardProps { ... }
+```
+
+## 데이터 페칭 패턴
+
+클라이언트에서는 TanStack Query 훅으로 추상화:
+
+```tsx
+// features/post/model/usePost.ts
+import { useQuery } from '@tanstack/react-query';
+import { getPost } from '../api/postApi';
+
+export const usePost = (postId: number) =>
+  useQuery({
+    queryKey: ['post', postId],
+    queryFn: () => getPost(postId),
+  });
+```
+
+```tsx
+// ui/PostDetail.tsx
+'use client';
+
+export const PostDetail = ({ postId }: { postId: number }) => {
+  const { data, isPending } = usePost(postId);
+  if (isPending) return <Spinner />;
+  return <div>{data.title}</div>;
+};
+```
+
+## 상태관리 분리 원칙
+
+- **서버 상태** (API 데이터): TanStack Query
+- **UI 전역 상태** (모달 열림 여부, 폼 임시저장 등): Zustand
+- **로컬 상태** (단일 컴포넌트 내): `useState`
+
+Zustand store는 `*/model/use*Store.ts`에 위치:
+
+```tsx
+// features/post/post-form/model/usePostFormStore.ts
+import { create } from 'zustand';
+
+type PostFormState = {
+  title: string;
+  content: string;
+  setTitle: (title: string) => void;
+  resetForm: () => void;
+};
+
+export const usePostFormStore = create<PostFormState>((set) => ({
+  title: '',
+  content: '',
+  setTitle: (title) => set({ title }),
+  resetForm: () => set({ title: '', content: '' }),
+}));
+```
+
+## Next.js Page 파일
+
+route 파일은 app-pages로 위임만 함. 로직 없음.
+
+```tsx
+// app/(protected)/post/[id]/page.tsx ✅
+import PostDetailPage from '@/app-pages/post/detail/ui/PostDetailPage';
+
+const Page = ({ params }: { params: { id: string } }) => (
+  <PostDetailPage postId={Number(params.id)} />
+);
+
+export default Page;
+```
+
+## 서버 API 호출
+
+서버 컴포넌트에서는 `serverFetchJsonGuarded`로 타입 안전하게 fetch.  
+두 번째 인자는 `Guard<T>` — `(x: unknown) => x is T` 시그니처의 타입 가드 함수.
+
+```ts
+// entities/post/api/guards.ts
+import type { Guard } from '@/shared/api/types';
+import { commonResponseGuard } from '@/shared/api/types';
+import { isNumber, isString } from '@/shared/api/primitives';
+import type { PostDetail } from './types';
+
+const isPostDetailData: Guard<PostDetail> = (x): x is PostDetail => {
+  if (typeof x !== 'object' || x === null) return false;
+  const o = x as Record<string, unknown>;
+  return isNumber(o.postId) && isString(o.title);
+};
+
+// API 응답이 { code, message, data } 구조면 commonResponseGuard로 래핑
+export const isPostDetailResponse = commonResponseGuard(isPostDetailData);
+```
+
+```tsx
+// 서버 컴포넌트에서 사용
+import { serverFetchJsonGuarded } from '@/shared/api/serverFetchJsonGuarded';
+import { isPostDetailResponse } from '../api/guards';
+
+const data = await serverFetchJsonGuarded(`/posts/${id}`, isPostDetailResponse);
+```
+
+## 레이어 판단 기준
+
+신규 컴포넌트 생성 전 아래 기준으로 레이어를 결정한다.
+
+| 조건 | 레이어 | 예시 |
+|------|--------|------|
+| 디자인 시스템 원자 단위. 도메인 무관 | `packages/ui` | Button, Input, Badge, Card |
+| 도메인 데이터 표시. packages/ui 조합. 인터랙션 없음 | `entities` | PostCard, UserAvatar, CommentItem |
+| 사용자 인터랙션 + API 연동 (useQuery / useMutation) 포함 | `features` | PostCreateForm, LikeButton, LoginForm |
+| 여러 features/entities를 조합한 페이지 단위 블록 | `widgets` | PostFeed, ProfileSection, CommentThread |
+
+### 판단이 애매할 때 체크리스트
+
+API 호출이 있는가?
+Y → features 이상
+N → 아래로
+여러 features/entities를 조합하는가?
+Y → widgets
+N → 아래로
+특정 도메인 데이터(Post, User 등)를 표시하는가?
+Y → entities
+N → packages/ui
+
+
+### packages/ui 재사용 원칙
+
+신규 컴포넌트 생성 전 `packages/ui`에서 재사용 가능한 컴포넌트를 먼저 확인한다.
+직접 구현하지 않고 조합으로 해결할 수 있으면 조합을 우선한다.
+
+```tsx
+// ✅ packages/ui 조합
+import { Card, Badge } from '@surf/ui';
+
+export const PostCard = ({ title, category }: PostCardProps) => (
+  <Card>
+    <Badge>{category}</Badge>
+    <h3>{title}</h3>
+  </Card>
+);
+
+// ❌ 직접 구현
+export const PostCard = ({ title, category }: PostCardProps) => (
+  <div className="rounded-lg border p-4">
+    <span className="rounded bg-gray-100 px-2 py-1 text-sm">{category}</span>
+    <h3>{title}</h3>
+  </div>
+);
+```

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -14,7 +14,7 @@
 
 ## 모노레포 구조
 
-```
+```text
 surf-monorepo/
 ├── apps/
 │   ├── web/          # surf-web (메인 유저 앱)
@@ -31,7 +31,7 @@ surf-monorepo/
 
 ## apps/web 디렉토리 구조 (FSD)
 
-```
+```text
 src/
 ├── app/              # Next.js App Router (라우팅만)
 │   ├── (protected)/  # 인증 필요 페이지

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,66 @@
+# Project Overview
+
+## 기술 스택
+
+| 영역 | 기술 |
+|------|------|
+| 프레임워크 | Next.js 14 (App Router, Turbopack) |
+| 언어 | TypeScript (strict) |
+| 스타일 | Tailwind CSS v4 |
+| 서버 상태 | TanStack Query v5 |
+| 클라이언트 상태 | Zustand |
+| 테스트 | Vitest + React Testing Library |
+| 모노레포 | Turborepo + pnpm workspaces |
+
+## 모노레포 구조
+
+```
+surf-monorepo/
+├── apps/
+│   ├── web/          # surf-web (메인 유저 앱)
+│   ├── admin/        # surf-admin
+│   └── mobile/
+└── packages/
+    ├── ui/           # 공유 컴포넌트 (@surf/ui)
+    ├── hooks/        # 공유 훅 (@surf/hooks)
+    ├── utils/        # 공유 유틸 (@surf/utils)
+    ├── eslint-config/
+    ├── prettier-config/
+    └── typescript-config/
+```
+
+## apps/web 디렉토리 구조 (FSD)
+
+```
+src/
+├── app/              # Next.js App Router (라우팅만)
+│   ├── (protected)/  # 인증 필요 페이지
+│   ├── (public)/     # 공개 페이지
+│   ├── api/          # Route Handlers
+│   └── providers/    # QueryProvider, ThemeProvider 등
+├── app-pages/        # 페이지 단위 컴포넌트 (route → app-pages로 위임)
+├── widgets/          # 여러 feature를 조합한 복합 UI 블록
+├── features/         # 사용자 시나리오 단위 기능
+├── entities/         # 비즈니스 도메인 (post, user, calendar 등)
+└── shared/           # 재사용 기반 요소
+    ├── api/          # fetch 클라이언트, 타입 가드
+    ├── hooks/        # 공통 훅
+    ├── lib/          # 서드파티 래퍼
+    ├── store/        # 전역 store (Zustand)
+    ├── constants/
+    └── styles/
+```
+
+## 레이어 의존성 규칙
+
+```
+app → app-pages → widgets → features → entities → shared
+```
+
+상위 레이어는 하위 레이어만 import 가능. 같은 레이어 간 import 금지.
+
+## 환경 설정
+
+- `.env.local` — 로컬 환경변수 (`NEXT_PUBLIC_*` prefix로 클라이언트 노출)
+- `apps/web/next.config.ts` — Next.js 설정
+- `turbo.json` — Turborepo 태스크 파이프라인

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,180 @@
+# Testing
+
+## 설정
+
+- **러너**: Vitest
+- **DOM**: `@testing-library/react` + `@testing-library/user-event`
+- **setup**: `src/test/setup.ts` — jest-dom matchers + next/navigation mock 자동 로드
+
+## 파일 위치
+
+```
+src/app-pages/post/write/
+└── __tests__/
+    └── post-page.integration.test.tsx
+```
+
+테스트 파일은 대상 코드와 같은 레이어의 `__tests__/` 폴더에 위치.
+
+## 컴포넌트 테스트 (feature UI)
+
+인터랙션이 있는 컴포넌트만 테스트. 판단 기준:
+
+| 조건 | 방식 |
+|------|------|
+| `onClick`, `onSubmit` 등 이벤트 + 상태 변화 있음 | RTL 단위 테스트 |
+| props 받아서 렌더링만 함 | Storybook 위임 — 테스트 파일 생성 안 함 |
+
+```tsx
+// ✅ 인터랙션 있는 컴포넌트 — RTL로 테스트
+it('좋아요 버튼 클릭 시 카운트가 화면에 반영된다', async () => {
+  vi.mock('@/features/post/model/useLikePost', () => ({
+    useLikePost: () => ({ mutate: vi.fn(), isPending: false }),
+  }));
+
+  const user = userEvent.setup();
+  renderWithProviders(<LikeButton postId={1} initialCount={5} />);
+
+  await user.click(screen.getByRole('button'));
+  expect(screen.getByText('6')).toBeInTheDocument(); // 화면 변화 검증
+});
+
+// ❌ props만 받아 렌더링하는 컴포넌트 — 테스트 파일 생성 안 함, Storybook으로 위임
+```
+
+## 렌더링
+
+`renderWithProviders(ui: ReactNode)`로 QueryClient를 포함한 환경에서 렌더링.  
+반환값: `{ queryClient, ...RTL render result }` — `queryClient`로 캐시 직접 조작 가능.
+
+```tsx
+import { renderWithProviders } from '@/test/renderWithProviders';
+
+it('제목 입력 후 유지', async () => {
+  const user = userEvent.setup();
+  const { queryClient } = renderWithProviders(<PostPage mode="create" boardId="1" />);
+
+  await user.type(screen.getByLabelText('제목'), '서프 게시글 제목');
+  expect(screen.getByLabelText('제목')).toHaveValue('서프 게시글 제목');
+});
+```
+
+Zustand 초기 상태 주입이 필요하면 렌더링 전에 `setState` 직접 호출:
+
+```tsx
+beforeEach(() => usePostFormStore.getState().resetForm());
+
+it('임시저장 값이 복원된다', () => {
+  usePostFormStore.setState({ title: '임시 제목' }); // ← 렌더 전에 주입
+  renderWithProviders(<PostPage mode="create" boardId="1" />);
+  expect(screen.getByLabelText('제목')).toHaveValue('임시 제목');
+});
+```
+
+## 모킹
+
+### next/navigation
+
+`src/test/mocks/nextNavigation.ts`에서 자동 모킹됨 (setup에서 import).  
+테스트 내에서 경로 조작이 필요하면:
+
+```tsx
+import { setMockPathname, resetMockNavigation } from '@/test/mocks/nextNavigation';
+
+beforeEach(() => resetMockNavigation());
+
+it('특정 경로에서 렌더링', () => {
+  setMockPathname('/post/123');
+  renderWithProviders(<Header />);
+});
+```
+
+### API / 훅 모킹
+
+실제 API 호출을 막을 때는 `vi.mock`으로 훅 단위 모킹:
+
+```tsx
+vi.mock('@/features/post/create-post/model/useCreatePost', () => ({
+  useCreatePost: () => ({
+    mutateAsync: vi.fn().mockResolvedValue({ postId: 123 }),
+    isPending: false,
+  }),
+}));
+```
+
+### Zustand store
+
+store 초기화는 `beforeEach`에서 reset:
+
+```tsx
+beforeEach(() => {
+  usePostFormStore.getState().resetForm();
+});
+```
+
+### 훅 단위 테스트 패턴
+
+**뮤테이션 훅** — `onSuccess` / `onError` 분기 검증:
+
+```tsx
+it('삭제 성공 시 토스트가 표시된다', async () => {
+  const { result } = renderHook(() => useDeletePost(), {
+    wrapper: createWrapper(),
+  });
+
+  await act(async () => {
+    await result.current.mutateAsync(1);
+  });
+
+  expect(screen.getByText('삭제되었습니다.')).toBeInTheDocument();
+});
+```
+
+**쿼리 훅** — queryKey, 반환 데이터 구조 검증:
+
+```tsx
+it('postId로 올바른 queryKey가 생성된다', () => {
+  const { result } = renderHook(() => usePost(42), {
+    wrapper: createWrapper(),
+  });
+
+  expect(result.current.queryKey).toEqual(['post', 42]);
+});
+```
+
+## 무엇을 테스트하는가
+
+| 대상 | 방식 |
+|------|------|
+| 페이지 수준 사용자 시나리오 | `app-pages/__tests__/` 통합 테스트 |
+| feature 컴포넌트 (인터랙션 있음) | `features/**/__tests__/` RTL 단위 테스트 |
+| feature 컴포넌트 (순수 표시용) | Storybook 위임 — 테스트 파일 생성 안 함 |
+| mappers, 순수 유틸 함수 | 단위 테스트 (입력 → 출력만 검증, 모킹 없음) |
+| 뮤테이션 훅 | `onSuccess` / `onError` 분기 검증 |
+| 쿼리 훅 | `queryKey`, `queryFn` 반환값 검증 |
+
+TipTap 등 외부 에디터는 store 직접 조작으로 우회 (`useStore.setState(...)`).
+
+## 테스트하지 않는 것
+
+- **API 함수 (`*/api/*.ts`)** — 훅 레벨 테스트에서 커버됨. axios/fetch 동작 자체를 검증하는 건 의미 없음
+- **Zustand store 액션** — 단순 `set` 액션은 통합 테스트에서 커버됨. store만 독립 테스트하지 않음
+- **`*/index.ts`** — re-export 파일은 테스트 대상 아님
+- **UI 스냅샷 테스트** — Storybook으로 대체
+
+```tsx
+// ❌ 컴포넌트 내부 state 직접 검증
+expect(component.state.isOpen).toBe(true);
+
+// ❌ CSS 클래스명 검증 — 스타일은 Storybook으로 확인
+expect(element).toHaveClass('flex', 'items-center');
+
+// ❌ 함수 호출 횟수 등 구현 세부사항
+expect(mockFn).toHaveBeenCalledTimes(1);
+
+// ✅ 사용자가 실제로 보거나 할 수 있는 것을 검증
+expect(screen.getByText('삭제되었습니다.')).toBeInTheDocument();
+expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+```
+
+검증 기준은 항상 **사용자 관점** (`screen.getByRole`, `getByLabelText`, `getByText`)


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 코드에 any가 사용되지 않았습니다
- [ ] 스토리북에 추가했습니다 (해당 시)
- [ ] 이슈와 커밋이 명확히 연결되어 있습니다

## 📌 작업 목적

- Codex, Claude 활용을 위해 AGENTS.md, CLAUDE.md, 서브 에이전트 문서 생성

## 🔨 주요 작업 내용
### 참조 문서 리스트 
- [프로젝트 개요 문서](https://github.com/Tave-Makers/SURF-FE/blob/docs/claude/docs/overview.md)
- [코드컨벤션](https://github.com/Tave-Makers/SURF-FE/blob/docs/claude/docs/code-convention.md)
- [컴포넌트 패턴](https://github.com/Tave-Makers/SURF-FE/blob/docs/claude/docs/component-patterns.md)
- [테스팅 전략](https://github.com/Tave-Makers/SURF-FE/blob/docs/claude/docs/testing.md)

### 서브 에이전트
- [Figma MCP, Playwright 기반 컴포넌트 퍼블리싱 에이전트](https://github.com/Tave-Makers/SURF-FE/blob/docs/claude/.claude/commands/publish-components.md)
- [코드리뷰&검증 에이전트](https://github.com/Tave-Makers/SURF-FE/blob/docs/claude/.claude/commands/review.md)
- [테스트 코드 자동 생성 및 실행 에이전트](https://github.com/Tave-Makers/SURF-FE/blob/docs/claude/.claude/commands/gen-test.md)

> 각 에이전트의 사용법을 참고해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 프로젝트 개요, 기술 스택 및 FSD 기반 구조 문서 추가
  * 코드 컨벤션, 컴포넌트 패턴, 테스트 전략 문서화 및 상세 가이드 제공
  * 에이전트/명령어 설명 문서(리뷰, 테스트 생성, 컴포넌트 발행) 추가

* **New Features**
  * 명령형 워크플로우 사양(파일 리뷰, 테스트 생성, Figma→컴포넌트 발행 등) 문서화로 개발 UX 개선

* **Chores**
  * 개발 가이드 정리 및 문서 간색(연동) 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->