### PR TITLE
[FEAT] 웰컴메세지 관리 API 연동 및 기능 구현

### DIFF
--- a/apps/admin/src/app-pages/welcome-message/ui/WelcomeMessageManagePage.tsx
+++ b/apps/admin/src/app-pages/welcome-message/ui/WelcomeMessageManagePage.tsx
@@ -45,7 +45,7 @@ export const WelcomeMessageManagePage = () => {
         }
       />
 
-      <div className="flex flex-1 flex-col gap-18 px-14 py-11">
+      <div className="flex flex-1 flex-col gap-14 px-14 py-11">
         <FieldGroup title="메인 메시지" isRequired={isEditMode}>
           <TextArea
             mode="multiLine"

--- a/apps/admin/src/app-pages/welcome-message/ui/WelcomeMessageManagePage.tsx
+++ b/apps/admin/src/app-pages/welcome-message/ui/WelcomeMessageManagePage.tsx
@@ -5,9 +5,7 @@ import { FieldGroup } from '@surf/ui/field-group';
 import { HeaderMode } from '@surf/ui/header';
 import { TextArea } from '@surf/ui/text-area';
 
-import { useEffect, useState } from 'react';
-import { useUpdateWelcomeMessageMutation } from '@/features/welcome-message/model/queries/useUpdateWelcomeMessageMutation';
-import { useWelcomeMessageQuery } from '@/features/welcome-message/model/queries/useWelcomeMessageQuery';
+import { useWelcomeMessageForm } from '@/features/welcome-message';
 import { AppHeader } from '@/widgets/header/ui/AppHeader';
 
 const MAIN_MESSAGE_LIMIT = 40;
