### PR TITLE
[FEAT] 어드민 활동 뱃지 목록 화면 구현

### DIFF
--- a/apps/admin/src/app-pages/badge/BadgeListPage.tsx
+++ b/apps/admin/src/app-pages/badge/BadgeListPage.tsx
@@ -1,3 +1,27 @@
+'use client';
+
+import { Fab } from '@surf/ui/fab';
+import { useRouter } from 'next/navigation';
+import { PAGE_ROUTES } from '@/shared/config/path';
+import { BadgeListWidget } from '@/widgets/badge/ui/BadgeListWidget';
+
 export const BadgeListPage = () => {
-  return <div>배지 목록 페이지</div>;
+  const router = useRouter();
+
+  return (
+    <div className="bg-background-normal relative flex h-full min-h-0 w-full flex-col">
+      <div className="min-h-0 flex-1 overflow-y-auto pb-28">
+        <BadgeListWidget />
+      </div>
+
+      <div className="pointer-events-none absolute inset-0 z-50">
+        <div className="pointer-events-auto absolute right-15 bottom-15">
+          <Fab
+            ariaLabel="신규 뱃지 생성 버튼"
+            onClick={() => router.push(PAGE_ROUTES.BADGE_MNG.CREATE)}
+          />
+        </div>
+      </div>
+    </div>
+  );
 };

