### PR TITLE
[FEAT] 활동 배지 수정 화면 구현

### DIFF
--- a/apps/admin/src/app-pages/badge/BadgeAssignPage.tsx
+++ b/apps/admin/src/app-pages/badge/BadgeAssignPage.tsx
@@ -1,7 +1,63 @@
+'use client';
+
+import { HeaderMode } from '@surf/ui/header';
+import { TextInput } from '@surf/ui/text-input';
+import { useBadgeAssignPage } from '@/app-pages/badge/model/useBadgeAssignPage';
+import { BottomActionBar } from '@/shared/ui/BottomActionBar';
+import { BadgeAssignAccordionList } from '@/widgets/badge/ui/BadgeAssignAccordionList';
+import { AppHeader } from '@/widgets/header/ui/AppHeader';
+
 type BadgeAssignPageProps = {
   badgeId: number;
 };
 
 export const BadgeAssignPage = ({ badgeId }: BadgeAssignPageProps) => {
-  return <div>{badgeId} 배지 부여 페이지</div>;
+  const { state, actions } = useBadgeAssignPage(badgeId);
+
+  return (
+    <>
+      <AppHeader
+        customBack={actions.handleBack}
+        overrideHeader={{
+          mode: HeaderMode.Default,
+          title: '활동 뱃지 부여',
+          hasLeftIcon: true,
+        }}
+      />
+      <div className="flex h-full min-h-0 w-full flex-col">
+        {/* 회원 검색 입력 영역 */}
+        <div className="shrink-0 px-13">
+          <TextInput
+            mode="search"
+            placeholder="회원이름을 검색해주세요"
+            iconName="Search"
+            value={state.keyword}
+            onChange={actions.setKeyword}
+            aria-label="회원이름 검색"
+          />
+        </div>
+
+        {/* 현재 선택된 멤버 수 안내 영역 */}
+        <div className="shrink-0 px-13 pt-10">
+          <p className="text-body-body8 text-foreground-normal-lighter">
+            {state.selectedIds.size}명 선택중
+          </p>
+        </div>
+
+        {/* 기수별 멤버 목록 영역 */}
+        <BadgeAssignAccordionList
+          generations={state.generations}
+          keyword={state.debouncedKeyword}
+          selectedIds={state.selectedIds}
+          assignedMemberIds={state.assignedMemberIds}
+          onToggle={actions.toggleSelect}
+        />
+
+        {/* 선택된 멤버에게 배지를 부여하는 하단 액션 */}
+        <div className="shrink-0">
+          <BottomActionBar actions={actions.bottomActions} />
+        </div>
+      </div>
+    </>
+  );
 };

--- a/apps/admin/src/app-pages/badge/BadgeEditPage.tsx
+++ b/apps/admin/src/app-pages/badge/BadgeEditPage.tsx
@@ -1,7 +1,29 @@
+'use client';
+
+import { HeaderMode } from '@surf/ui/header';
+import { useRouter } from 'next/navigation';
+import { PAGE_ROUTES } from '@/shared/config/path';
+import { BadgeManageWidget } from '@/widgets/badge/ui/BadgeManageWidget';
+import { AppHeader } from '@/widgets/header/ui/AppHeader';
+
 type BadgeEditPageProps = {
   badgeId: number;
 };
 
 export const BadgeEditPage = ({ badgeId }: BadgeEditPageProps) => {
-  return <div>{badgeId} 배지 수정 페이지</div>;
+  const router = useRouter();
+
+  return (
+    <>
+      <AppHeader
+        customBack={() => router.push(PAGE_ROUTES.BADGE_MNG.DETAIL(badgeId))}
+        overrideHeader={{
+          mode: HeaderMode.Default,
+          title: '활동 뱃지 관리',
+          hasLeftIcon: true,
+        }}
+      />
+      <BadgeManageWidget badgeId={badgeId} mode="edit" />
+    </>
+  );
 };

--- a/apps/admin/src/app-pages/badge/BadgeListPage.tsx
+++ b/apps/admin/src/app-pages/badge/BadgeListPage.tsx
@@ -1,3 +1,27 @@
+'use client';
+
+import { Fab } from '@surf/ui/fab';
+import { useRouter } from 'next/navigation';
+import { PAGE_ROUTES } from '@/shared/config/path';
+import { BadgeListWidget } from '@/widgets/badge/ui/BadgeListWidget';
+
 export const BadgeListPage = () => {
-  return <div>배지 목록 페이지</div>;
+  const router = useRouter();
+
+  return (
+    <div className="bg-background-normal relative flex h-full min-h-0 w-full flex-col">
+      <div className="min-h-0 flex-1 overflow-y-auto pb-28">
+        <BadgeListWidget />
+      </div>
+
+      <div className="pointer-events-none absolute inset-0 z-50">
+        <div className="pointer-events-auto absolute right-15 bottom-15">
+          <Fab
+            ariaLabel="신규 뱃지 생성 버튼"
+            onClick={() => router.push(PAGE_ROUTES.BADGE_MNG.CREATE)}
+          />
+        </div>
+      </div>
+    </div>
+  );
 };

