### PR TITLE
[HOTFIX] 웹 오류 수정

### DIFF
--- a/apps/web/src/app-pages/post/write/ui/PostPage.tsx
+++ b/apps/web/src/app-pages/post/write/ui/PostPage.tsx
@@ -13,7 +13,10 @@ import { getCategoriesForBoard } from '@/entities/post/model/category';
 import { POST_VALIDATION } from '@/entities/post/model/validation';
 import { PostBadge } from '@/entities/post/ui/post-badge/PostBadge';
 
+import { useAuthStore } from '@/features/auth/model/useAuthStore';
+
 import { useGetPostScheduleQuery } from '@/features/post/model/useGetPostScheduleQuery';
+import { TOOLBAR_KEY } from '@/features/post/post-editor/ui/PostEditorToolbar';
 import { usePostForm } from '@/features/post/post-form/model/usePostForm';
 import { usePostFormStore } from '@/features/post/post-form/model/usePostFormStore';
 import { usePostInitialization } from '@/features/post/post-form/model/usePostInitialization';
@@ -36,6 +39,7 @@ const PostPage = (props: PostPageProps) => {
   const postId = mode === 'edit' ? props.postId : undefined;
 
   // == Stores ==
+  const memberRole = useAuthStore((s) => s.memberRole);
   const title = usePostFormStore((s) => s.title);
   const category = usePostFormStore((s) => s.category);
   const content = usePostFormStore((s) => s.content);
@@ -146,6 +150,10 @@ const PostPage = (props: PostPageProps) => {
   const boardLabel = board ? board.label : '';
   const boardCategories = getCategoriesForBoard(Number(boardId));
 
+  const disabledToolbarKeys = [
+    ...(memberRole === 'member' || Number(boardId) === 2 ? [TOOLBAR_KEY.CALENDAR] : []),
+  ];
+
   const { MAX_TITLE_LENGTH } = POST_VALIDATION;
 
   useEffect(() => {
@@ -245,6 +253,7 @@ const PostPage = (props: PostPageProps) => {
           onScheduleRemove={handleScheduleRemove}
           onReservationClick={handleOpenReservation}
           isPublished={isPublished}
+          disabledToolbarKeys={disabledToolbarKeys}
         />
       </div>
     </div>

--- a/apps/web/src/features/laws/ui/LawBottomSheet.tsx
+++ b/apps/web/src/features/laws/ui/LawBottomSheet.tsx
@@ -63,7 +63,7 @@ export const LawBottomSheet = ({
           </Sheet>
         </ModalSheet.Content>
       </ModalSheet.Container>
-      <ModalSheet.Backdrop className="bg-effect-overlay-dim-normal pointer-events-auto touch-none" />
+      <ModalSheet.Backdrop className="bg-effect-overlay-dim-normal touch-none" onClick={() => {}} />
     </ModalSheet>
   );
 };

--- a/apps/web/src/widgets/post/post-editor/PostEditor.tsx
+++ b/apps/web/src/widgets/post/post-editor/PostEditor.tsx
@@ -9,14 +9,13 @@ import { EventCard } from '@/entities/calendar/ui/EventCard/EventCard';
 import { POST_VALIDATION } from '@/entities/post/model/validation';
 import { FileCard } from '@/entities/post/post-file/ui/FileCard';
 import { ImageList } from '@/entities/post/post-image/ui/ImageList';
-import { useAuthStore } from '@/features/auth/model/useAuthStore';
 import { useImageManager } from '@/features/image/model/useImageManager';
 import { usePostEditor } from '@/features/post/post-editor/lib/usePostEditor';
 import styles from '@/features/post/post-editor/ui/PostEditor.module.css';
 import {
   ALL_TOOLBAR_ITEMS,
   PostEditorToolbar,
-  TOOLBAR_KEY,
+  type ToolbarKey,
 } from '@/features/post/post-editor/ui/PostEditorToolbar';
 import { useFileManager } from '@/features/post/post-file/model/useFileManager';
 import { PostFormState } from '@/features/post/post-form/model/types';
@@ -31,6 +30,7 @@ export type PostEditorProps = {
   onScheduleRemove: () => void;
   onReservationClick: () => void;
   isPublished: boolean;
+  disabledToolbarKeys?: ToolbarKey[];
 };
 
 export const PostEditor = memo(
@@ -43,12 +43,12 @@ export const PostEditor = memo(
     onScheduleRemove,
     onReservationClick,
     isPublished,
+    disabledToolbarKeys = [],
   }: PostEditorProps) => {
     const showToast = useToastStore((s) => s.show);
-    const memberRole = useAuthStore((s) => s.memberRole);
 
     const toolbarItems = ALL_TOOLBAR_ITEMS.filter(
-      (item) => !(item.key === TOOLBAR_KEY.CALENDAR && memberRole === 'member'),
+      (item) => !disabledToolbarKeys.includes(item.key),
     );
 
     const {


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 any가 사용되지 않았습니다
- [ ] 스토리북에 추가했습니다 (해당 시)
- [ ] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈

- close #

## 📌 작업 목적

- 웹 오류를 수정했습니다.

## 🔨 주요 작업 내용

- 약관 동의 바텀시트가 뜬 후 뒷배경에 있는 헤더 클릭이 가능한 문제를 수정했습니다.
- post editor 툴바의 일정 연결 아이템을 board/멤버 조건에 따라 숨기는 필터링 로직을 추가했습니다.

## ⚠️ 기존 문제 (선택)

- `react-modal-sheet`의 `Backdrop`은 `onClick`/`onTap` prop이 없을 경우 `pointer-events: none`을 inline style로 강제 적용합니다. Tailwind 클래스 `pointer-events-auto`는 inline style보다 specificity가 낮아 무시되어, 백드롭이 시각적으로는 dim 처리되지만 실제 클릭 이벤트를 막지 못했습니다.
- `PostEditor` 내부에서 `useAuthStore`로 role을 직접 읽어 툴바를 필터링하고 있어, board 단위 조건이 추가될 경우 컴포넌트 내부 로직이 복잡해지는 구조였습니다.

## ☑️ 해결 방법 (선택)

- `ModalSheet.Backdrop`에 빈 `onClick={() => {}}` 핸들러를 추가해 `isClickable`이 true가 되도록 하여 `pointer-events: auto`가 정상 적용되게 했습니다.
- `PostEditor`에 `disabledToolbarKeys` prop을 추가하고 `useAuthStore` 의존성을 제거했습니다. 판단 로직은 `PostPage`로 이동하여 `memberRole === 'member'` 또는 `boardId === 2`일 때 CALENDAR 키를 숨깁니다.

## 🧪 테스트 방법

- 

## ✔️ 설치 라이브러리

-

## 📷 실행 영상 또는 스크린샷

-

## 💬 논의할 점

-

## 🙋🏻 참고 자료

-