--- a/apps/admin/src/entities/badge/ui/BadgeListItem.stories.tsx
+++ b/apps/admin/src/entities/badge/ui/BadgeListItem.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { BadgeListItem } from './BadgeListItem';
+import DEFAULT_BADGE_IMAGE from '@/shared/assets/images/default-item.png';
+
+const meta: Meta<typeof BadgeListItem> = {
+  title: 'Entities/UI/Badge/BadgeListItem',
+  component: BadgeListItem,
+  args: {
+    badgeId: 1,
+    imageUrl: DEFAULT_BADGE_IMAGE.src,
+    name: '새로운 17기 환영',
+    onClick: () => {},
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof BadgeListItem>;
+
+export const Default: Story = {};

--- a/apps/admin/src/entities/badge/ui/BadgeListItem.tsx
+++ b/apps/admin/src/entities/badge/ui/BadgeListItem.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import Image from 'next/image';
+
+type BadgeListItemProps = {
+  badgeId: number;
+  imageUrl: string;
+  name: string;
+  onClick: () => void;
+};
+
+export const BadgeListItem = ({ imageUrl, name, onClick }: BadgeListItemProps) => {
+  return (
+    <button
+      type="button"
+      className="border-border-normal flex w-full items-center gap-10 border-b px-14 py-11 text-left"
+      onClick={onClick}
+    >
+      <div className="rounded-3 relative h-[3rem] w-[4.875rem]">
+        <Image src={imageUrl} alt={name} fill className="shrink-0 object-cover" />
+      </div>
+
+      <span className="text-body-body6 text-foreground-static-black min-w-0 flex-1 truncate">
+        {name}
+      </span>
+    </button>
+  );
+};

--- a/apps/admin/src/features/badge/api/getBadgeList.ts
+++ b/apps/admin/src/features/badge/api/getBadgeList.ts
@@ -1,0 +1,8 @@
+import { axiosInstance } from '@/shared/lib/axiosInstance';
+import { BadgeListData, BadgeListParams, BadgeListResponse } from './types';
+
+export async function getBadgeList(params: BadgeListParams): Promise<BadgeListData> {
+  const response = await axiosInstance.get<BadgeListResponse>('/v1/admin/badges', { params });
+
+  return response.data.data;
+}

--- a/apps/admin/src/features/badge/api/types.ts
+++ b/apps/admin/src/features/badge/api/types.ts
@@ -1,3 +1,10 @@
+import { CommonResponse } from '@/shared/api/types';
+
+export interface BadgeListParams {
+  pageNum: number;
+  pageSize: number;
+}
+
 export interface CreateBadgeRequest {
   name: string;
   imageUrl: string;
@@ -8,6 +15,18 @@ export interface CreateBadgeRequest {
 export interface BadgeResDto extends CreateBadgeRequest {
   badgeId: number;
 }
+
+export interface BadgeListData {
+  content: BadgeResDto[];
+  pageNumber: number;
+  pageSize: number;
+  numberOfElements?: number;
+  isLast?: boolean;
+  hasNext?: boolean;
+  totalCount?: number;
+}
+
+export type BadgeListResponse = CommonResponse<BadgeListData>;
 
 export interface BadgeAwardedMemberResDto {
   memberId: number;

--- a/apps/admin/src/features/badge/model/queries/useBadgeListQuery.ts
+++ b/apps/admin/src/features/badge/model/queries/useBadgeListQuery.ts
@@ -1,0 +1,58 @@
+import { infiniteQueryOptions, useInfiniteQuery } from '@tanstack/react-query';
+import { Badge } from '@/entities/badge/model/types';
+import { getBadgeList } from '@/features/badge/api/getBadgeList';
+import {
+  createInfiniteDataSelector,
+  getNextPageNumber,
+  InfiniteSelectResult,
+  PageWithContent,
+} from '@/shared/lib/tanstack-query/infiniteQueryUtils';
+
+import { badgeQueryKeys } from './queryKeys';
+import { mapBadgeResDtoToBadge } from '../mapper';
+
+const BADGE_LIST_PAGE_SIZE = 20;
+
+export const useBadgeListQuery = () => {
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, isError, refetch } =
+    useInfiniteQuery(
+      infiniteQueryOptions<
+        PageWithContent<Badge>,
+        Error,
+        InfiniteSelectResult<Badge>,
+        ReturnType<typeof badgeQueryKeys.list>,
+        number
+      >({
+        queryKey: badgeQueryKeys.list(),
+        queryFn: async ({ pageParam = 0 }) => {
+          const response = await getBadgeList({
+            pageNum: pageParam,
+            pageSize: BADGE_LIST_PAGE_SIZE,
+          });
+          const { content, ...pageMeta } = response;
+
+          return {
+            ...pageMeta,
+            numberOfElements: pageMeta.numberOfElements ?? content.length,
+            isLast: pageMeta.isLast ?? !pageMeta.hasNext,
+            content: content.map(mapBadgeResDtoToBadge),
+          };
+        },
+        initialPageParam: 0,
+        getNextPageParam: getNextPageNumber,
+        select: createInfiniteDataSelector<Badge>(),
+        refetchOnWindowFocus: false,
+      }),
+    );
+
+  return {
+    badges: data?.items ?? [],
+    isLast: data?.isLast ?? true,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading,
+    isError,
+    refetch,
+  };
+};

--- a/apps/admin/src/widgets/badge/ui/BadgeListWidget.tsx
+++ b/apps/admin/src/widgets/badge/ui/BadgeListWidget.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useInfiniteScroll } from '@surf/hooks';
+import { useRouter } from 'next/navigation';
+import Loading from '@/app/loading';
+import { BadgeListItem } from '@/entities/badge/ui/BadgeListItem';
+import { useBadgeListQuery } from '@/features/badge/model/queries/useBadgeListQuery';
+import { PAGE_ROUTES } from '@/shared/config/path';
+import { ErrorState } from '@/shared/ui/error/ErrorState';
+
+export const BadgeListWidget = () => {
+  const router = useRouter();
+  const { badges, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, isError } =
+    useBadgeListQuery();
+
+  const triggerRef = useInfiniteScroll({
+    hasNextPage,
+    isFetching: isFetchingNextPage,
+    onLoadMore: () => {
+      void fetchNextPage();
+    },
+  });
+
+  if (isLoading) {
+    return <Loading />;
+  }
+
+  if (isError || !badges) {
+    return <ErrorState message="배지 목록을 불러오지 못했습니다." />;
+  }
+
+  if (badges.length === 0) {
+    return (
+      <div className="flex flex-1 items-center justify-center px-13">
+        <p className="text-body-body8 text-foreground-tertiary">등록된 뱃지가 없어요.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex w-full flex-col">
+      {badges.map((badge) => (
+        <BadgeListItem
+          key={badge.id}
+          badgeId={badge.id}
+          imageUrl={badge.imageUrl}
+          name={badge.name}
+          onClick={() => router.push(PAGE_ROUTES.BADGE_MNG.DETAIL(badge.id))}
+        />
+      ))}
+      <div ref={triggerRef} className="h-10" aria-hidden="true" />
+      {isFetchingNextPage && (
+        <div className="flex justify-center py-4" role="status" aria-label="로딩 중">
+          <div className="h-6 w-6 animate-spin rounded-full border-b-2 border-blue-600" />
+        </div>
+      )}
+    </div>
+  );
+};


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 코드에 any가 사용되지 않았습니다
- [ ] 스토리북에 추가했습니다 (해당 시)
- [ ] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈

- close #591 

## 📌 작업 목적

- 어드민 활동 뱃지 목록 화면 구현

## 🔨 주요 작업 내용

- 어드민 활동 뱃지 목록 화면 구현


## ⚠️ 기존 문제 (선택)

- 버그나 리팩토링인 경우 작성해주세요.

## ☑️ 해결 방법 (선택)

- 위 문제를 어떻게 해결했는지 요약해주세요.

## 🧪 테스트 방법

- ex. 회원가입 폼 UI 구현 시 올바른 정보 입력 시 회원가입 성공 후 홈으로 이동되는지 확인

## ✔️ 설치 라이브러리

-

## 📷 실행 영상 또는 스크린샷

<img width="300" alt="image" src="https://github.com/user-attachments/assets/1df9014e-81b8-4848-a6da-a00b07a8c671" />

## 💬 논의할 점

- 플로팅 버튼 아이콘 Edit이 해당 아이콘으로 나와서 그냥 저걸로 구현해써용.. Fab 공통 컴포넌트 활용했는데, 혹시 다른 공통 컴포넌트 있으면 알려주세요!

## 🙋🏻 참고 자료

-