--- a/apps/admin/src/app-pages/badge/model/useBadgeAssignPage.ts
+++ b/apps/admin/src/app-pages/badge/model/useBadgeAssignPage.ts
@@ -1,0 +1,101 @@
+'use client';
+
+import { useDebouncedValue } from '@surf/hooks';
+import { useAlertStore } from '@surf/ui/store/alertStore';
+import { useToastStore } from '@surf/ui/store/toastStore';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { useAssignBadgeMembersMutation } from '@/features/badge/model/queries/useAssignBadgeMembersMutation';
+import { useBadgeMembersQuery } from '@/features/badge/model/queries/useBadgeMembersQuery';
+import { PAGE_ROUTES } from '@/shared/config/path';
+import { useSelectableListState } from '@/shared/hooks/useSelectableListState';
+import { useMemberGenerationListQuery } from '@/widgets/member-directory/model/queries/useMemberGenerationListQuery';
+
+/**
+ * 배지 부여 화면의 검색, 멤버 선택, 확인 Alert, 부여 요청 플로우를 관리한다.
+ */
+export const useBadgeAssignPage = (badgeId: number) => {
+  const router = useRouter();
+  const openAlert = useAlertStore((s) => s.open);
+  const closeAlert = useAlertStore((s) => s.close);
+  const showToast = useToastStore((s) => s.show);
+  const [keyword, setKeyword] = useState('');
+  const debouncedKeyword = useDebouncedValue(keyword, 300);
+
+  const { selectedIds, toggleSelect, resetSelectionState } = useSelectableListState<number>({
+    initialMode: 'select',
+  });
+
+  const { data: generations } = useMemberGenerationListQuery();
+  const { data: assignedMembers = [] } = useBadgeMembersQuery(badgeId);
+  const { mutateAsync: assignBadgeMembers, isPending } = useAssignBadgeMembersMutation(badgeId);
+
+  const assignedMemberIds = new Set(assignedMembers.map((member) => member.id));
+
+  /** 배지 수정 화면으로 돌아간다. */
+  const handleBack = () => {
+    router.push(PAGE_ROUTES.BADGE_MNG.EDIT(badgeId));
+  };
+
+  /** 선택된 멤버들에게 배지를 부여하고 수정 화면으로 이동한다. */
+  const handleSubmit = async () => {
+    if (selectedIds.size === 0 || isPending) return;
+
+    try {
+      await assignBadgeMembers({ memberIds: [...selectedIds] });
+      showToast('배지가 부여되었습니다.');
+      resetSelectionState();
+      router.replace(PAGE_ROUTES.BADGE_MNG.EDIT(badgeId));
+    } catch {
+      showToast('배지 부여에 실패했습니다.');
+    }
+  };
+
+  /** 부여 확인 Alert을 열고 확인 시 실제 부여 요청을 실행한다. */
+  const handleOpenAssignAlert = () => {
+    if (selectedIds.size === 0 || isPending) return;
+
+    openAlert({
+      state: 'default',
+      title: '부여하시겠습니까?',
+      infoText: `부여하기 버튼을 누를 시, 선택한 ${selectedIds.size}명의 인원에게 활동 뱃지가 부여됩니다.`,
+      actions: [
+        { type: 'solid', variant: 'secondary', label: '취소', onClick: closeAlert },
+        {
+          type: 'solid',
+          variant: 'primary',
+          label: '부여하기',
+          onClick: () => {
+            closeAlert();
+            void handleSubmit();
+          },
+        },
+      ],
+    });
+  };
+
+  const bottomActions = [
+    {
+      key: 'assign',
+      label: '부여하기',
+      onClick: handleOpenAssignAlert,
+      disabled: selectedIds.size === 0 || isPending,
+    },
+  ];
+
+  return {
+    state: {
+      keyword,
+      debouncedKeyword,
+      selectedIds,
+      assignedMemberIds,
+      generations,
+    },
+    actions: {
+      setKeyword,
+      toggleSelect,
+      handleBack,
+      bottomActions,
+    },
+  };
+};