@@ -21,27 +19,9 @@ const SUB_MESSAGE_LIMIT = 10;
  * - `message` → 메인 메시지(최대 40자), `sender` → 서브 메시지(최대 10자)
  */
 export const WelcomeMessageManagePage = () => {
-  const [isEditMode, setIsEditMode] = useState(false);
-  const [mainMessage, setMainMessage] = useState('');
-  const [subMessage, setSubMessage] = useState('');
-
-  const { data } = useWelcomeMessageQuery();
-  const { mutate, isPending } = useUpdateWelcomeMessageMutation();
-
-  useEffect(() => {
-    if (!data) return;
-    setMainMessage(data.message);
-    setSubMessage(data.sender);
-  }, [data]);
-
-  const canSubmit = mainMessage.trim().length > 0 && subMessage.trim().length > 0;
-
-  const handleEdit = () => setIsEditMode(true);
-  const handleBack = () => setIsEditMode(false);
-
-  const handleSubmit = () => {
-    mutate({ message: mainMessage, sender: subMessage }, { onSuccess: () => setIsEditMode(false) });
-  };
+  const { state, actions } = useWelcomeMessageForm();
+  const { isEditMode, mainMessage, subMessage, canSubmit, isPending } = state;
+  const { setMainMessage, setSubMessage, handleEdit, handleBack, handleSubmit } = actions;
 
   return (
     <div className="flex h-dvh w-full flex-col">

--- a/apps/admin/src/app-pages/welcome-message/ui/WelcomeMessageManagePage.tsx
+++ b/apps/admin/src/app-pages/welcome-message/ui/WelcomeMessageManagePage.tsx
@@ -5,27 +5,42 @@ import { FieldGroup } from '@surf/ui/field-group';
 import { HeaderMode } from '@surf/ui/header';
 import { TextArea } from '@surf/ui/text-area';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { useUpdateWelcomeMessageMutation } from '@/features/welcome-message/model/queries/useUpdateWelcomeMessageMutation';
+import { useWelcomeMessageQuery } from '@/features/welcome-message/model/queries/useWelcomeMessageQuery';
 import { AppHeader } from '@/widgets/header/ui/AppHeader';
 
 const MAIN_MESSAGE_LIMIT = 40;
 const SUB_MESSAGE_LIMIT = 10;
 
+/**
+ * 홈 화면 웰컴 메시지(메인 문구·서브 문구)를 조회·수정하는 관리 페이지.
+ *
+ * - 조회 모드: 헤더 우측 "수정" 버튼으로 편집 진입
+ * - 편집 모드: 저장 성공 시 조회 모드로 복귀, 뒤로가기 시 변경 취소(서버 데이터로 재설정)
+ * - `message` → 메인 메시지(최대 40자), `sender` → 서브 메시지(최대 10자)
+ */
 export const WelcomeMessageManagePage = () => {
   const [isEditMode, setIsEditMode] = useState(false);
-  // TODO: ADM-MES-01 — useWelcomeMessageQuery()로 조회 후 useEffect에서 setMainMessage/setSubMessage로 초기값 주입
   const [mainMessage, setMainMessage] = useState('');
   const [subMessage, setSubMessage] = useState('');
+
+  const { data } = useWelcomeMessageQuery();
+  const { mutate, isPending } = useUpdateWelcomeMessageMutation();
+
+  useEffect(() => {
+    if (!data) return;
+    setMainMessage(data.message);
+    setSubMessage(data.sender);
+  }, [data]);
 
   const canSubmit = mainMessage.trim().length > 0 && subMessage.trim().length > 0;
 
   const handleEdit = () => setIsEditMode(true);
   const handleBack = () => setIsEditMode(false);
 
-  // TODO: ADM-MES-02 — isPending을 useUpdateWelcomeMessageMutation()에서 받아 canSubmit 조건에 추가
-  const isPending = false;
   const handleSubmit = () => {
-    // TODO: ADM-MES-02 — useMutation으로 웰컴 메시지 수정, 성공 시 setIsEditMode(false)
+    mutate({ message: mainMessage, sender: subMessage }, { onSuccess: () => setIsEditMode(false) });
   };
 
   return (

--- a/apps/admin/src/features/welcome-message/api/homeContentApi.ts
+++ b/apps/admin/src/features/welcome-message/api/homeContentApi.ts
@@ -1,0 +1,17 @@
+import { axiosInstance } from '@/shared/lib/axiosInstance';
+import {
+  HomeContentResDto,
+  HomeContentResponse,
+  UpdateHomeContentRequest,
+} from '@/features/welcome-message/api/types';
+
+export const homeContentApi = {
+  getHomeContent: async (): Promise<HomeContentResDto> => {
+    const res = await axiosInstance.get<HomeContentResponse>('/v1/admin/home/content');
+    return res.data.data;
+  },
+  updateHomeContent: async (body: UpdateHomeContentRequest): Promise<HomeContentResDto> => {
+    const res = await axiosInstance.put<HomeContentResponse>('/v1/admin/home/content', body);
+    return res.data.data;
+  },
+};

--- a/apps/admin/src/features/welcome-message/api/types.ts
+++ b/apps/admin/src/features/welcome-message/api/types.ts
@@ -1,0 +1,14 @@
+import { CommonResponse } from '@/shared/api/types';
+
+export interface HomeContentResDto {
+  id: number;
+  message: string;
+  sender: string;
+}
+
+export interface UpdateHomeContentRequest {
+  message: string;
+  sender: string;
+}
+
+export type HomeContentResponse = CommonResponse<HomeContentResDto>;

--- a/apps/admin/src/features/welcome-message/index.ts
+++ b/apps/admin/src/features/welcome-message/index.ts
@@ -1,0 +1,1 @@
+export { useWelcomeMessageForm } from './model/useWelcomeMessageForm';

--- a/apps/admin/src/features/welcome-message/model/mapper.ts
+++ b/apps/admin/src/features/welcome-message/model/mapper.ts
@@ -1,0 +1,16 @@
+import { HomeContentResDto, UpdateHomeContentRequest } from '@/features/welcome-message/api/types';
+import { UpdateWelcomeMessageInput, WelcomeMessage } from '@/features/welcome-message/model/types';
+
+export const mapHomeContentResDtoToWelcomeMessage = (dto: HomeContentResDto): WelcomeMessage => ({
+  id: dto.id,
+  main: dto.message,
+  sub: dto.sender,
+});
+
+export const mapUpdateWelcomeMessageInputToRequest = ({
+  main,
+  sub,
+}: UpdateWelcomeMessageInput): UpdateHomeContentRequest => ({
+  message: main,
+  sender: sub,
+});

--- a/apps/admin/src/features/welcome-message/model/queries/queryKeys.ts
+++ b/apps/admin/src/features/welcome-message/model/queries/queryKeys.ts
@@ -1,0 +1,4 @@
+export const welcomeMessageQueryKeys = {
+  all: ['homeContent'] as const,
+  detail: () => [...welcomeMessageQueryKeys.all, 'detail'] as const,
+};

--- a/apps/admin/src/features/welcome-message/model/queries/useUpdateWelcomeMessageMutation.ts
+++ b/apps/admin/src/features/welcome-message/model/queries/useUpdateWelcomeMessageMutation.ts
@@ -2,15 +2,18 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useToastStore } from '@surf/ui/store/toastStore';
 
 import { homeContentApi } from '@/features/welcome-message/api/homeContentApi';
-import { UpdateHomeContentRequest } from '@/features/welcome-message/api/types';
+import { mapUpdateWelcomeMessageInputToRequest } from '@/features/welcome-message/model/mapper';
 import { welcomeMessageQueryKeys } from '@/features/welcome-message/model/queries/queryKeys';
+import { UpdateWelcomeMessageInput } from '@/features/welcome-message/model/types';
 
 export const useUpdateWelcomeMessageMutation = () => {
   const qc = useQueryClient();
   const showToast = useToastStore((s) => s.show);
 
   return useMutation({
-    mutationFn: (body: UpdateHomeContentRequest) => homeContentApi.updateHomeContent(body),
+    mutationFn: async (input: UpdateWelcomeMessageInput) =>
+      await homeContentApi.updateHomeContent(mapUpdateWelcomeMessageInputToRequest(input)),
+
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: welcomeMessageQueryKeys.all });
       showToast('웰컴 메시지가 수정되었습니다.');

--- a/apps/admin/src/features/welcome-message/model/queries/useUpdateWelcomeMessageMutation.ts
+++ b/apps/admin/src/features/welcome-message/model/queries/useUpdateWelcomeMessageMutation.ts
@@ -1,0 +1,23 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useToastStore } from '@surf/ui/store/toastStore';
+
+import { homeContentApi } from '@/features/welcome-message/api/homeContentApi';
+import { UpdateHomeContentRequest } from '@/features/welcome-message/api/types';
+import { welcomeMessageQueryKeys } from '@/features/welcome-message/model/queries/queryKeys';
+
+export const useUpdateWelcomeMessageMutation = () => {
+  const qc = useQueryClient();
+  const showToast = useToastStore((s) => s.show);
+
+  return useMutation({
+    mutationFn: (body: UpdateHomeContentRequest) => homeContentApi.updateHomeContent(body),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: welcomeMessageQueryKeys.all });
+      showToast('웰컴 메시지가 수정되었습니다.');
+    },
+    onError: (err) => {
+      console.error('[Welcome Message Update Error]', err.message);
+      showToast('웰컴 메시지 수정에 실패했습니다.');
+    },
+  });
+};

