### PR TITLE
[FEAT] 어드민 멤버 관리 퇴출/제명 기능 구현

### DIFF
--- a/apps/admin/src/features/member/dismiss/api/dismissMember.ts
+++ b/apps/admin/src/features/member/dismiss/api/dismissMember.ts
@@ -1,0 +1,10 @@
+import { CommonResponse } from '@/shared/api/types';
+import { axiosInstance } from '@/shared/lib/axiosInstance';
+
+export async function dismissMember(memberId: number): Promise<null> {
+  const response = await axiosInstance.patch<CommonResponse<null>>(
+    `/v1/admin/members/${memberId}/dismiss`,
+  );
+
+  return response.data.data;
+}

--- a/apps/admin/src/features/member/dismiss/model/openDismissMemberConfirm.ts
+++ b/apps/admin/src/features/member/dismiss/model/openDismissMemberConfirm.ts
@@ -1,6 +1,6 @@
 import { AlertPayload } from '@surf/ui/store/alertStore';
 
-export function openExpelMemberConfirm({
+export function openDismissMemberConfirm({
   openAlert,
   closeAlert,
   onConfirm,
@@ -11,14 +11,14 @@ export function openExpelMemberConfirm({
 }) {
   openAlert({
     state: 'default',
-    title: '퇴출하시겠습니까?',
-    infoText: '퇴출 버튼을 누를 시 해당 멤버를 SURF에서 퇴출합니다.',
+    title: '제명하시겠습니까?',
+    infoText: '제명 버튼을 누를 시 해당 멤버를 SURF에서 제명합니다.',
     actions: [
       { type: 'solid', variant: 'secondary', label: '취소', onClick: closeAlert },
       {
         type: 'solid',
         variant: 'danger',
-        label: '퇴출하기',
+        label: '제명하기',
         onClick: () => {
           onConfirm();
           closeAlert();

--- a/apps/admin/src/features/member/dismiss/model/useDismissMemberMutation.ts
+++ b/apps/admin/src/features/member/dismiss/model/useDismissMemberMutation.ts
@@ -1,0 +1,27 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { memberQueryKeys } from '@/entities/member/model/queries/memberQueryKeys';
+import { dismissMember } from '../api/dismissMember';
+
+type DismissMembersParams = {
+  memberIds: number[];
+};
+
+export const useDismissMemberMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<null, Error, DismissMembersParams>({
+    mutationKey: ['member', 'dismiss'],
+    mutationFn: async ({ memberIds }) => {
+      await Promise.all(memberIds.map((memberId) => dismissMember(memberId)));
+      return null;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: memberQueryKeys.all });
+    },
+    onError: (error) => {
+      console.error('[Members Dismiss Error]', error.message);
+    },
+  });
+};

--- a/apps/admin/src/features/member/expel/api/expelMember.ts
+++ b/apps/admin/src/features/member/expel/api/expelMember.ts
@@ -1,0 +1,10 @@
+import { CommonResponse } from '@/shared/api/types';
+import { axiosInstance } from '@/shared/lib/axiosInstance';
+
+export async function expelMember(memberId: number): Promise<null> {
+  const response = await axiosInstance.patch<CommonResponse<null>>(
+    `/v1/admin/members/${memberId}/expel`,
+  );
+
+  return response.data.data;
+}

--- a/apps/admin/src/features/member/expel/model/useExpelMemberMutation.ts
+++ b/apps/admin/src/features/member/expel/model/useExpelMemberMutation.ts
@@ -1,0 +1,27 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { memberQueryKeys } from '@/entities/member/model/queries/memberQueryKeys';
+import { expelMember } from '../api/expelMember';
+
+type ExpelMembersParams = {
+  memberIds: number[];
+};
+
+export const useExpelMemberMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<null, Error, ExpelMembersParams>({
+    mutationKey: ['member', 'expel'],
+    mutationFn: async ({ memberIds }) => {
+      await Promise.all(memberIds.map((memberId) => expelMember(memberId)));
+      return null;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: memberQueryKeys.all });
+    },
+    onError: (error) => {
+      console.error('[Members Expel Error]', error.message);
+    },
+  });
+};

--- a/apps/admin/src/widgets/member-directory/ui/MemberDirectoryWidget.tsx
+++ b/apps/admin/src/widgets/member-directory/ui/MemberDirectoryWidget.tsx
@@ -1,9 +1,14 @@
 'use client';
 
+import { useAlertStore } from '@surf/ui/store/alertStore';
+import { useToastStore } from '@surf/ui/store/toastStore';
 import { Suspense, useEffect } from 'react';
 import { MemberGenerationAccordionList } from './MemberGenerationAccordionList';
 import { useApprovedMemberCountQuery } from '@/entities/member/model/queries/useMemberCountQuery';
+import { useDismissMemberMutation } from '@/features/member/dismiss/model/useDismissMemberMutation';
+import { useExpelMemberMutation } from '@/features/member/expel/model/useExpelMemberMutation';
 import { useSelectableListState } from '@/shared/hooks/useSelectableListState';
+import { BottomActionBar } from '@/shared/ui/BottomActionBar';
 import { ErrorBoundary } from '@/shared/ui/error/ErrorBoundary';
 import { SelectableListTopBar } from '@/shared/ui/SelectableListTopBar';
 
@@ -14,12 +19,117 @@ interface MemberDirectoryWidgetProps {
 export const MemberDirectoryWidget = ({ keyword }: MemberDirectoryWidgetProps) => {
   const { data: totalCount } = useApprovedMemberCountQuery(keyword); //승인된 전체 멤버수 조회
 
-  const { mode, selectedCount, enterSelectMode, exitSelectMode, resetSelectionState } =
-    useSelectableListState<number>();
+  const {
+    mode,
+    selectedIds,
+    selectedCount,
+    enterSelectMode,
+    exitSelectMode,
+    toggleSelect,
+    resetSelectionState,
+  } = useSelectableListState<number>();
+
+  const openAlert = useAlertStore((s) => s.open);
+  const closeAlert = useAlertStore((s) => s.close);
+  const showToast = useToastStore((s) => s.show);
+  const { mutate: dismissMembers, isPending: isDismissPending } = useDismissMemberMutation();
+  const { mutate: expelMembers, isPending: isExpelPending } = useExpelMemberMutation();
+
+  const selectedMemberIds = Array.from(selectedIds);
+  const isPending = isDismissPending || isExpelPending;
 
   useEffect(() => {
     resetSelectionState();
   }, [keyword, resetSelectionState]);
+
+  const handleDismissMembers = () => {
+    if (isPending || selectedMemberIds.length === 0) return;
+
+    dismissMembers(
+      { memberIds: selectedMemberIds },
+      {
+        onSuccess: () => {
+          showToast('선택한 멤버가 제명되었습니다.');
+          resetSelectionState();
+        },
+        onError: (error) => {
+          showToast(error.message);
+        },
+      },
+    );
+  };
+
+  const handleExpelMembers = () => {
+    if (isPending || selectedMemberIds.length === 0) return;
+
+    expelMembers(
+      { memberIds: selectedMemberIds },
+      {
+        onSuccess: () => {
+          showToast('선택한 멤버가 퇴출되었습니다.');
+          resetSelectionState();
+        },
+        onError: (error) => {
+          showToast(error.message);
+        },
+      },
+    );
+  };
+
+  const openDismissConfirm = () => {
+    openAlert({
+      state: 'default',
+      title: '선택한 멤버를 제명하시겠습니까?',
+      infoText: `제명 버튼을 누를 시 선택한 ${selectedCount}명의 멤버를 SURF에서 제명합니다.`,
+      actions: [
+        { type: 'solid', variant: 'secondary', label: '취소', onClick: closeAlert },
+        {
+          type: 'solid',
+          variant: 'danger',
+          label: '제명하기',
+          onClick: () => {
+            closeAlert();
+            handleDismissMembers();
+          },
+        },
+      ],
+    });
+  };
+
+  const openExpelConfirm = () => {
+    openAlert({
+      state: 'default',
+      title: '선택한 멤버를 퇴출하시겠습니까?',
+      infoText: `퇴출 버튼을 누를 시 선택한 ${selectedCount}명의 멤버를 SURF에서 퇴출합니다.`,
+      actions: [
+        { type: 'solid', variant: 'secondary', label: '취소', onClick: closeAlert },
+        {
+          type: 'solid',
+          variant: 'danger',
+          label: '퇴출하기',
+          onClick: () => {
+            closeAlert();
+            handleExpelMembers();
+          },
+        },
+      ],
+    });
+  };
+
+  const bottomActions = [
+    {
+      key: 'dismiss',
+      label: '제명하기',
+      disabled: selectedCount === 0 || isPending,
+      onClick: openDismissConfirm,
+    },
+    {
+      key: 'expel',
+      label: '퇴출하기',
+      disabled: selectedCount === 0 || isPending,
+      onClick: openExpelConfirm,
+    },
+  ];
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
@@ -35,9 +145,15 @@ export const MemberDirectoryWidget = ({ keyword }: MemberDirectoryWidgetProps) =
       {/* 기수별 멤버 목록 아코디언 리스트 */}
       <ErrorBoundary>
         <Suspense fallback={<div className="p-4">loading...</div>}>
-          <MemberGenerationAccordionList keyword={keyword} />
+          <MemberGenerationAccordionList
+            keyword={keyword}
+            mode={mode}
+            selectedIds={selectedIds}
+            onToggleMember={toggleSelect}
+          />
         </Suspense>
       </ErrorBoundary>
+      {mode === 'select' && <BottomActionBar actions={bottomActions} />}
     </div>
   );
 };

--- a/apps/admin/src/widgets/member-directory/ui/MemberGenerationAccordionList.tsx
+++ b/apps/admin/src/widgets/member-directory/ui/MemberGenerationAccordionList.tsx
@@ -4,14 +4,23 @@ import { useMemberGenerationListQuery } from '../model/queries/useMemberGenerati
 import { RoleBadge } from '@/entities/member/ui/RoleBadge';
 import { SelectableMemberCard } from '@/entities/member/ui/SelectableMemberCard';
 import { MemberGenerationAccordion } from '@/features/member-by-generation/ui/MemberGenerationAccordion';
+import type { SelectMode } from '@/shared/hooks/useSelectableListState';
 import { useBottomSheetStore } from '@/shared/store/bottomSheetStore';
 
 export interface MemberGenerationAccordionListProps {
   keyword: string;
+  mode: SelectMode;
+  selectedIds: Set<number>;
+  onToggleMember: (memberId: number) => void;
 }
 
 const ACCORDIAN_MAX_HEIGHT = '36vh';
-export const MemberGenerationAccordionList = ({ keyword }: MemberGenerationAccordionListProps) => {
+export const MemberGenerationAccordionList = ({
+  keyword,
+  mode,
+  selectedIds,
+  onToggleMember,
+}: MemberGenerationAccordionListProps) => {
   //기수 목록 조회
   const { data: generations } = useMemberGenerationListQuery();
 
@@ -46,8 +55,9 @@ export const MemberGenerationAccordionList = ({ keyword }: MemberGenerationAccor
             <SelectableMemberCard
               name={m.name}
               tracks={m.tracks}
-              checked={false}
-              onToggle={() => {}}
+              isSelectionEnabled={mode === 'select'}
+              checked={selectedIds.has(m.id)}
+              onToggle={() => onToggleMember(m.id)}
               leftSlot={
                 <div className="relative">
                   <Avatar src={m.profileImageUrl} size="m" />
@@ -60,13 +70,15 @@ export const MemberGenerationAccordionList = ({ keyword }: MemberGenerationAccor
               rightSlot={
                 <>
                   <RoleBadge type={m.role} />
-                  <button
-                    type="button"
-                    onClick={() => handleOpenMemberSheet(m.id)}
-                    aria-label={`${m.name} 상세 보기`}
-                  >
-                    <SurfIcon name="ChevronRight" />
-                  </button>
+                  {mode === 'view' && (
+                    <button
+                      type="button"
+                      onClick={() => handleOpenMemberSheet(m.id)}
+                      aria-label={`${m.name} 상세 보기`}
+                    >
+                      <SurfIcon name="ChevronRight" />
+                    </button>
+                  )}
                 </>
               }
             />

--- a/apps/admin/src/widgets/member-management-sheet/MemberManagementSheet.tsx
+++ b/apps/admin/src/widgets/member-management-sheet/MemberManagementSheet.tsx
@@ -4,7 +4,10 @@ import { useEffect, useState } from 'react';
 import { Sheet as ModalSheet } from 'react-modal-sheet';
 import { useMemberInfoQuery } from '@/entities/member/model/queries/useMemberInfoQuery';
 import { MemberProfileSummary } from '@/entities/member/ui/MemberProfileSummary';
+import { openDismissMemberConfirm } from '@/features/member/dismiss/model/openDismissMemberConfirm';
+import { useDismissMemberMutation } from '@/features/member/dismiss/model/useDismissMemberMutation';
 import { openExpelMemberConfirm } from '@/features/member/expel/model/openExpelMemberConfirm';
+import { useExpelMemberMutation } from '@/features/member/expel/model/useExpelMemberMutation';
 import { MemberRoleChangeField } from '@/features/member/role-change/ui/MemberRoleChangeField';
 
 declare module '@/shared/store/bottomSheetStore' {
@@ -33,6 +36,8 @@ export const MemberManagementSheet = ({
 
   const openAlert = useAlertStore((s) => s.open);
   const closeAlert = useAlertStore((s) => s.close);
+  const { mutate: dismissMember, isPending: isDismissPending } = useDismissMemberMutation();
+  const { mutate: expelMember, isPending: isExpelPending } = useExpelMemberMutation();
 
   useEffect(() => {
     if (!isOpen) {
@@ -40,8 +45,22 @@ export const MemberManagementSheet = ({
     }
   }, [isOpen]);
 
+  const handleDismiss = () => {
+    dismissMember(
+      { memberIds: [memberId] },
+      {
+        onSuccess: onClose,
+      },
+    );
+  };
+
   const handleExpel = () => {
-    // TODO: 제명 API 호출 및 에러 처리 구현 필요
+    expelMember(
+      { memberIds: [memberId] },
+      {
+        onSuccess: onClose,
+      },
+    );
   };
 
   return (
@@ -54,12 +73,24 @@ export const MemberManagementSheet = ({
         <ModalSheet.Content>
           <Sheet
             primaryBtn={{
-              label: '퇴출/제명하기',
+              label: '퇴출하기',
+              disabled: isDismissPending || isExpelPending,
               onClick: () =>
                 openExpelMemberConfirm({
                   openAlert,
                   closeAlert,
                   onConfirm: handleExpel,
+                }),
+            }}
+            secondaryBtn={{
+              label: '제명하기',
+
+              disabled: isDismissPending || isExpelPending,
+              onClick: () =>
+                openDismissMemberConfirm({
+                  openAlert,
+                  closeAlert,
+                  onConfirm: handleDismiss,
                 }),
             }}
           >


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 코드에 any가 사용되지 않았습니다
- [ ] 스토리북에 추가했습니다 (해당 시)
- [ ] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈

- close #552 

## 📌 작업 목적

- 어드민 멤버 관리 퇴출/제명 기능 구현

## 🔨 주요 작업 내용

- 퇴출/제명 API 함수 및 뮤테이션 훅 추가
- 멤버 관리 시트에 퇴출/제명 액션 구현
- 멤버관리 화면에서 인원 선택 및 선택 인원 퇴출/제명 액션 구현 

## ⚠️ 기존 문제 (선택)

- 버그나 리팩토링인 경우 작성해주세요.

## ☑️ 해결 방법 (선택)

- 위 문제를 어떻게 해결했는지 요약해주세요.

## 🧪 테스트 방법

- 어드민 멤버 관리 메뉴 접속 -> 인원 선택 후 퇴출/제명 버튼 클릭 해 기능 테스트



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 회원 제명 기능 추가 및 확인 대화상자 구현
* 회원 디렉토리에서 다중 선택 모드 추가
* 배치로 여러 회원 제명/퇴출 처리 가능
* 작업 완료 또는 오류 발생 시 토스트 알림 표시
* 회원 관리 시트에 제명/퇴출 버튼 추가 및 기존 퇴출 기능 개선

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Tave-Makers/SURF-FE/pull/604)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->