--- a/apps/admin/src/entities/badge/ui/BadgeListItem.stories.tsx
+++ b/apps/admin/src/entities/badge/ui/BadgeListItem.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { BadgeListItem } from './BadgeListItem';
+import DEFAULT_BADGE_IMAGE from '@/shared/assets/images/default-item.png';
+
+const meta: Meta<typeof BadgeListItem> = {
+  title: 'Entities/UI/Badge/BadgeListItem',
+  component: BadgeListItem,
+  args: {
+    badgeId: 1,
+    imageUrl: DEFAULT_BADGE_IMAGE.src,
+    name: '새로운 17기 환영',
+    onClick: () => {},
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof BadgeListItem>;
+
+export const Default: Story = {};

--- a/apps/admin/src/entities/badge/ui/BadgeListItem.tsx
+++ b/apps/admin/src/entities/badge/ui/BadgeListItem.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import Image from 'next/image';
+
+type BadgeListItemProps = {
+  badgeId: number;
+  imageUrl: string;
+  name: string;
+  onClick: () => void;
+};
+
+export const BadgeListItem = ({ imageUrl, name, onClick }: BadgeListItemProps) => {
+  return (
+    <button
+      type="button"
+      className="border-border-normal flex w-full items-center gap-10 border-b px-14 py-11 text-left"
+      onClick={onClick}
+    >
+      <div className="rounded-3 relative h-[3rem] w-[4.875rem]">
+        <Image src={imageUrl} alt={name} fill className="shrink-0 object-cover" />
+      </div>
+
+      <span className="text-body-body6 text-foreground-static-black min-w-0 flex-1 truncate">
+        {name}
+      </span>
+    </button>
+  );
+};

--- a/apps/admin/src/features/badge/api/assignBadge.ts
+++ b/apps/admin/src/features/badge/api/assignBadge.ts
@@ -1,0 +1,11 @@
+import { axiosInstance } from '@/shared/lib/axiosInstance';
+import { CommonResponse } from '@/shared/api/types';
+import { AssignBadgeMembersRequest } from './types';
+
+export async function assignBadgeMembers(badgeId: number, data: AssignBadgeMembersRequest) {
+  const response = await axiosInstance.post<CommonResponse<null>>(
+    `/v1/admin/badges/${badgeId}/members`,
+    data,
+  );
+  return response.data.data;
+}

--- a/apps/admin/src/features/badge/api/deleteBadge.ts
+++ b/apps/admin/src/features/badge/api/deleteBadge.ts
@@ -1,0 +1,9 @@
+import { axiosInstance } from '@/shared/lib/axiosInstance';
+import { CommonResponse } from '@/shared/api/types';
+
+export async function deleteBadge(badgeId: number) {
+  const response = await axiosInstance.delete<CommonResponse<null>>(
+    `/v1/admin/badges/${badgeId}`,
+  );
+  return response.data.data;
+}

--- a/apps/admin/src/features/badge/api/getBadgeList.ts
+++ b/apps/admin/src/features/badge/api/getBadgeList.ts
@@ -1,0 +1,8 @@
+import { axiosInstance } from '@/shared/lib/axiosInstance';
+import { BadgeListData, BadgeListParams, BadgeListResponse } from './types';
+
+export async function getBadgeList(params: BadgeListParams): Promise<BadgeListData> {
+  const response = await axiosInstance.get<BadgeListResponse>('/v1/admin/badges', { params });
+
+  return response.data.data;
+}

--- a/apps/admin/src/features/badge/api/removeBadgeMember.ts
+++ b/apps/admin/src/features/badge/api/removeBadgeMember.ts
@@ -1,0 +1,11 @@
+import { axiosInstance } from '@/shared/lib/axiosInstance';
+import { CommonResponse } from '@/shared/api/types';
+import { RemoveBadgeMembersRequest } from './types';
+
+export async function removeBadgeMembers(badgeId: number, data: RemoveBadgeMembersRequest) {
+  const response = await axiosInstance.delete<CommonResponse<null>>(
+    `/v1/admin/badges/${badgeId}/members`,
+    { data },
+  );
+  return response.data.data;
+}

--- a/apps/admin/src/features/badge/api/types.ts
+++ b/apps/admin/src/features/badge/api/types.ts
@@ -26,3 +26,9 @@ export interface BadgeMembersResDto {
   pageSize: number;
   hasNext: boolean;
 }
+
+export type UpdateBadgeRequest = Partial<CreateBadgeRequest>;
+
+export interface RemoveBadgeMembersRequest {
+  memberIds: number[];
+}

--- a/apps/admin/src/features/badge/api/types.ts
+++ b/apps/admin/src/features/badge/api/types.ts
@@ -1,3 +1,10 @@
+import { CommonResponse } from '@/shared/api/types';
+
+export interface BadgeListParams {
+  pageNum: number;
+  pageSize: number;
+}
+
 export interface CreateBadgeRequest {
   name: string;
   imageUrl: string;
@@ -8,6 +15,18 @@ export interface CreateBadgeRequest {
 export interface BadgeResDto extends CreateBadgeRequest {
   badgeId: number;
 }
+
+export interface BadgeListData {
+  content: BadgeResDto[];
+  pageNumber: number;
+  pageSize: number;
+  numberOfElements?: number;
+  isLast?: boolean;
+  hasNext?: boolean;
+  totalCount?: number;
+}
+
+export type BadgeListResponse = CommonResponse<BadgeListData>;
 
 export interface BadgeAwardedMemberResDto {
   memberId: number;
@@ -30,5 +49,9 @@ export interface BadgeMembersResDto {
 export type UpdateBadgeRequest = Partial<CreateBadgeRequest>;
 
 export interface RemoveBadgeMembersRequest {
+  memberIds: number[];
+}
+
+export interface AssignBadgeMembersRequest {
   memberIds: number[];
 }

--- a/apps/admin/src/features/badge/api/updateBadge.ts
+++ b/apps/admin/src/features/badge/api/updateBadge.ts
@@ -1,0 +1,11 @@
+import { axiosInstance } from '@/shared/lib/axiosInstance';
+import { CommonResponse } from '@/shared/api/types';
+import { BadgeResDto, UpdateBadgeRequest } from './types';
+
+export async function updateBadge(badgeId: number, data: UpdateBadgeRequest) {
+  const response = await axiosInstance.patch<CommonResponse<BadgeResDto>>(
+    `/v1/admin/badges/${badgeId}`,
+    data,
+  );
+  return response.data.data;
+}

--- a/apps/admin/src/features/badge/model/queries/useAssignBadgeMembersMutation.ts
+++ b/apps/admin/src/features/badge/model/queries/useAssignBadgeMembersMutation.ts
@@ -1,0 +1,22 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { assignBadgeMembers } from '@/features/badge/api/assignBadge';
+import { AssignBadgeMembersRequest } from '@/features/badge/api/types';
+import { badgeQueryKeys } from './queryKeys';
+
+export const useAssignBadgeMembersMutation = (badgeId?: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: AssignBadgeMembersRequest) => {
+      if (!badgeId) throw new Error('INVALID_BADGE_ID');
+      return assignBadgeMembers(badgeId, data);
+    },
+    onSuccess: () => {
+      if (!badgeId) return;
+      void queryClient.invalidateQueries({ queryKey: badgeQueryKeys.members(badgeId) });
+    },
+    onError: (error) => {
+      console.error('[useAssignBadgeMembersMutation] 배지 부여 실패:', error);
+    },
+  });
+};

--- a/apps/admin/src/features/badge/model/queries/useBadgeListQuery.ts
+++ b/apps/admin/src/features/badge/model/queries/useBadgeListQuery.ts
@@ -1,0 +1,58 @@
+import { infiniteQueryOptions, useInfiniteQuery } from '@tanstack/react-query';
+import { Badge } from '@/entities/badge/model/types';
+import { getBadgeList } from '@/features/badge/api/getBadgeList';
+import {
+  createInfiniteDataSelector,
+  getNextPageNumber,
+  InfiniteSelectResult,
+  PageWithContent,
+} from '@/shared/lib/tanstack-query/infiniteQueryUtils';
+
+import { badgeQueryKeys } from './queryKeys';
+import { mapBadgeResDtoToBadge } from '../mapper';
+
+const BADGE_LIST_PAGE_SIZE = 20;
+
+export const useBadgeListQuery = () => {
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, isError, refetch } =
+    useInfiniteQuery(
+      infiniteQueryOptions<
+        PageWithContent<Badge>,
+        Error,
+        InfiniteSelectResult<Badge>,
+        ReturnType<typeof badgeQueryKeys.list>,
+        number
+      >({
+        queryKey: badgeQueryKeys.list(),
+        queryFn: async ({ pageParam = 0 }) => {
+          const response = await getBadgeList({
+            pageNum: pageParam,
+            pageSize: BADGE_LIST_PAGE_SIZE,
+          });
+          const { content, ...pageMeta } = response;
+
+          return {
+            ...pageMeta,
+            numberOfElements: pageMeta.numberOfElements ?? content.length,
+            isLast: pageMeta.isLast ?? !pageMeta.hasNext,
+            content: content.map(mapBadgeResDtoToBadge),
+          };
+        },
+        initialPageParam: 0,
+        getNextPageParam: getNextPageNumber,
+        select: createInfiniteDataSelector<Badge>(),
+        refetchOnWindowFocus: false,
+      }),
+    );
+
+  return {
+    badges: data?.items ?? [],
+    isLast: data?.isLast ?? true,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading,
+    isError,
+    refetch,
+  };
+};

--- a/apps/admin/src/features/badge/model/queries/useDeleteBadgeMutation.ts
+++ b/apps/admin/src/features/badge/model/queries/useDeleteBadgeMutation.ts
@@ -1,0 +1,23 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { deleteBadge } from '@/features/badge/api/deleteBadge';
+import { badgeQueryKeys } from './queryKeys';
+
+export const useDeleteBadgeMutation = (badgeId?: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => {
+      if (!badgeId) throw new Error('INVALID_BADGE_ID');
+      return deleteBadge(badgeId);
+    },
+    onSuccess: () => {
+      if (!badgeId) return;
+      queryClient.removeQueries({ queryKey: badgeQueryKeys.detail(badgeId) });
+      queryClient.removeQueries({ queryKey: badgeQueryKeys.members(badgeId) });
+      void queryClient.invalidateQueries({ queryKey: badgeQueryKeys.list() });
+    },
+    onError: (error) => {
+      console.error('[useDeleteBadgeMutation] 배지 삭제 실패:', error);
+    },
+  });
+};