--- a/apps/admin/src/features/welcome-message/model/queries/useWelcomeMessageQuery.ts
+++ b/apps/admin/src/features/welcome-message/model/queries/useWelcomeMessageQuery.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { homeContentApi } from '@/features/welcome-message/api/homeContentApi';
+import { welcomeMessageQueryKeys } from '@/features/welcome-message/model/queries/queryKeys';
+
+export const useWelcomeMessageQuery = () =>
+  useQuery({
+    queryKey: welcomeMessageQueryKeys.detail(),
+    queryFn: homeContentApi.getHomeContent,
+  });

--- a/apps/admin/src/features/welcome-message/model/queries/useWelcomeMessageQuery.ts
+++ b/apps/admin/src/features/welcome-message/model/queries/useWelcomeMessageQuery.ts
@@ -1,10 +1,14 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { homeContentApi } from '@/features/welcome-message/api/homeContentApi';
+import { mapHomeContentResDtoToWelcomeMessage } from '@/features/welcome-message/model/mapper';
 import { welcomeMessageQueryKeys } from '@/features/welcome-message/model/queries/queryKeys';
 
 export const useWelcomeMessageQuery = () =>
   useQuery({
     queryKey: welcomeMessageQueryKeys.detail(),
-    queryFn: homeContentApi.getHomeContent,
+    queryFn: async () => {
+      const data = await homeContentApi.getHomeContent();
+      return mapHomeContentResDtoToWelcomeMessage(data);
+    },
   });

