### PR TITLE
[FIX] 아코디언 높이 갱신 문제 수정

### DIFF
--- a/packages/ui/components/accordion/Accordion.tsx
+++ b/packages/ui/components/accordion/Accordion.tsx
@@ -40,7 +40,7 @@ export const Accordion = ({
 
       updateMaxHeight();
       const inner = el.firstElementChild;
-      const resizeObserver = new ResizeObserver(updateMaxHeight);
+      const resizeObserver = new ResizeObserver();
       const mutationObserver = new MutationObserver(() => {
         requestAnimationFrame(updateMaxHeight);
       });

--- a/packages/ui/components/accordion/Accordion.tsx
+++ b/packages/ui/components/accordion/Accordion.tsx
@@ -40,7 +40,7 @@ export const Accordion = ({
 
       updateMaxHeight();
       const inner = el.firstElementChild;
-      const resizeObserver = new ResizeObserver();
+      const resizeObserver = new ResizeObserver(updateMaxHeight);
       const mutationObserver = new MutationObserver(() => {
         requestAnimationFrame(updateMaxHeight);
       });

--- a/packages/ui/components/accordion/Accordion.tsx
+++ b/packages/ui/components/accordion/Accordion.tsx
@@ -34,15 +34,28 @@ export const Accordion = ({
     if (!el) return;
 
     if (isOpen) {
-      setMaxHeight(`${el.scrollHeight}px`);
-
-      const inner = el.firstElementChild;
-      const observer = new ResizeObserver(() => {
+      const updateMaxHeight = () => {
         setMaxHeight(`${el.scrollHeight}px`);
-      });
-      if (inner) observer.observe(inner);
+      };
 
-      return () => observer.disconnect();
+      updateMaxHeight();
+      const inner = el.firstElementChild;
+      const resizeObserver = new ResizeObserver(updateMaxHeight);
+      const mutationObserver = new MutationObserver(() => {
+        requestAnimationFrame(updateMaxHeight);
+      });
+      if (inner) {
+        resizeObserver.observe(inner);
+        mutationObserver.observe(inner, {
+          childList: true,
+          subtree: true,
+        });
+      }
+
+      return () => {
+        resizeObserver.disconnect();
+        mutationObserver.disconnect();
+      };
     } else {
       setMaxHeight('0px');
     }


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 코드에 any가 사용되지 않았습니다
- [ ] 스토리북에 추가했습니다 (해당 시)
- [ ] 이슈와 커밋이 명확히 연결되어 있습니다

## 📌 작업 목적

- 멤버 관리 화면에서 기수 아코디언을 펼칠 때 간헐적으로 아코디언 높이가 갱신되지 않는 문제 해결 

## 🔨 주요 작업 내용

- 아코디언에 MutationObserver 추가해 DOM 내부 요소가 변경되었을 경우도 높이 갱신할 수 있도록 수정

## ⚠️ 기존 문제 (선택)

- Accordion은 펼쳐지는 순간 scrollHeight를 한 번 측정해 maxHeight를 설정함
- 이후 높이 갱신은 ResizeObserver에 의존하고 있었음
- 멤버 목록은 아코디언이 열린 뒤 비동기로 loading -> member list로 DOM이 변경됨
- 내부 컨테이너에 maxHeight, overflow-y-auto가 있어 DOM 내용은 바뀌어도 관찰 대상의 실제 박스 크기 변화가 항상 발생하지 않음
- 그래서 ResizeObserver 콜백이 간헐적으로 실행되지 않아 maxHeight가 로딩 시점 높이로 남음
- 아코디언을 다시 접었다 펴면 이미 데이터가 로딩된 상태라 scrollHeight가 정상적으로 다시 측정됨


## ☑️ 해결 방법 (선택)

- ResizeObserver는 유지해서 실제 크기 변화 감지는 계속 처리
- 추가로 MutationObserver를 적용해 내부 DOM 구조 변경을 감지
- 자식 노드가 추가/삭제되거나 하위 DOM이 변경되면 scrollHeight를 다시 계산
- DOM 변경 직후 레이아웃 반영 타이밍을 맞추기 위해 requestAnimationFrame 안에서 maxHeight 갱신
- 결과적으로 비동기 로딩, 리스트 렌더링, 무한 스크롤 등으로 컨텐츠가 바뀌어도 열린 아코디언 높이가 다시 계산됨


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **버그 수정**
  * 아코디언 컴포넌트의 열림/닫힘 상태에서의 높이 처리 로직을 개선하여 동적 콘텐츠 변경에 더욱 정확하게 반응하도록 수정되었습니다.
  * 아코디언 내부 콘텐츠 변경 감지 성능을 향상시켰습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->