--- a/apps/admin/src/features/badge/model/queries/useRemoveBadgeMembersMutation.ts
+++ b/apps/admin/src/features/badge/model/queries/useRemoveBadgeMembersMutation.ts
@@ -1,0 +1,22 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { removeBadgeMembers } from '@/features/badge/api/removeBadgeMember';
+import { RemoveBadgeMembersRequest } from '@/features/badge/api/types';
+import { badgeQueryKeys } from './queryKeys';
+
+export const useRemoveBadgeMembersMutation = (badgeId?: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: RemoveBadgeMembersRequest) => {
+      if (!badgeId) throw new Error('INVALID_BADGE_ID');
+      return removeBadgeMembers(badgeId, data);
+    },
+    onSuccess: () => {
+      if (!badgeId) return;
+      void queryClient.invalidateQueries({ queryKey: badgeQueryKeys.members(badgeId) });
+    },
+    onError: (error) => {
+      console.error('[useRemoveBadgeMembersMutation] 배지 멤버 회수 실패:', error);
+    },
+  });
+};

--- a/apps/admin/src/features/badge/model/queries/useUpdateBadgeMutation.ts
+++ b/apps/admin/src/features/badge/model/queries/useUpdateBadgeMutation.ts
@@ -1,0 +1,23 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { updateBadge } from '@/features/badge/api/updateBadge';
+import { UpdateBadgeRequest } from '@/features/badge/api/types';
+import { badgeQueryKeys } from './queryKeys';
+
+export const useUpdateBadgeMutation = (badgeId?: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: UpdateBadgeRequest) => {
+      if (!badgeId) throw new Error('INVALID_BADGE_ID');
+      return updateBadge(badgeId, data);
+    },
+    onSuccess: () => {
+      if (!badgeId) return;
+      void queryClient.invalidateQueries({ queryKey: badgeQueryKeys.list() });
+      void queryClient.invalidateQueries({ queryKey: badgeQueryKeys.detail(badgeId) });
+    },
+    onError: (error) => {
+      console.error('[useUpdateBadgeMutation] 배지 수정 실패:', error);
+    },
+  });
+};

--- a/apps/admin/src/features/badge/model/types.ts
+++ b/apps/admin/src/features/badge/model/types.ts
@@ -12,3 +12,15 @@ export interface BadgeAwardedMember {
   tracks: MemberTrack[];
   awardedAt: string;
 }
+
+/**
+ * 배지 수정 화면에서 관리하는 폼 상태.
+ *
+ * 서버의 Badge 도메인 값에 더해 새 이미지 파일과 회수 예정 멤버 ID 목록을 함께 보관한다.
+ */
+export interface BadgeEditFormData {
+  name: string;
+  imageUrl: string;
+  imageFile: File | null;
+  removedMemberIds: number[];
+}