--- a/apps/admin/src/features/welcome-message/model/types.ts
+++ b/apps/admin/src/features/welcome-message/model/types.ts
@@ -1,0 +1,10 @@
+export interface WelcomeMessage {
+  id: number;
+  main: string;
+  sub: string;
+}
+
+export interface UpdateWelcomeMessageInput {
+  main: string;
+  sub: string;
+}

--- a/apps/admin/src/features/welcome-message/model/useWelcomeMessageForm.ts
+++ b/apps/admin/src/features/welcome-message/model/useWelcomeMessageForm.ts
@@ -20,9 +20,10 @@ export const useWelcomeMessageForm = () => {
 
   useEffect(() => {
     if (!data) return;
+    if (isEditMode) return; //편집 중에는 서버 값으로 덮어쓰지 않음
     setMainMessage(data.message);
     setSubMessage(data.sender);
-  }, [data]);
+  }, [data, isEditMode]);
 
   const canSubmit = mainMessage.trim().length > 0 && subMessage.trim().length > 0;
 

--- a/apps/admin/src/features/welcome-message/model/useWelcomeMessageForm.ts
+++ b/apps/admin/src/features/welcome-message/model/useWelcomeMessageForm.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+import { useWelcomeMessageQuery } from './queries/useWelcomeMessageQuery';
+import { useUpdateWelcomeMessageMutation } from './queries/useUpdateWelcomeMessageMutation';
+
+/**
+ * 웰컴 메시지 조회·수정 페이지의 상태와 액션을 관리하는 훅.
+ *
+ * - 조회한 서버 데이터를 로컬 편집 상태(mainMessage, subMessage)로 복사해 두어
+ *   편집 취소(handleBack) 시 서버 데이터가 자동으로 재적용되도록 한다.
+ * - 수정 성공 시 isEditMode를 false로 전환하는 onSuccess 콜백을 mutate에 직접 주입하여
+ *   토스트(전역) · 모드 전환(로컬)의 책임을 분리한다.
+ */
+export const useWelcomeMessageForm = () => {
+  const [isEditMode, setIsEditMode] = useState(false);
+  const [mainMessage, setMainMessage] = useState('');
+  const [subMessage, setSubMessage] = useState('');
+
+  const { data } = useWelcomeMessageQuery();
+  const { mutate, isPending } = useUpdateWelcomeMessageMutation();
+
+  useEffect(() => {
+    if (!data) return;
+    setMainMessage(data.message);
+    setSubMessage(data.sender);
+  }, [data]);
+
+  const canSubmit = mainMessage.trim().length > 0 && subMessage.trim().length > 0;
+
+  const handleEdit = () => setIsEditMode(true);
+  const handleBack = () => setIsEditMode(false);
+  const handleSubmit = () => {
+    mutate({ message: mainMessage, sender: subMessage }, { onSuccess: () => setIsEditMode(false) });
+  };
+
+  return {
+    state: { isEditMode, mainMessage, subMessage, canSubmit, isPending },
+    actions: { setMainMessage, setSubMessage, handleEdit, handleBack, handleSubmit },
+  };
+};

