### PR TITLE
[FEAT] 어드민 활동 뱃지 부여 화면 구현

### DIFF
--- a/apps/admin/src/app-pages/badge/BadgeAssignPage.tsx
+++ b/apps/admin/src/app-pages/badge/BadgeAssignPage.tsx
@@ -1,7 +1,106 @@
+'use client';
+
+import { useDebouncedValue } from '@surf/hooks';
+import { HeaderMode } from '@surf/ui/header';
+import { useToastStore } from '@surf/ui/store/toastStore';
+import { TextInput } from '@surf/ui/text-input';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { useAssignBadgeMembersMutation } from '@/features/badge/model/queries/useAssignBadgeMembersMutation';
+import { useBadgeMembersQuery } from '@/features/badge/model/queries/useBadgeMembersQuery';
+import { PAGE_ROUTES } from '@/shared/config/path';
+import { useSelectableListState } from '@/shared/hooks/useSelectableListState';
+import { BottomActionBar } from '@/shared/ui/BottomActionBar';
+import { BadgeAssignAccordionList } from '@/widgets/badge/ui/BadgeAssignAccordionList';
+import { AppHeader } from '@/widgets/header/ui/AppHeader';
+import { useMemberGenerationListQuery } from '@/widgets/member-directory/model/queries/useMemberGenerationListQuery';
+
 type BadgeAssignPageProps = {
   badgeId: number;
 };
 
 export const BadgeAssignPage = ({ badgeId }: BadgeAssignPageProps) => {
-  return <div>{badgeId} 배지 부여 페이지</div>;
+  const router = useRouter();
+  const showToast = useToastStore((s) => s.show);
+  const [keyword, setKeyword] = useState('');
+  const debouncedKeyword = useDebouncedValue(keyword, 300);
+
+  const { selectedIds, toggleSelect, resetSelectionState } = useSelectableListState<number>({
+    initialMode: 'select',
+  });
+
+  const { data: generations } = useMemberGenerationListQuery();
+  const { data: assignedMembers = [] } = useBadgeMembersQuery(badgeId);
+  const { mutateAsync: assignBadgeMembers, isPending } = useAssignBadgeMembersMutation(badgeId);
+
+  const assignedMemberIds = new Set(assignedMembers.map((member) => member.id));
+
+  const handleSubmit = async () => {
+    if (selectedIds.size === 0 || isPending) return;
+
+    try {
+      await assignBadgeMembers({ memberIds: [...selectedIds] });
+      showToast('배지가 부여되었습니다.');
+      resetSelectionState();
+      router.replace(PAGE_ROUTES.BADGE_MNG.EDIT(badgeId));
+    } catch {
+      showToast('배지 부여에 실패했습니다.');
+    }
+  };
+
+  const bottomActions = [
+    {
+      key: 'assign',
+      label: '부여하기',
+      onClick: () => void handleSubmit(),
+      disabled: selectedIds.size === 0 || isPending,
+    },
+  ];
+
+  return (
+    <>
+      <AppHeader
+        customBack={() => router.push(PAGE_ROUTES.BADGE_MNG.EDIT(badgeId))}
+        overrideHeader={{
+          mode: HeaderMode.Default,
+          title: '활동 뱃지 부여',
+          hasLeftIcon: true,
+        }}
+      />
+      <div className="flex h-full min-h-0 w-full flex-col">
+        {/* 회원 검색 입력 영역 */}
+        <div className="shrink-0 px-13">
+          <TextInput
+            mode="search"
+            placeholder="회원이름을 검색해주세요"
+            iconName="Search"
+            value={keyword}
+            onChange={(value) => setKeyword(value)}
+            aria-label="회원이름 검색"
+          />
+        </div>
+
+        {/* 현재 선택된 멤버 수 안내 영역 */}
+        <div className="shrink-0 px-13 pt-10">
+          <p className="text-body-body8 text-foreground-normal-lighter">
+            {selectedIds.size}명 선택중
+          </p>
+        </div>
+
+        {/* 기수별 멤버 목록 영역 */}
+        <BadgeAssignAccordionList
+          generations={generations}
+          keyword={debouncedKeyword}
+          selectedIds={selectedIds}
+          assignedMemberIds={assignedMemberIds}
+          onToggle={toggleSelect}
+        />
+
+        {/* 선택된 멤버에게 배지를 부여하는 하단 액션 */}
+        <div className="shrink-0">
+          <BottomActionBar actions={bottomActions} />
+        </div>
+      </div>
+    </>
+  );
 };