--- a/apps/admin/src/features/badge/model/useBadgeEditForm.ts
+++ b/apps/admin/src/features/badge/model/useBadgeEditForm.ts
@@ -1,0 +1,226 @@
+'use client';
+
+import { useAlertStore } from '@surf/ui/store/alertStore';
+import { useToastStore } from '@surf/ui/store/toastStore';
+import { safeUUID, UploadImage } from '@surf/utils';
+import { useRouter } from 'next/navigation';
+import { useEffect, useMemo, useState } from 'react';
+import type { Badge } from '@/entities/badge/model/types';
+import { useImageUploader } from '@/entities/image/model/useImageUploader';
+import { useDeleteBadgeMutation } from '@/features/badge/model/queries/useDeleteBadgeMutation';
+import { useRemoveBadgeMembersMutation } from '@/features/badge/model/queries/useRemoveBadgeMembersMutation';
+import { useUpdateBadgeMutation } from '@/features/badge/model/queries/useUpdateBadgeMutation';
+import type { BadgeAwardedMember, BadgeEditFormData } from '@/features/badge/model/types';
+import { PAGE_ROUTES } from '@/shared/config/path';
+
+const INITIAL_FORM: BadgeEditFormData = {
+  name: '',
+  imageUrl: '',
+  imageFile: null,
+  removedMemberIds: [],
+};
+
+/**
+ * 배지 수정 화면의 폼 상태와 저장/삭제 액션을 관리하는 훅.
+ *
+ * 초기 배지 정보와 부여 멤버 목록을 받아 수정 가능 상태로 변환하고,
+ * 이미지 업로드, 배지 정보 수정, 멤버 회수, 배지 삭제 플로우를 조합한다.
+ */
+export const useBadgeEditForm = (
+  badgeId: number,
+  initialBadge: Badge | undefined,
+  members: BadgeAwardedMember[] = [],
+) => {
+  const router = useRouter();
+  const { uploadImages } = useImageUploader();
+
+  const openAlert = useAlertStore((s) => s.open);
+  const closeAlert = useAlertStore((s) => s.close);
+  const showToast = useToastStore((s) => s.show);
+
+  const { mutateAsync: updateBadge } = useUpdateBadgeMutation(badgeId);
+  const { mutateAsync: removeBadgeMembers } = useRemoveBadgeMembersMutation(badgeId);
+  const { mutateAsync: deleteBadge, isPending: isDeleting } = useDeleteBadgeMutation(badgeId);
+
+  const [initial, setInitial] = useState<Badge | null>(null);
+  const [form, setForm] = useState<BadgeEditFormData>(INITIAL_FORM);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  /** 서버에서 받은 배지 상세값을 수정 폼 초기값으로 동기화한다. */
+  useEffect(() => {
+    if (!initialBadge) return;
+
+    setInitial(initialBadge);
+    setForm({
+      name: initialBadge.name,
+      imageUrl: initialBadge.imageUrl,
+      imageFile: null,
+      removedMemberIds: [],
+    });
+  }, [badgeId, initialBadge]);
+
+  /** 회수 예정 멤버를 화면 목록에서 제외한 표시용 멤버 목록이다. */
+  const visibleMembers = useMemo(() => {
+    const removedIds = new Set(form.removedMemberIds);
+    return members.filter((member) => !removedIds.has(member.id));
+  }, [form.removedMemberIds, members]);
+
+  /** 배지 기본 정보, 이미지 파일, 회수 예정 멤버 중 하나라도 바뀌었는지 판단한다. */
+  const isChanged = useMemo(() => {
+    if (!initial) return false;
+    return (
+      initial.name !== form.name ||
+      initial.imageUrl !== form.imageUrl ||
+      form.imageFile !== null ||
+      form.removedMemberIds.length > 0
+    );
+  }, [initial, form]);
+
+  /** 필수값과 변경 여부, 제출 상태를 기준으로 수정 가능 여부를 계산한다. */
+  const canSubmit = useMemo(() => {
+    const hasName = form.name.trim().length > 0;
+    const hasImage = form.imageUrl.trim().length > 0 || form.imageFile !== null;
+    return !!initial && hasName && hasImage && isChanged && !isSubmitting && !isDeleting;
+  }, [initial, form, isChanged, isSubmitting, isDeleting]);
+
+  /** 배지명 입력값을 수정 폼에 반영한다. */
+  const setBadgeName = (name: string) => {
+    setForm((prev) => ({ ...prev, name }));
+  };
+
+  /** 새로 선택한 배지 이미지 파일을 수정 폼에 반영한다. */
+  const setBadgeFile = (file: File | null) => {
+    setForm((prev) => ({ ...prev, imageFile: file }));
+  };
+
+  /** 멤버 회수를 즉시 요청하지 않고 저장 시 처리할 회수 예정 목록에 추가한다. */
+  const removeMember = (memberId: number) => {
+    setForm((prev) => {
+      if (prev.removedMemberIds.includes(memberId)) return prev;
+      return { ...prev, removedMemberIds: [...prev.removedMemberIds, memberId] };
+    });
+  };
+
+  /** 이미지 업로드, 배지 정보 수정, 멤버 회수를 순서대로 처리한다. */
+  const handleSubmit = async () => {
+    if (!initial || !canSubmit || isSubmitting) return;
+
+    setIsSubmitting(true);
+    try {
+      let imageUrl = form.imageUrl;
+
+      if (form.imageFile) {
+        const uploadItem: UploadImage = {
+          id: safeUUID(),
+          file: form.imageFile,
+          preview: '',
+          status: 'pending',
+        };
+        const [result] = await uploadImages([uploadItem]);
+
+        if (result.status !== 'uploaded' || !result.uploadedUrl) {
+          showToast('이미지 업로드에 실패했습니다.');
+          return;
+        }
+
+        imageUrl = result.uploadedUrl;
+      }
+
+      const apiTasks: Promise<unknown>[] = [];
+      const hasBadgeInfoChanged = initial.name !== form.name || initial.imageUrl !== imageUrl;
+
+      if (hasBadgeInfoChanged) {
+        apiTasks.push(updateBadge({ name: form.name.trim(), imageUrl }));
+      }
+
+      if (form.removedMemberIds.length > 0) {
+        apiTasks.push(removeBadgeMembers({ memberIds: form.removedMemberIds }));
+      }
+
+      await Promise.all(apiTasks);
+      showToast('배지가 수정되었습니다.');
+      router.replace(PAGE_ROUTES.BADGE_MNG.DETAIL(badgeId));
+    } catch {
+      showToast('배지 수정에 실패했습니다.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  /** 배지를 삭제하고 목록 페이지로 이동한다. */
+  const handleDelete = async () => {
+    if (isDeleting || isSubmitting) return;
+
+    try {
+      await deleteBadge();
+      showToast('배지가 삭제되었습니다.');
+      router.replace(PAGE_ROUTES.BADGE_MNG.LIST);
+    } catch {
+      showToast('배지 삭제에 실패했습니다.');
+    }
+  };
+
+  /** 저장 확인 Alert을 열고 확인 시 수정 요청을 실행한다. */
+  const handleOpenSaveAlert = () => {
+    openAlert({
+      state: 'default',
+      title: '수정하시겠습니까?',
+      infoText: '수정하기 버튼을 누를 시, 수정된 배지 정보가 반영됩니다.',
+      actions: [
+        { type: 'solid', variant: 'secondary', label: '취소', onClick: closeAlert },
+        {
+          type: 'solid',
+          variant: 'primary',
+          label: '수정하기',
+          onClick: () => {
+            closeAlert();
+            void handleSubmit();
+          },
+        },
+      ],
+    });
+  };
+
+  /** 삭제 확인 Alert을 열고 확인 시 삭제 요청을 실행한다. */
+  const handleOpenDeleteAlert = () => {
+    openAlert({
+      state: 'default',
+      title: '삭제하시겠습니까?',
+      infoText:
+        '삭제하기 버튼을 누를 시, 해당 뱃지 데이터와 함께 부여된 회원들의 뱃지 목록에서도 해당 뱃지가 삭제됩니다.',
+      actions: [
+        { type: 'solid', variant: 'secondary', label: '취소', onClick: closeAlert },
+        {
+          type: 'solid',
+          variant: 'danger',
+          label: '삭제하기',
+          onClick: () => {
+            closeAlert();
+            void handleDelete();
+          },
+        },
+      ],
+    });
+  };
+
+  return {
+    state: {
+      form,
+      visibleMembers,
+      canSubmit,
+      isChanged,
+      isSubmitting,
+      isDeleting,
+      isLoading: !initial,
+    },
+    actions: {
+      setForm,
+      setBadgeName,
+      setBadgeFile,
+      removeMember,
+      handleSubmit,
+      handleOpenSaveAlert,
+      handleOpenDeleteAlert,
+    },
+  };
+};

--- a/apps/admin/src/widgets/badge/ui/BadgeAssignAccordionList.tsx
+++ b/apps/admin/src/widgets/badge/ui/BadgeAssignAccordionList.tsx
@@ -1,0 +1,70 @@
+import { Avatar } from '@surf/ui/avatar';
+import { RoleBadge } from '@/entities/member/ui/RoleBadge';
+import { SelectableMemberCard } from '@/entities/member/ui/SelectableMemberCard';
+import { MemberGenerationAccordion } from '@/features/member-by-generation/ui/MemberGenerationAccordion';
+
+type BadgeAssignAccordionListProps = {
+  generations: number[];
+  keyword: string;
+  selectedIds: Set<number>;
+  assignedMemberIds: Set<number>;
+  onToggle: (memberId: number) => void;
+};
+
+const ACCORDION_MAX_HEIGHT = '36vh';
+
+/**
+ * 배지 부여 화면에서 기수별 멤버 목록을 렌더링하는 아코디언 리스트.
+ *
+ * 이미 해당 배지를 부여받은 멤버는 renderItem에서 null을 반환해 목록에서 제외한다.
+ */
+export const BadgeAssignAccordionList = ({
+  generations,
+  keyword,
+  selectedIds,
+  assignedMemberIds,
+  onToggle,
+}: BadgeAssignAccordionListProps) => {
+  if (generations.length === 0) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-12">
+        <span className="text-body-body8 text-foreground-tertiary">아직 가입한 멤버가 없어요.</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="scrollbar-hide min-h-0 flex-1 overflow-y-auto">
+      {generations.map((generation) => (
+        <MemberGenerationAccordion
+          key={generation}
+          generation={generation}
+          label={`${generation}기`}
+          keyword={keyword}
+          contentMaxHeight={ACCORDION_MAX_HEIGHT}
+          renderItem={(member) => {
+            if (assignedMemberIds.has(member.id)) return null;
+
+            return (
+              <SelectableMemberCard
+                name={member.name}
+                tracks={member.tracks}
+                isSelectionEnabled={true}
+                checked={selectedIds.has(member.id)}
+                onToggle={() => onToggle(member.id)}
+                leftSlot={
+                  <Avatar
+                    size="s"
+                    alt={`${member.name} 프로필 이미지`}
+                    src={member.profileImageUrl}
+                  />
+                }
+                rightSlot={<RoleBadge type={member.role} />}
+              />
+            );
+          }}
+        />
+      ))}
+    </div>
+  );
+};

--- a/apps/admin/src/widgets/badge/ui/BadgeAssignedMemberSection.tsx
+++ b/apps/admin/src/widgets/badge/ui/BadgeAssignedMemberSection.tsx
@@ -1,3 +1,4 @@
+import { SolidButton } from '@surf/ui/button';
 import { FieldGroup } from '@surf/ui/field-group';
 import { RemovableMemberCard } from '@/entities/member/ui/RemovableMemberCard';
 import type { BadgeAwardedMember } from '@/features/badge/model/types';
@@ -9,6 +10,7 @@ type BadgeAssignedMemberSectionProps = {
   mode: BadgeManageMode;
   members: BadgeAwardedMember[];
   onRemoveMember?: (memberId: number) => void;
+  onAddMember?: () => void;
 };
 
 /**
@@ -21,12 +23,14 @@ export const BadgeAssignedMemberSection = ({
   mode,
   members,
   onRemoveMember,
+  onAddMember,
 }: BadgeAssignedMemberSectionProps) => {
   const isEdit = mode === 'edit';
 
   return (
     <FieldGroup title="부여 인원" className="px-14">
       {members.length === 0 ? (
+        // 부여된 멤버가 없을 때 보여주는 empty state
         <div className="flex w-full justify-center py-10">
           <div className="flex flex-col items-center gap-5">
             <CareerEmpty />
@@ -34,6 +38,7 @@ export const BadgeAssignedMemberSection = ({
           </div>
         </div>
       ) : (
+        // 부여 멤버가 5명을 초과해도 섹션 높이가 커지지 않도록 내부 스크롤을 사용한다.
         <div className="max-h-[17.5rem] w-full overflow-y-auto">
           {members.map((member) => (
             <RemovableMemberCard
@@ -47,6 +52,12 @@ export const BadgeAssignedMemberSection = ({
             />
           ))}
         </div>
+      )}
+      {/* 수정 모드에서 배지 부여 페이지로 이동하는 액션 */}
+      {isEdit && (
+        <SolidButton size="m" variant="secondary" onClick={onAddMember} className="mt-5">
+          추가하기
+        </SolidButton>
       )}
     </FieldGroup>
   );