--- a/apps/admin/src/features/welcome-message/model/useWelcomeMessageForm.ts
+++ b/apps/admin/src/features/welcome-message/model/useWelcomeMessageForm.ts
@@ -21,8 +21,8 @@ export const useWelcomeMessageForm = () => {
   useEffect(() => {
     if (!data) return;
     if (isEditMode) return; //편집 중에는 서버 값으로 덮어쓰지 않음
-    setMainMessage(data.message);
-    setSubMessage(data.sender);
+    setMainMessage(data.main);
+    setSubMessage(data.sub);
   }, [data, isEditMode]);
 
   const canSubmit = mainMessage.trim().length > 0 && subMessage.trim().length > 0;
@@ -30,7 +30,7 @@ export const useWelcomeMessageForm = () => {
   const handleEdit = () => setIsEditMode(true);
   const handleBack = () => setIsEditMode(false);
   const handleSubmit = () => {
-    mutate({ message: mainMessage, sender: subMessage }, { onSuccess: () => setIsEditMode(false) });
+    mutate({ main: mainMessage, sub: subMessage }, { onSuccess: () => setIsEditMode(false) });
   };
 
   return {

--- a/apps/admin/src/shared/config/path.ts
+++ b/apps/admin/src/shared/config/path.ts
@@ -21,4 +21,5 @@ export const PAGE_ROUTES = {
   },
   SCORE_MNG: '/score-management',
   BADGE_MNG: '/badge-management',
+  WELCOME_MSG: '/welcome-message',
 } as const;

--- a/apps/admin/src/widgets/navigation/model/config.ts
+++ b/apps/admin/src/widgets/navigation/model/config.ts
@@ -41,6 +41,11 @@ export const NAV_ITEMS = [
     label: '활동배지 관리',
     path: PAGE_ROUTES.BADGE_MNG,
   },
+  {
+    id: 'welcome-msg',
+    label: '웰컴 메세지 관리',
+    path: PAGE_ROUTES.WELCOME_MSG,
+  },
 ] as const;
 
 export type TabId = (typeof NAV_ITEMS)[number]['id'];


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 코드에 any가 사용되지 않았습니다
- [ ] 스토리북에 추가했습니다 (해당 시)
- [ ] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈

- close #586 

## 📌 작업 목적

-  WelcomeMessageManagePage에 홈 문구 조회·수정 API를 연동

## 🔨 주요 작업 내용

- 홈에 "웰컴 메세지 관리" 메뉴 항목 추가
- API 모듈/쿼리 훅, 뮤테이션 (features/welcome-message/) 구성
- useWelcomeMessageForm 훅에 비즈니스 로직 구성
- WelcomeMessageManagePage에 웰컴메세지 조회, 수정 로직 연동

## 📷 실행 영상 또는 스크린샷

https://github.com/user-attachments/assets/6189921a-eaa7-4e24-b81a-ffd9003ada83

## 💬 논의할 점

-

## 🙋🏻 참고 자료

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 관리자에서 홈 환영 메시지를 조회·편집·저장할 수 있는 관리 페이지 추가
  * 내비게이션 메뉴에 환영 메시지 관리 항목 추가로 빠른 이동 지원
  * 서버 연동으로 홈 콘텐츠 실시간 조회 및 업데이트 지원
  * 편집 폼 개선: 편집 모드, 취소, 제출 동작과 제출 가능 여부 자동 적용
  * 편집 성공/실패에 대한 사용자 알림(토스트) 및 데이터 갱신 처리 포함
<!-- end of auto-generated comment: release notes by coderabbit.ai -->