--- a/apps/admin/src/app-pages/badge/BadgeAssignPage.tsx
+++ b/apps/admin/src/app-pages/badge/BadgeAssignPage.tsx
@@ -1,66 +1,23 @@
 'use client';
 
-import { useDebouncedValue } from '@surf/hooks';
 import { HeaderMode } from '@surf/ui/header';
-import { useToastStore } from '@surf/ui/store/toastStore';
 import { TextInput } from '@surf/ui/text-input';
-import { useRouter } from 'next/navigation';
-import { useState } from 'react';
-import { useAssignBadgeMembersMutation } from '@/features/badge/model/queries/useAssignBadgeMembersMutation';
-import { useBadgeMembersQuery } from '@/features/badge/model/queries/useBadgeMembersQuery';
-import { PAGE_ROUTES } from '@/shared/config/path';
-import { useSelectableListState } from '@/shared/hooks/useSelectableListState';
+import { useBadgeAssignPage } from '@/app-pages/badge/model/useBadgeAssignPage';
 import { BottomActionBar } from '@/shared/ui/BottomActionBar';
 import { BadgeAssignAccordionList } from '@/widgets/badge/ui/BadgeAssignAccordionList';
 import { AppHeader } from '@/widgets/header/ui/AppHeader';
-import { useMemberGenerationListQuery } from '@/widgets/member-directory/model/queries/useMemberGenerationListQuery';
 
 type BadgeAssignPageProps = {
   badgeId: number;
 };
 
 export const BadgeAssignPage = ({ badgeId }: BadgeAssignPageProps) => {
-  const router = useRouter();
-  const showToast = useToastStore((s) => s.show);
-  const [keyword, setKeyword] = useState('');
-  const debouncedKeyword = useDebouncedValue(keyword, 300);
-
-  const { selectedIds, toggleSelect, resetSelectionState } = useSelectableListState<number>({
-    initialMode: 'select',
-  });
-
-  const { data: generations } = useMemberGenerationListQuery();
-  const { data: assignedMembers = [] } = useBadgeMembersQuery(badgeId);
-  const { mutateAsync: assignBadgeMembers, isPending } = useAssignBadgeMembersMutation(badgeId);
-
-  const assignedMemberIds = new Set(assignedMembers.map((member) => member.id));
-
-  const handleSubmit = async () => {
-    if (selectedIds.size === 0 || isPending) return;
-
-    try {
-      await assignBadgeMembers({ memberIds: [...selectedIds] });
-      showToast('배지가 부여되었습니다.');
-      resetSelectionState();
-      router.replace(PAGE_ROUTES.BADGE_MNG.EDIT(badgeId));
-    } catch {
-      showToast('배지 부여에 실패했습니다.');
-    }
-  };
-
-  const bottomActions = [
-    {
-      key: 'assign',
-      label: '부여하기',
-      onClick: () => void handleSubmit(),
-      disabled: selectedIds.size === 0 || isPending,
-    },
-  ];
+  const { state, actions } = useBadgeAssignPage(badgeId);
 
   return (
     <>
       <AppHeader
-        customBack={() => router.push(PAGE_ROUTES.BADGE_MNG.EDIT(badgeId))}
+        customBack={actions.handleBack}
         overrideHeader={{
           mode: HeaderMode.Default,
           title: '활동 뱃지 부여',
@@ -74,8 +31,8 @@ export const BadgeAssignPage = ({ badgeId }: BadgeAssignPageProps) => {
             mode="search"
             placeholder="회원이름을 검색해주세요"
             iconName="Search"
-            value={keyword}
-            onChange={(value) => setKeyword(value)}
+            value={state.keyword}
+            onChange={actions.setKeyword}
             aria-label="회원이름 검색"
           />
         </div>
@@ -83,22 +40,22 @@ export const BadgeAssignPage = ({ badgeId }: BadgeAssignPageProps) => {
         {/* 현재 선택된 멤버 수 안내 영역 */}
         <div className="shrink-0 px-13 pt-10">
           <p className="text-body-body8 text-foreground-normal-lighter">
-            {selectedIds.size}명 선택중
+            {state.selectedIds.size}명 선택중
           </p>
         </div>
 
         {/* 기수별 멤버 목록 영역 */}
         <BadgeAssignAccordionList
-          generations={generations}
-          keyword={debouncedKeyword}
-          selectedIds={selectedIds}
-          assignedMemberIds={assignedMemberIds}
-          onToggle={toggleSelect}
+          generations={state.generations}
+          keyword={state.debouncedKeyword}
+          selectedIds={state.selectedIds}
+          assignedMemberIds={state.assignedMemberIds}
+          onToggle={actions.toggleSelect}
         />
 
         {/* 선택된 멤버에게 배지를 부여하는 하단 액션 */}
         <div className="shrink-0">
-          <BottomActionBar actions={bottomActions} />
+          <BottomActionBar actions={actions.bottomActions} />
         </div>
       </div>
     </>

--- a/apps/admin/src/app-pages/badge/BadgeListPage.tsx
+++ b/apps/admin/src/app-pages/badge/BadgeListPage.tsx
@@ -1,3 +1,27 @@
+'use client';
+
+import { Fab } from '@surf/ui/fab';
+import { useRouter } from 'next/navigation';
+import { PAGE_ROUTES } from '@/shared/config/path';
+import { BadgeListWidget } from '@/widgets/badge/ui/BadgeListWidget';
+
 export const BadgeListPage = () => {
-  return <div>배지 목록 페이지</div>;
+  const router = useRouter();
+
+  return (
+    <div className="bg-background-normal relative flex h-full min-h-0 w-full flex-col">
+      <div className="min-h-0 flex-1 overflow-y-auto pb-28">
+        <BadgeListWidget />
+      </div>
+
+      <div className="pointer-events-none absolute inset-0 z-50">
+        <div className="pointer-events-auto absolute right-15 bottom-15">
+          <Fab
+            ariaLabel="신규 뱃지 생성 버튼"
+            onClick={() => router.push(PAGE_ROUTES.BADGE_MNG.CREATE)}
+          />
+        </div>
+      </div>
+    </div>
+  );
 };

--- a/apps/admin/src/app-pages/badge/model/useBadgeAssignPage.ts
+++ b/apps/admin/src/app-pages/badge/model/useBadgeAssignPage.ts
@@ -1,0 +1,101 @@
+'use client';
+
+import { useDebouncedValue } from '@surf/hooks';
+import { useAlertStore } from '@surf/ui/store/alertStore';
+import { useToastStore } from '@surf/ui/store/toastStore';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { useAssignBadgeMembersMutation } from '@/features/badge/model/queries/useAssignBadgeMembersMutation';
+import { useBadgeMembersQuery } from '@/features/badge/model/queries/useBadgeMembersQuery';
+import { PAGE_ROUTES } from '@/shared/config/path';
+import { useSelectableListState } from '@/shared/hooks/useSelectableListState';
+import { useMemberGenerationListQuery } from '@/widgets/member-directory/model/queries/useMemberGenerationListQuery';
+
+/**
+ * 배지 부여 화면의 검색, 멤버 선택, 확인 Alert, 부여 요청 플로우를 관리한다.
+ */
+export const useBadgeAssignPage = (badgeId: number) => {
+  const router = useRouter();
+  const openAlert = useAlertStore((s) => s.open);
+  const closeAlert = useAlertStore((s) => s.close);
+  const showToast = useToastStore((s) => s.show);
+  const [keyword, setKeyword] = useState('');
+  const debouncedKeyword = useDebouncedValue(keyword, 300);
+
+  const { selectedIds, toggleSelect, resetSelectionState } = useSelectableListState<number>({
+    initialMode: 'select',
+  });
+
+  const { data: generations } = useMemberGenerationListQuery();
+  const { data: assignedMembers = [] } = useBadgeMembersQuery(badgeId);
+  const { mutateAsync: assignBadgeMembers, isPending } = useAssignBadgeMembersMutation(badgeId);
+
+  const assignedMemberIds = new Set(assignedMembers.map((member) => member.id));
+
+  /** 배지 수정 화면으로 돌아간다. */
+  const handleBack = () => {
+    router.push(PAGE_ROUTES.BADGE_MNG.EDIT(badgeId));
+  };
+
+  /** 선택된 멤버들에게 배지를 부여하고 수정 화면으로 이동한다. */
+  const handleSubmit = async () => {
+    if (selectedIds.size === 0 || isPending) return;
+
+    try {
+      await assignBadgeMembers({ memberIds: [...selectedIds] });
+      showToast('배지가 부여되었습니다.');
+      resetSelectionState();
+      router.replace(PAGE_ROUTES.BADGE_MNG.EDIT(badgeId));
+    } catch {
+      showToast('배지 부여에 실패했습니다.');
+    }
+  };
+
+  /** 부여 확인 Alert을 열고 확인 시 실제 부여 요청을 실행한다. */
+  const handleOpenAssignAlert = () => {
+    if (selectedIds.size === 0 || isPending) return;
+
+    openAlert({
+      state: 'default',
+      title: '부여하시겠습니까?',
+      infoText: `부여하기 버튼을 누를 시, 선택한 ${selectedIds.size}명의 인원에게 활동 뱃지가 부여됩니다.`,
+      actions: [
+        { type: 'solid', variant: 'secondary', label: '취소', onClick: closeAlert },
+        {
+          type: 'solid',
+          variant: 'primary',
+          label: '부여하기',
+          onClick: () => {
+            closeAlert();
+            void handleSubmit();
+          },
+        },
+      ],
+    });
+  };
+
+  const bottomActions = [
+    {
+      key: 'assign',
+      label: '부여하기',
+      onClick: handleOpenAssignAlert,
+      disabled: selectedIds.size === 0 || isPending,
+    },
+  ];
+
+  return {
+    state: {
+      keyword,
+      debouncedKeyword,
+      selectedIds,
+      assignedMemberIds,
+      generations,
+    },
+    actions: {
+      setKeyword,
+      toggleSelect,
+      handleBack,
+      bottomActions,
+    },
+  };
+};

--- a/apps/admin/src/entities/badge/ui/BadgeListItem.stories.tsx
+++ b/apps/admin/src/entities/badge/ui/BadgeListItem.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { BadgeListItem } from './BadgeListItem';
+import DEFAULT_BADGE_IMAGE from '@/shared/assets/images/default-item.png';
+
+const meta: Meta<typeof BadgeListItem> = {
+  title: 'Entities/UI/Badge/BadgeListItem',
+  component: BadgeListItem,
+  args: {
+    badgeId: 1,
+    imageUrl: DEFAULT_BADGE_IMAGE.src,
+    name: '새로운 17기 환영',
+    onClick: () => {},
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof BadgeListItem>;
+
+export const Default: Story = {};

--- a/apps/admin/src/entities/badge/ui/BadgeListItem.tsx
+++ b/apps/admin/src/entities/badge/ui/BadgeListItem.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import Image from 'next/image';
+
+type BadgeListItemProps = {
+  badgeId: number;
+  imageUrl: string;
+  name: string;
+  onClick: () => void;
+};
+
+export const BadgeListItem = ({ imageUrl, name, onClick }: BadgeListItemProps) => {
+  return (
+    <button
+      type="button"
+      className="border-border-normal flex w-full items-center gap-10 border-b px-14 py-11 text-left"
+      onClick={onClick}
+    >
+      <div className="rounded-3 relative h-[3rem] w-[4.875rem]">
+        <Image src={imageUrl} alt={name} fill className="shrink-0 object-cover" />
+      </div>
+
+      <span className="text-body-body6 text-foreground-static-black min-w-0 flex-1 truncate">
+        {name}
+      </span>
+    </button>
+  );
+};

--- a/apps/admin/src/features/badge/api/assignBadge.ts
+++ b/apps/admin/src/features/badge/api/assignBadge.ts
@@ -1,0 +1,11 @@
+import { axiosInstance } from '@/shared/lib/axiosInstance';
+import { CommonResponse } from '@/shared/api/types';
+import { AssignBadgeMembersRequest } from './types';
+
+export async function assignBadgeMembers(badgeId: number, data: AssignBadgeMembersRequest) {
+  const response = await axiosInstance.post<CommonResponse<null>>(
+    `/v1/admin/badges/${badgeId}/members`,
+    data,
+  );
+  return response.data.data;
+}

--- a/apps/admin/src/features/badge/api/getBadgeList.ts
+++ b/apps/admin/src/features/badge/api/getBadgeList.ts
@@ -1,0 +1,8 @@
+import { axiosInstance } from '@/shared/lib/axiosInstance';
+import { BadgeListData, BadgeListParams, BadgeListResponse } from './types';
+
+export async function getBadgeList(params: BadgeListParams): Promise<BadgeListData> {
+  const response = await axiosInstance.get<BadgeListResponse>('/v1/admin/badges', { params });
+
+  return response.data.data;
+}

--- a/apps/admin/src/features/badge/api/types.ts
+++ b/apps/admin/src/features/badge/api/types.ts
@@ -1,3 +1,10 @@
+import { CommonResponse } from '@/shared/api/types';
+
+export interface BadgeListParams {
+  pageNum: number;
+  pageSize: number;
+}
+
 export interface CreateBadgeRequest {
   name: string;
   imageUrl: string;
@@ -8,6 +15,18 @@ export interface CreateBadgeRequest {
 export interface BadgeResDto extends CreateBadgeRequest {
   badgeId: number;
 }
+
+export interface BadgeListData {
+  content: BadgeResDto[];
+  pageNumber: number;
+  pageSize: number;
+  numberOfElements?: number;
+  isLast?: boolean;
+  hasNext?: boolean;
+  totalCount?: number;
+}
+
+export type BadgeListResponse = CommonResponse<BadgeListData>;
 
 export interface BadgeAwardedMemberResDto {
   memberId: number;

--- a/apps/admin/src/features/badge/api/types.ts
+++ b/apps/admin/src/features/badge/api/types.ts
@@ -32,3 +32,7 @@ export type UpdateBadgeRequest = Partial<CreateBadgeRequest>;
 export interface RemoveBadgeMembersRequest {
   memberIds: number[];
 }
+
+export interface AssignBadgeMembersRequest {
+  memberIds: number[];
+}

--- a/apps/admin/src/features/badge/model/queries/useAssignBadgeMembersMutation.ts
+++ b/apps/admin/src/features/badge/model/queries/useAssignBadgeMembersMutation.ts
@@ -1,0 +1,22 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { assignBadgeMembers } from '@/features/badge/api/assignBadge';
+import { AssignBadgeMembersRequest } from '@/features/badge/api/types';
+import { badgeQueryKeys } from './queryKeys';
+
+export const useAssignBadgeMembersMutation = (badgeId?: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: AssignBadgeMembersRequest) => {
+      if (!badgeId) throw new Error('INVALID_BADGE_ID');
+      return assignBadgeMembers(badgeId, data);
+    },
+    onSuccess: () => {
+      if (!badgeId) return;
+      void queryClient.invalidateQueries({ queryKey: badgeQueryKeys.members(badgeId) });
+    },
+    onError: (error) => {
+      console.error('[useAssignBadgeMembersMutation] 배지 부여 실패:', error);
+    },
+  });
+};

--- a/apps/admin/src/features/badge/model/queries/useBadgeListQuery.ts
+++ b/apps/admin/src/features/badge/model/queries/useBadgeListQuery.ts
@@ -1,0 +1,58 @@
+import { infiniteQueryOptions, useInfiniteQuery } from '@tanstack/react-query';
+import { Badge } from '@/entities/badge/model/types';
+import { getBadgeList } from '@/features/badge/api/getBadgeList';
+import {
+  createInfiniteDataSelector,
+  getNextPageNumber,
+  InfiniteSelectResult,
+  PageWithContent,
+} from '@/shared/lib/tanstack-query/infiniteQueryUtils';
+
+import { badgeQueryKeys } from './queryKeys';
+import { mapBadgeResDtoToBadge } from '../mapper';
+
+const BADGE_LIST_PAGE_SIZE = 20;
+
+export const useBadgeListQuery = () => {
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, isError, refetch } =
+    useInfiniteQuery(
+      infiniteQueryOptions<
+        PageWithContent<Badge>,
+        Error,
+        InfiniteSelectResult<Badge>,
+        ReturnType<typeof badgeQueryKeys.list>,
+        number
+      >({
+        queryKey: badgeQueryKeys.list(),
+        queryFn: async ({ pageParam = 0 }) => {
+          const response = await getBadgeList({
+            pageNum: pageParam,
+            pageSize: BADGE_LIST_PAGE_SIZE,
+          });
+          const { content, ...pageMeta } = response;
+
+          return {
+            ...pageMeta,
+            numberOfElements: pageMeta.numberOfElements ?? content.length,
+            isLast: pageMeta.isLast ?? !pageMeta.hasNext,
+            content: content.map(mapBadgeResDtoToBadge),
+          };
+        },
+        initialPageParam: 0,
+        getNextPageParam: getNextPageNumber,
+        select: createInfiniteDataSelector<Badge>(),
+        refetchOnWindowFocus: false,
+      }),
+    );
+
+  return {
+    badges: data?.items ?? [],
+    isLast: data?.isLast ?? true,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading,
+    isError,
+    refetch,
+  };
+};

--- a/apps/admin/src/widgets/badge/ui/BadgeAssignAccordionList.tsx
+++ b/apps/admin/src/widgets/badge/ui/BadgeAssignAccordionList.tsx
@@ -1,0 +1,70 @@
+import { Avatar } from '@surf/ui/avatar';
+import { RoleBadge } from '@/entities/member/ui/RoleBadge';
+import { SelectableMemberCard } from '@/entities/member/ui/SelectableMemberCard';
+import { MemberGenerationAccordion } from '@/features/member-by-generation/ui/MemberGenerationAccordion';
+
+type BadgeAssignAccordionListProps = {
+  generations: number[];
+  keyword: string;
+  selectedIds: Set<number>;
+  assignedMemberIds: Set<number>;
+  onToggle: (memberId: number) => void;
+};
+
+const ACCORDION_MAX_HEIGHT = '36vh';
+
+/**
+ * 배지 부여 화면에서 기수별 멤버 목록을 렌더링하는 아코디언 리스트.
+ *
+ * 이미 해당 배지를 부여받은 멤버는 renderItem에서 null을 반환해 목록에서 제외한다.
+ */
+export const BadgeAssignAccordionList = ({
+  generations,
+  keyword,
+  selectedIds,
+  assignedMemberIds,
+  onToggle,
+}: BadgeAssignAccordionListProps) => {
+  if (generations.length === 0) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-12">
+        <span className="text-body-body8 text-foreground-tertiary">아직 가입한 멤버가 없어요.</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="scrollbar-hide min-h-0 flex-1 overflow-y-auto">
+      {generations.map((generation) => (
+        <MemberGenerationAccordion
+          key={generation}
+          generation={generation}
+          label={`${generation}기`}
+          keyword={keyword}
+          contentMaxHeight={ACCORDION_MAX_HEIGHT}
+          renderItem={(member) => {
+            if (assignedMemberIds.has(member.id)) return null;
+
+            return (
+              <SelectableMemberCard
+                name={member.name}
+                tracks={member.tracks}
+                isSelectionEnabled={true}
+                checked={selectedIds.has(member.id)}
+                onToggle={() => onToggle(member.id)}
+                leftSlot={
+                  <Avatar
+                    size="s"
+                    alt={`${member.name} 프로필 이미지`}
+                    src={member.profileImageUrl}
+                  />
+                }
+                rightSlot={<RoleBadge type={member.role} />}
+              />
+            );
+          }}
+        />
+      ))}
+    </div>
+  );
+};

--- a/apps/admin/src/widgets/badge/ui/BadgeAssignedMemberSection.tsx
+++ b/apps/admin/src/widgets/badge/ui/BadgeAssignedMemberSection.tsx
@@ -1,5 +1,4 @@
 import { SolidButton } from '@surf/ui/button';
-import { FieldGroup } from '@surf/ui/field-group';
 import { RemovableMemberCard } from '@/entities/member/ui/RemovableMemberCard';
 import type { BadgeAwardedMember } from '@/features/badge/model/types';
 import CareerEmpty from '@/shared/assets/icons/career-empty.svg';
@@ -28,7 +27,8 @@ export const BadgeAssignedMemberSection = ({
   const isEdit = mode === 'edit';
 
   return (
-    <FieldGroup title="부여 인원" className="px-14">
+    <section className="flex flex-col gap-12">
+      <p className="text-title-title2 text-foreground-normal px-14">부여 인원</p>
       {members.length === 0 ? (
         // 부여된 멤버가 없을 때 보여주는 empty state
         <div className="flex w-full justify-center py-10">
@@ -39,7 +39,7 @@ export const BadgeAssignedMemberSection = ({
         </div>
       ) : (
         // 부여 멤버가 5명을 초과해도 섹션 높이가 커지지 않도록 내부 스크롤을 사용한다.
-        <div className="max-h-[17.5rem] w-full overflow-y-auto">
+        <div className="max-h-70 w-full overflow-y-auto">
           {members.map((member) => (
             <RemovableMemberCard
               key={member.id}
@@ -55,10 +55,12 @@ export const BadgeAssignedMemberSection = ({
       )}
       {/* 수정 모드에서 배지 부여 페이지로 이동하는 액션 */}
       {isEdit && (
-        <SolidButton size="m" variant="secondary" onClick={onAddMember} className="mt-5">
-          추가하기
-        </SolidButton>
+        <div className="px-14">
+          <SolidButton size="s" variant="secondary" onClick={onAddMember}>
+            추가하기
+          </SolidButton>
+        </div>
       )}
-    </FieldGroup>
+    </section>
   );
 };

--- a/apps/admin/src/widgets/badge/ui/BadgeListWidget.tsx
+++ b/apps/admin/src/widgets/badge/ui/BadgeListWidget.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useInfiniteScroll } from '@surf/hooks';
+import { useRouter } from 'next/navigation';
+import Loading from '@/app/loading';
+import { BadgeListItem } from '@/entities/badge/ui/BadgeListItem';
+import { useBadgeListQuery } from '@/features/badge/model/queries/useBadgeListQuery';
+import { PAGE_ROUTES } from '@/shared/config/path';
+import { ErrorState } from '@/shared/ui/error/ErrorState';
+
+export const BadgeListWidget = () => {
+  const router = useRouter();
+  const { badges, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, isError } =
+    useBadgeListQuery();
+
+  const triggerRef = useInfiniteScroll({
+    hasNextPage,
+    isFetching: isFetchingNextPage,
+    onLoadMore: () => {
+      void fetchNextPage();
+    },
+  });
+
+  if (isLoading) {
+    return <Loading />;
+  }
+
+  if (isError || !badges) {
+    return <ErrorState message="배지 목록을 불러오지 못했습니다." />;
+  }
+
+  if (badges.length === 0) {
+    return (
+      <div className="flex flex-1 items-center justify-center px-13">
+        <p className="text-body-body8 text-foreground-tertiary">등록된 뱃지가 없어요.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex w-full flex-col">
+      {badges.map((badge) => (
+        <BadgeListItem
+          key={badge.id}
+          badgeId={badge.id}
+          imageUrl={badge.imageUrl}
+          name={badge.name}
+          onClick={() => router.push(PAGE_ROUTES.BADGE_MNG.DETAIL(badge.id))}
+        />
+      ))}
+      <div ref={triggerRef} className="h-10" aria-hidden="true" />
+      {isFetchingNextPage && (
+        <div className="flex justify-center py-4" role="status" aria-label="로딩 중">
+          <div className="h-6 w-6 animate-spin rounded-full border-b-2 border-blue-600" />
+        </div>
+      )}
+    </div>
+  );
+};


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 코드에 any가 사용되지 않았습니다
- [ ] 스토리북에 추가했습니다 (해당 시)
- [ ] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈

- close #597

## 📌 작업 목적

- 배지 부여 화면 기능 구현

## 🔨 주요 작업 내용

-배지 부여 API 연동: POST /v1/admin/badges/{badgeId}/members API 함수 추가
- 배지 부여 mutation hook 추가
    - 부여 성공 시 배지 부여 인원 목록 query invalidate 처리
- 배지 부여 화면 구성
    - BadgeAssignPage에서 헤더, 검색바, 선택 인원 카운터, 기수별 멤버 아코디언, 하단 액션바 조립
    - MemberGenerationAccordion 기반으로 기수별 멤버 목록 렌더링
    - 검색어 입력 시 debounce 적용
    - 이미 해당 배지를 받은 멤버는 목록에서 제외
- 멤버 선택 및 부여 처리
    - useSelectableListState로 멤버 선택 상태 관리, 선택된 멤버 수를 검색바 하단에 {n}명 선택중으로 표시
    - BottomActionBar를 사용해 하단 부여하기 버튼 구성
    - 선택 인원이 없거나 요청 중이면 버튼 비활성화
    - 부여 성공 시 toast 노출 후 배지 수정 화면으로 이동

## 🧪 테스트 방법

- http://localhost:3000/badge-management/2 접속
- 수정 버튼 클릭
- 부여 인원 섹션 '추가하기' 버튼 클릭
- 멤버 선택 후 '부여하기' 버튼 클릭
## ✔️ 설치 라이브러리

-

## 📷 실행 영상 또는 스크린샷

https://github.com/user-attachments/assets/3c8445ed-e14c-4b51-9f7f-eeed0be712ea

## 💬 논의할 점



## 🙋🏻 참고 자료

-