--- a/apps/admin/src/widgets/badge/ui/BadgeAssignedMemberSection.tsx
+++ b/apps/admin/src/widgets/badge/ui/BadgeAssignedMemberSection.tsx
@@ -1,5 +1,4 @@
 import { SolidButton } from '@surf/ui/button';
-import { FieldGroup } from '@surf/ui/field-group';
 import { RemovableMemberCard } from '@/entities/member/ui/RemovableMemberCard';
 import type { BadgeAwardedMember } from '@/features/badge/model/types';
 import CareerEmpty from '@/shared/assets/icons/career-empty.svg';
@@ -28,7 +27,8 @@ export const BadgeAssignedMemberSection = ({
   const isEdit = mode === 'edit';
 
   return (
-    <FieldGroup title="부여 인원" className="px-14">
+    <section className="flex flex-col gap-12">
+      <p className="text-title-title2 text-foreground-normal px-14">부여 인원</p>
       {members.length === 0 ? (
         // 부여된 멤버가 없을 때 보여주는 empty state
         <div className="flex w-full justify-center py-10">
@@ -39,7 +39,7 @@ export const BadgeAssignedMemberSection = ({
         </div>
       ) : (
         // 부여 멤버가 5명을 초과해도 섹션 높이가 커지지 않도록 내부 스크롤을 사용한다.
-        <div className="max-h-[17.5rem] w-full overflow-y-auto">
+        <div className="max-h-70 w-full overflow-y-auto">
           {members.map((member) => (
             <RemovableMemberCard
               key={member.id}
@@ -55,10 +55,12 @@ export const BadgeAssignedMemberSection = ({
       )}
       {/* 수정 모드에서 배지 부여 페이지로 이동하는 액션 */}
       {isEdit && (
-        <SolidButton size="m" variant="secondary" onClick={onAddMember} className="mt-5">
-          추가하기
-        </SolidButton>
+        <div className="px-14">
+          <SolidButton size="s" variant="secondary" onClick={onAddMember}>
+            추가하기
+          </SolidButton>
+        </div>
       )}
-    </FieldGroup>
+    </section>
   );
 };

--- a/apps/admin/src/widgets/badge/ui/BadgeBasicSection.tsx
+++ b/apps/admin/src/widgets/badge/ui/BadgeBasicSection.tsx
@@ -1,13 +1,20 @@
 import { FieldGroup } from '@surf/ui/field-group';
+import { TextArea } from '@surf/ui/text-area';
 import { upgradeHttpToHttps } from '@surf/utils';
 import Image from 'next/image';
 import { Badge } from '@/entities/badge/model/types';
+import type { BadgeEditFormData } from '@/features/badge/model/types';
+import { ImgUploader } from '@/features/image/ui/ImgUploader';
 
 type BadgeManageMode = 'detail' | 'edit';
 
 type BadgeBasicSectionProps = {
   mode: BadgeManageMode;
   badge: Badge;
+  form?: BadgeEditFormData;
+  isSubmitting?: boolean;
+  onChangeName?: (name: string) => void;
+  onSelectFile?: (file: File | null) => void;
 };
 
 /**
@@ -16,33 +23,65 @@ type BadgeBasicSectionProps = {
  * 상세 모드에서는 배지 이미지와 이름을 읽기 전용으로 표시하고,
  * 수정 모드에서는 동일한 레이아웃을 유지한 채 입력/업로드 UI로 확장할 수 있다.
  */
-export const BadgeBasicSection = ({ mode, badge }: BadgeBasicSectionProps) => {
+export const BadgeBasicSection = ({
+  mode,
+  badge,
+  form,
+  isSubmitting = false,
+  onChangeName,
+  onSelectFile,
+}: BadgeBasicSectionProps) => {
   const isEdit = mode === 'edit';
-  const imageUrl = upgradeHttpToHttps(badge.imageUrl);
+  const name = form?.name ?? badge.name;
+  const imageUrl = upgradeHttpToHttps(form?.imageUrl ?? badge.imageUrl);
 
   return (
     <>
+      {/* 배지 이미지 표시/수정 영역 */}
       <FieldGroup title="뱃지 이미지 등록" className="px-13">
-        <div className="rounded-3 border-border-quaternary bg-background-quaternary relative h-[5rem] w-full overflow-hidden border border-dashed">
-          {imageUrl ? (
-            <Image
-              src={imageUrl}
-              alt={`${badge.name} 이미지`}
-              className="object-cover"
-              fill
-              sizes="343px"
-            />
-          ) : null}
-        </div>
+        {isEdit && onSelectFile ? (
+          <ImgUploader
+            mode="edit"
+            value={imageUrl}
+            onSelectFile={onSelectFile}
+            isDisabled={isSubmitting}
+            overlayText="해당 이미지 클릭 시, 이미지 변경이 가능합니다"
+            buttonClassName="h-[5rem]"
+            imageAlt="배지 이미지"
+          />
+        ) : (
+          <div className="rounded-3 border-border-quaternary bg-background-quaternary relative h-[5rem] w-full overflow-hidden border border-dashed">
+            {imageUrl ? (
+              <Image
+                src={imageUrl}
+                alt={`${name} 이미지`}
+                className="object-cover"
+                fill
+                sizes="343px"
+              />
+            ) : null}
+          </div>
+        )}
       </FieldGroup>
 
+      {/* 배지 이름 표시/수정 영역 */}
       <FieldGroup title="뱃지 이름" className="px-13">
-        <div
-          className="bg-background-quaternary rounded-3 text-body-body9 text-foreground-normal flex min-h-[2.5rem] items-center px-10 py-10"
-          aria-readonly={!isEdit}
-        >
-          {badge.name}
-        </div>
+        {isEdit && onChangeName ? (
+          <TextArea
+            mode="oneLine"
+            value={name}
+            onChange={onChangeName}
+            placeholder="배지 이름을 입력해주세요."
+            isDisabled={isSubmitting}
+          />
+        ) : (
+          <div
+            className="bg-background-quaternary rounded-3 text-body-body9 text-foreground-normal flex min-h-[2.5rem] items-center px-10 py-10"
+            aria-readonly={!isEdit}
+          >
+            {name}
+          </div>
+        )}
       </FieldGroup>
     </>
   );

--- a/apps/admin/src/widgets/badge/ui/BadgeEditActionSection.tsx
+++ b/apps/admin/src/widgets/badge/ui/BadgeEditActionSection.tsx
@@ -1,0 +1,23 @@
+import { SolidButton } from '@surf/ui/button';
+
+type BadgeEditActionSectionProps = {
+  isDisabled?: boolean;
+  onDelete: () => void;
+};
+
+/**
+ * 배지 수정 화면에서 사용하는 삭제 액션 섹션.
+ */
+export const BadgeEditActionSection = ({
+  isDisabled = false,
+  onDelete,
+}: BadgeEditActionSectionProps) => {
+  return (
+    // 배지 자체를 삭제하는 위험 액션 영역
+    <div className="px-13">
+      <SolidButton size="m" variant="warning" isDisabled={isDisabled} onClick={onDelete}>
+        해당 뱃지 삭제하기
+      </SolidButton>
+    </div>
+  );
+};

--- a/apps/admin/src/widgets/badge/ui/BadgeEditBottomBar.tsx
+++ b/apps/admin/src/widgets/badge/ui/BadgeEditBottomBar.tsx
@@ -1,0 +1,36 @@
+import { useKeyboardOffset } from '@surf/hooks';
+import { SolidButton } from '@surf/ui/button';
+
+type BadgeEditBottomBarProps = {
+  canSubmit: boolean;
+  isSubmitting: boolean;
+  onSubmit: () => void;
+};
+
+/**
+ * 배지 수정 화면 하단에 고정되는 저장 버튼 영역.
+ */
+export const BadgeEditBottomBar = ({
+  canSubmit,
+  isSubmitting,
+  onSubmit,
+}: BadgeEditBottomBarProps) => {
+  const keyboardOffset = useKeyboardOffset();
+
+  return (
+    // 키보드가 올라와도 저장 버튼이 가려지지 않도록 하단 여백을 보정한다.
+    <div
+      className="bg-background-normal shadow-embossed-inverse sticky bottom-0 px-13 pt-13 pb-16"
+      style={{ paddingBottom: keyboardOffset + 16 }}
+    >
+      <SolidButton
+        size="l"
+        variant="primary"
+        isDisabled={!canSubmit || isSubmitting}
+        onClick={onSubmit}
+      >
+        수정하기
+      </SolidButton>
+    </div>
+  );
+};

--- a/apps/admin/src/widgets/badge/ui/BadgeListWidget.tsx
+++ b/apps/admin/src/widgets/badge/ui/BadgeListWidget.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useInfiniteScroll } from '@surf/hooks';
+import { useRouter } from 'next/navigation';
+import Loading from '@/app/loading';
+import { BadgeListItem } from '@/entities/badge/ui/BadgeListItem';
+import { useBadgeListQuery } from '@/features/badge/model/queries/useBadgeListQuery';
+import { PAGE_ROUTES } from '@/shared/config/path';
+import { ErrorState } from '@/shared/ui/error/ErrorState';
+
+export const BadgeListWidget = () => {
+  const router = useRouter();
+  const { badges, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, isError } =
+    useBadgeListQuery();
+
+  const triggerRef = useInfiniteScroll({
+    hasNextPage,
+    isFetching: isFetchingNextPage,
+    onLoadMore: () => {
+      void fetchNextPage();
+    },
+  });
+
+  if (isLoading) {
+    return <Loading />;
+  }
+
+  if (isError || !badges) {
+    return <ErrorState message="배지 목록을 불러오지 못했습니다." />;
+  }
+
+  if (badges.length === 0) {
+    return (
+      <div className="flex flex-1 items-center justify-center px-13">
+        <p className="text-body-body8 text-foreground-tertiary">등록된 뱃지가 없어요.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex w-full flex-col">
+      {badges.map((badge) => (
+        <BadgeListItem
+          key={badge.id}
+          badgeId={badge.id}
+          imageUrl={badge.imageUrl}
+          name={badge.name}
+          onClick={() => router.push(PAGE_ROUTES.BADGE_MNG.DETAIL(badge.id))}
+        />
+      ))}
+      <div ref={triggerRef} className="h-10" aria-hidden="true" />
+      {isFetchingNextPage && (
+        <div className="flex justify-center py-4" role="status" aria-label="로딩 중">
+          <div className="h-6 w-6 animate-spin rounded-full border-b-2 border-blue-600" />
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/admin/src/widgets/badge/ui/BadgeManageWidget.tsx
+++ b/apps/admin/src/widgets/badge/ui/BadgeManageWidget.tsx
@@ -1,10 +1,15 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
 import { BadgeAssignedMemberSection } from './BadgeAssignedMemberSection';
 import { BadgeBasicSection } from './BadgeBasicSection';
+import { BadgeEditActionSection } from './BadgeEditActionSection';
+import { BadgeEditBottomBar } from './BadgeEditBottomBar';
 import Loading from '@/app/loading';
 import { useBadgeDetailQuery } from '@/features/badge/model/queries/useBadgeDetailQuery';
 import { useBadgeMembersQuery } from '@/features/badge/model/queries/useBadgeMembersQuery';
+import { useBadgeEditForm } from '@/features/badge/model/useBadgeEditForm';
+import { PAGE_ROUTES } from '@/shared/config/path';
 import { ErrorState } from '@/shared/ui/error/ErrorState';
 
 type BadgeManageMode = 'detail' | 'edit';
@@ -21,8 +26,10 @@ type BadgeManageWidgetProps = {
  * 기본 정보 섹션과 부여 인원 섹션을 조합해서 렌더링한다.
  */
 export const BadgeManageWidget = ({ badgeId, mode }: BadgeManageWidgetProps) => {
+  const router = useRouter();
   const badgeQuery = useBadgeDetailQuery(badgeId);
   const membersQuery = useBadgeMembersQuery(badgeId);
+  const editForm = useBadgeEditForm(badgeId, badgeQuery.data, membersQuery.data ?? []);
 
   if (badgeQuery.isLoading || membersQuery.isLoading) {
     return <Loading />;
@@ -32,10 +39,52 @@ export const BadgeManageWidget = ({ badgeId, mode }: BadgeManageWidgetProps) => 
     return <ErrorState message="배지 정보를 불러오지 못했습니다." />;
   }
 
+  const isEdit = mode === 'edit';
+  if (isEdit && editForm.state.isLoading) {
+    return <Loading />;
+  }
+
+  const members = isEdit ? editForm.state.visibleMembers : membersQuery.data;
+  const isSubmitting = editForm.state.isSubmitting || editForm.state.isDeleting;
+
   return (
-    <div className="bg-background-normal flex min-h-full flex-col gap-15 py-11">
-      <BadgeBasicSection mode={mode} badge={badgeQuery.data} />
-      <BadgeAssignedMemberSection mode={mode} members={membersQuery.data} />
+    <div className="bg-background-normal flex min-h-full flex-col">
+      {/* 배지 기본 정보와 부여 인원 목록을 담는 본문 영역 */}
+      <div className="flex flex-1 flex-col gap-15 py-11">
+        {/* 배지 이미지/이름 영역: 상세에서는 읽기 전용, 수정에서는 입력 가능 */}
+        <BadgeBasicSection
+          mode={mode}
+          badge={badgeQuery.data}
+          form={isEdit ? editForm.state.form : undefined}
+          isSubmitting={isSubmitting}
+          onChangeName={isEdit ? editForm.actions.setBadgeName : undefined}
+          onSelectFile={isEdit ? editForm.actions.setBadgeFile : undefined}
+        />
+        {/* 배지를 부여받은 멤버 목록 영역 */}
+        <BadgeAssignedMemberSection
+          mode={mode}
+          members={members}
+          onRemoveMember={isEdit ? editForm.actions.removeMember : undefined}
+          onAddMember={
+            isEdit ? () => router.push(PAGE_ROUTES.BADGE_MNG.ASSIGN(badgeId)) : undefined
+          }
+        />
+        {/* 수정 모드에서만 노출되는 배지 삭제 액션 */}
+        {isEdit && (
+          <BadgeEditActionSection
+            isDisabled={isSubmitting}
+            onDelete={editForm.actions.handleOpenDeleteAlert}
+          />
+        )}
+      </div>
+      {/* 수정 모드에서만 노출되는 하단 고정 저장 버튼 */}
+      {isEdit && (
+        <BadgeEditBottomBar
+          canSubmit={editForm.state.canSubmit}
+          isSubmitting={isSubmitting}
+          onSubmit={editForm.actions.handleOpenSaveAlert}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 코드에 any가 사용되지 않았습니다
- [ ] 스토리북에 추가했습니다 (해당 시)
- [ ] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈

- close #595

## 📌 작업 목적

- 작업 목적을 한 줄로 요약해주세요.

## 🔨 주요 작업 내용
- 활동 배지 수정 API 레이어 추가
  - `PATCH /v1/admin/badges/{badgeId}`
  - `DELETE /v1/admin/badges/{badgeId}/members`
  - `DELETE /v1/admin/badges/{badgeId}`

- 활동 배지 수정 상태 관리 훅 추가
  - 이미지 변경
  - 배지명 변경
  - 부여 멤버 회수 예정 처리
  - 저장/삭제 확인 Alert 처리
  - 저장 성공 시 상세 페이지 이동
  - 삭제 성공 시 목록 페이지 이동

- 활동 배지 수정 화면 구현
  - 상세/수정 공통 위젯 구조 구성
  - edit 모드에서 이미지 업로드/이름 입력 활성화
  - 멤버 회수 버튼 노출
  - `추가하기` 버튼으로 배지 부여 페이지 이동
  - 배지 삭제 버튼 추가
  - 하단 고정 `수정하기` 버튼 추가

## 📷 실행 영상 또는 스크린샷

<img width="300" alt="image" src="https://github.com/user-attachments/assets/1db3f304-78f6-4fd8-b8d4-8fc27ba31c5c" />

## 💬 논의할 점
- `BadgeDetailPage`, `BadgeEditPage`는 라우트 의미를 유지하고, 실제 화면 본문은 `BadgeManageWidget`에서 `mode` 기반으로 공통 처리했습니다.
- 섹션 컴포넌트는 `widgets/badge/ui`에 배치해 이후 상세/수정 화면에서 재사용 가능하도록 구성했습니다.
- `description`, `requirement`는 화면에서 사용되지 않아`Badge` 도메인 타입에 추가하지 않고 API/feature 레이어에서만 다루도록 유지했습니다.
- 부여 멤버의 track 정보는 별도 Badge 타입을 만들지 않고 기존 Member 도메인의 `MemberTrack`을 재사용했습니다.
- 현재 배지 수정 API가 모든 필드를 요구하는 경우 부분 수정 요청이 실패하고 있어, 백엔드에 PATCH optional 처리 요청 진행했습니다.

## 🙋🏻 참고 자료

-
