### PR TITLE
[HOTFIX] 서버 요청 로컬 프록시 경유 문제 수정

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,1 +1,103 @@
-# SURF-FE😁😁
+# SURF Web
+
+## Local HTTPS Setup
+
+`surf-web`는 OAuth 콜백 검증 때문에 로컬에서도 `https://tavesurf.site` 오리진으로 실행합니다.
+`dev` 스크립트는 443 포트와 `apps/web/tavesurf.site*.pem` 인증서를 사용합니다.
+
+클라이언트 요청은 `/api/proxy`를 사용하지만, Server Component와 route handler에서 실행되는 서버 fetch는 `API_BASE_URL`로 백엔드를 직접 호출합니다. 서버 내부에서 `https://tavesurf.site/api/proxy`를 다시 호출하면 로컬 인증서와 443 포트 영향을 다시 받기 때문입니다.
+
+### 1. mkcert 설치
+
+```bash
+brew install mkcert
+brew install nss # Firefox 사용 시에만
+mkcert -install
+```
+
+### 2. hosts 설정
+
+`/etc/hosts`에 로컬 도메인을 추가합니다.
+
+```bash
+sudo vi /etc/hosts
+```
+
+```txt
+127.0.0.1   tavesurf.site
+```
+
+적용 확인:
+
+```bash
+dscacheutil -q host -a name tavesurf.site
+```
+
+필요하면 DNS 캐시를 비웁니다.
+
+```bash
+sudo dscacheutil -flushcache
+sudo killall -HUP mDNSResponder
+```
+
+### 3. 인증서 생성
+
+`apps/web` 디렉토리에서 실행합니다. 생성되는 `.pem` 파일은 gitignore 대상이라 각자 로컬에서 만들어야 합니다.
+
+```bash
+cd apps/web
+mkcert tavesurf.site
+```
+
+아래 두 파일이 있어야 합니다.
+
+```txt
+tavesurf.site.pem
+tavesurf.site-key.pem
+```
+
+검증:
+
+```bash
+openssl verify -CAfile "$(mkcert -CAROOT)/rootCA.pem" tavesurf.site.pem
+openssl x509 -in tavesurf.site.pem -pubkey -noout | openssl sha256
+openssl pkey -in tavesurf.site-key.pem -pubout | openssl sha256
+```
+
+`verify`는 `OK`, 두 sha256 값은 같아야 합니다.
+
+### 4. 환경 변수
+
+`apps/web/.env.local`에 로컬 앱 URL이 아래처럼 설정되어 있어야 합니다.
+
+```env
+NEXT_PUBLIC_APP_URL=https://tavesurf.site
+```
+
+### 5. 실행
+
+루트에서 실행합니다.
+
+```bash
+pnpm dev:surf:local
+```
+
+이 스크립트는 Node 내부 `fetch()`가 mkcert 루트 CA를 신뢰하도록 `NODE_EXTRA_CA_CERTS`를 설정합니다.
+
+443 포트 점유 확인:
+
+```bash
+lsof -nP -iTCP:443 -sTCP:LISTEN
+```
+
+443 포트 권한 문제로 실패하면 아래처럼 실행합니다.
+
+```bash
+sudo -E env "PATH=$PATH" NODE_EXTRA_CA_CERTS="$(mkcert -CAROOT)/rootCA.pem" pnpm dev:surf
+```
+
+정상 실행 후 브라우저에서 접속합니다.
+
+```txt
+https://tavesurf.site
+```

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "node scripts/gen-sw.js && next dev --turbopack --experimental-https --experimental-https-cert tavesurf.site.pem --experimental-https-key tavesurf.site-key.pem --port 443",
+    "dev:local": "sh scripts/dev-local.sh",
     "build": "node scripts/gen-sw.js && next build --turbopack",
     "start": "next start",
     "lint": "eslint .",

--- a/apps/web/scripts/dev-local.sh
+++ b/apps/web/scripts/dev-local.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -eu
+
+if ! command -v mkcert >/dev/null 2>&1; then
+  echo "mkcert is required. Install it with: brew install mkcert"
+  exit 1
+fi
+
+if [ ! -f "tavesurf.site.pem" ] || [ ! -f "tavesurf.site-key.pem" ]; then
+  echo "Missing local certificates. Run from apps/web: mkcert tavesurf.site"
+  exit 1
+fi
+
+export NODE_EXTRA_CA_CERTS="$(mkcert -CAROOT)/rootCA.pem"
+
+node scripts/gen-sw.js
+next dev --turbopack --experimental-https --experimental-https-cert tavesurf.site.pem --experimental-https-key tavesurf.site-key.pem --port 443

--- a/apps/web/src/app/api/auth/apple/callback/route.ts
+++ b/apps/web/src/app/api/auth/apple/callback/route.ts
@@ -36,7 +36,6 @@ export async function POST(req: NextRequest) {
     code,
     state,
     user,
-    origin: baseUrl,
     cookieHeader: req.headers.get('cookie') ?? undefined,
   });
 

--- a/apps/web/src/app/api/auth/kakao/callback/route.ts
+++ b/apps/web/src/app/api/auth/kakao/callback/route.ts
@@ -28,7 +28,6 @@ export async function GET(req: NextRequest) {
     provider: 'kakao',
     code,
     state,
-    origin: baseUrl,
     cookieHeader: req.headers.get('cookie') ?? undefined,
   });
 

--- a/apps/web/src/features/auth/api/exchangeOAuthLogin.ts
+++ b/apps/web/src/features/auth/api/exchangeOAuthLogin.ts
@@ -1,6 +1,7 @@
 import type { OAuthLoginData } from './types';
 
 const TIMEOUT_MS = 15_000;
+const BACKEND = process.env.API_BASE_URL;
 
 type OAuthProvider = 'apple' | 'kakao';
 
@@ -8,7 +9,6 @@ type ExchangeOAuthLoginParams = {
   provider: OAuthProvider;
   code: string;
   state: string;
-  origin: string;
   cookieHeader?: string;
   user?: string;
 };
@@ -38,12 +38,12 @@ const PROVIDER_CONFIG: Record<
 > = {
   apple: {
     method: 'POST',
-    endpoint: '/api/proxy/login/oauth2/code/apple',
+    endpoint: '/login/oauth2/code/apple',
     label: '애플',
   },
   kakao: {
     method: 'GET',
-    endpoint: '/api/proxy/login/oauth2/code/kakao',
+    endpoint: '/login/oauth2/code/kakao',
     label: '카카오',
   },
 };
@@ -64,15 +64,15 @@ export async function exchangeOAuthLogin({
   code,
   state,
   user,
-  origin,
   cookieHeader,
 }: ExchangeOAuthLoginParams): Promise<ExchangeOAuthLoginResult> {
   const config = PROVIDER_CONFIG[provider];
-  const url = new URL(config.endpoint, origin);
-  url.searchParams.set('code', code);
-  url.searchParams.set('state', state);
 
   try {
+    const url = buildBackendUrl(config.endpoint);
+    url.searchParams.set('code', code);
+    url.searchParams.set('state', state);
+
     const headers: Record<string, string> = { 'X-Client-Type': 'WEB' };
     if (cookieHeader) headers['Cookie'] = cookieHeader;
 
@@ -89,6 +89,7 @@ export async function exchangeOAuthLogin({
       headers,
       body,
       cache: 'no-store',
+      redirect: 'manual',
     });
 
     const text = await upstream.text();
@@ -100,6 +101,14 @@ export async function exchangeOAuthLogin({
     }
 
     if (!upstream.ok) {
+      logOAuthFailure('upstream-error', {
+        provider,
+        status: upstream.status,
+        contentType: upstream.headers.get('content-type'),
+        bodyLength: text.length,
+        parsedShape: summarizeParsed(parsed),
+      });
+
       return {
         ok: false,
         message: getOAuthLoginErrorMessage(provider, upstream.status),
@@ -109,11 +118,21 @@ export async function exchangeOAuthLogin({
 
     const loginData = extractLoginData(parsed);
     if (!loginData) {
+      logOAuthFailure('invalid-response-shape', {
+        provider,
+        parsedShape: summarizeParsed(parsed),
+      });
+
       return { ok: false, message: '로그인 응답이 비어있어요.' };
     }
 
     return { ok: true, data: loginData, upstream, parsed };
-  } catch {
+  } catch (error) {
+    logOAuthFailure('fetch-error', {
+      provider,
+      message: safeErrorMessage(error),
+    });
+
     return {
       ok: false,
       message: `${config.label} 로그인 중 문제가 발생했어요. 잠시 후 다시 시도해주세요.`,
@@ -138,6 +157,50 @@ function extractLoginData(parsed: unknown): OAuthLoginData | null {
 
 function isRecord(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null;
+}
+
+function buildBackendUrl(endpoint: string) {
+  if (!BACKEND) {
+    throw new Error('API_BASE_URL is not configured');
+  }
+
+  const base = BACKEND.replace(/\/+$/, '');
+  return new URL(endpoint, `${base}/`);
+}
+
+function logOAuthFailure(event: string, payload: Record<string, unknown>) {
+  if (process.env.NODE_ENV === 'production') return;
+
+  console.warn(`[OAuthLogin] ${event}`, payload);
+}
+
+function summarizeParsed(parsed: unknown) {
+  if (!isRecord(parsed)) {
+    return { type: parsed === null ? 'null' : typeof parsed };
+  }
+
+  const data = isRecord(parsed.data) ? parsed.data : null;
+
+  return {
+    type: 'object',
+    keys: Object.keys(parsed),
+    dataKeys: data ? Object.keys(data) : undefined,
+    hasEmail: data ? typeof data.email === 'string' : typeof parsed.email === 'string',
+    hasAccessToken: data
+      ? typeof data.accessToken === 'string'
+      : typeof parsed.accessToken === 'string',
+  };
+}
+
+function safeErrorMessage(error: unknown) {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
 }
 
 function getOAuthLoginErrorMessage(provider: OAuthProvider, status: number) {

--- a/apps/web/src/shared/api/serverFetchWithCookies.ts
+++ b/apps/web/src/shared/api/serverFetchWithCookies.ts
@@ -1,11 +1,21 @@
 import 'server-only';
 import { cookies } from 'next/headers';
 import type { ServerFetchOptions } from './types';
-import { getAppOrigin } from '@/shared/lib/appOrigin';
 
-function toProxyPath(path: string): string {
+const BACKEND = process.env.API_BASE_URL;
+
+function toBackendPath(path: string): string {
   const p = path.startsWith('/') ? path : `/${path}`;
-  return p.startsWith('/api/proxy') ? p : `/api/proxy${p}`;
+  return p.startsWith('/api/proxy') ? p.replace(/^\/api\/proxy/, '') || '/' : p;
+}
+
+function buildBackendUrl(path: string): string {
+  if (!BACKEND) {
+    throw new Error('API_BASE_URL is not configured');
+  }
+
+  const base = BACKEND.replace(/\/+$/, '');
+  return `${base}${toBackendPath(path)}`;
 }
 
 function buildCookieHeader(store: { getAll(): { name: string; value: string }[] }) {
@@ -16,16 +26,21 @@ function buildCookieHeader(store: { getAll(): { name: string; value: string }[] 
 }
 
 export async function serverFetchWithCookies(path: string, options: ServerFetchOptions = {}) {
-  const baseUrl = await getAppOrigin();
-  const url = `${baseUrl}${toProxyPath(path)}`;
+  const url = buildBackendUrl(path);
 
   const cookieStore = await cookies();
   const cookie = buildCookieHeader(cookieStore);
+  const accessToken = cookieStore.get('accessToken')?.value;
 
   const headersObj: Record<string, string> = {
+    'X-Client-Type': 'WEB',
     ...(options.headers ?? {}),
     ...(cookie ? { cookie } : {}),
   };
+
+  if (accessToken && !headersObj.authorization && !headersObj.Authorization) {
+    headersObj.authorization = `Bearer ${accessToken}`;
+  }
 
   return fetch(url, {
     ...options,

--- a/apps/web/src/shared/lib/dal.ts
+++ b/apps/web/src/shared/lib/dal.ts
@@ -4,12 +4,13 @@ import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import type { ValidStatusResponse } from '@/features/auth/api/types';
 import { PAGE_ROUTES } from '@/shared/config/path';
-import { getAppOrigin } from '@/shared/lib/appOrigin';
+import { extractAccessToken } from '@/shared/lib/proxyCookie';
 
 const TIMEOUT_MS = 15_000;
+const BACKEND = process.env.API_BASE_URL;
 
-const VALID_PATH = '/api/proxy/v1/user/members/valid-status';
-const REFRESH_PATH = '/api/proxy/auth/refresh';
+const VALID_PATH = '/v1/user/members/valid-status';
+const REFRESH_PATH = '/auth/refresh';
 
 async function fetchWithTimeout(url: string, init: RequestInit) {
   const controller = new AbortController();
@@ -39,12 +40,50 @@ function safeErrorMessage(e: unknown): string {
   }
 }
 
-async function getBaseUrl(): Promise<string> {
-  return getAppOrigin();
+function buildBackendUrl(path: string): string {
+  if (!BACKEND) {
+    throw new Error('API_BASE_URL is not configured');
+  }
+
+  const base = BACKEND.replace(/\/+$/, '');
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  return `${base}${normalizedPath}`;
 }
 
 function buildCookieHeaderFromStore(all: { name: string; value: string }[]) {
   return all.map((c) => `${c.name}=${c.value}`).join('; ');
+}
+
+function getCookieValue(cookieHeader: string, targetName: string): string | null {
+  for (const part of cookieHeader.split(';')) {
+    const p = part.trim();
+    if (!p) continue;
+
+    const eq = p.indexOf('=');
+    if (eq === -1) continue;
+
+    const name = p.slice(0, eq).trim();
+    if (name === targetName) return p.slice(eq + 1);
+  }
+
+  return null;
+}
+
+function buildAuthHeaders(cookieHeader: string): Record<string, string> {
+  const headers: Record<string, string> = {
+    'X-Client-Type': 'WEB',
+  };
+
+  if (cookieHeader) {
+    headers.cookie = cookieHeader;
+  }
+
+  const accessToken = getCookieValue(cookieHeader, 'accessToken');
+  if (accessToken) {
+    headers.authorization = `Bearer ${accessToken}`;
+  }
+
+  return headers;
 }
 
 function mergeCookieHeaderWithSetCookie(origHeader: string, setCookies: string[]) {
@@ -90,14 +129,12 @@ function getSetCookieHeaders(res: Response): string[] {
 
 export const verifySession = cache(async function verifySession() {
   try {
-    const baseUrl = await getBaseUrl();
-
     const cookieStore = await cookies();
     const cookieHeader = buildCookieHeaderFromStore(cookieStore.getAll());
 
-    const res = await fetchWithTimeout(`${baseUrl}${VALID_PATH}`, {
+    const res = await fetchWithTimeout(buildBackendUrl(VALID_PATH), {
       cache: 'no-store',
-      headers: cookieHeader ? { cookie: cookieHeader } : {},
+      headers: buildAuthHeaders(cookieHeader),
     });
 
     // 최초 검증 성공
@@ -109,20 +146,35 @@ export const verifySession = cache(async function verifySession() {
 
     // 401이면 refresh -> retry
     if (res.status === 401) {
-      const refresh = await fetchWithTimeout(`${baseUrl}${REFRESH_PATH}`, {
+      const refresh = await fetchWithTimeout(buildBackendUrl(REFRESH_PATH), {
         method: 'POST',
         cache: 'no-store',
-        headers: cookieHeader ? { cookie: cookieHeader } : {},
+        headers: buildAuthHeaders(cookieHeader),
       });
 
       if (!refresh.ok) redirect(PAGE_ROUTES.LOGIN);
 
       const setCookies = getSetCookieHeaders(refresh);
-      const newCookieHeader = mergeCookieHeaderWithSetCookie(cookieHeader, setCookies);
+      const refreshText = await refresh.text();
+      let parsedRefresh: unknown = null;
+      try {
+        parsedRefresh = refreshText ? JSON.parse(refreshText) : null;
+      } catch {
+        parsedRefresh = null;
+      }
 
-      const retry = await fetchWithTimeout(`${baseUrl}${VALID_PATH}`, {
+      const refreshedAccessToken = extractAccessToken(parsedRefresh);
+      const refreshedSetCookies = refreshedAccessToken
+        ? [`accessToken=${refreshedAccessToken}; Path=/`]
+        : [];
+      const newCookieHeader = mergeCookieHeaderWithSetCookie(cookieHeader, [
+        ...setCookies,
+        ...refreshedSetCookies,
+      ]);
+
+      const retry = await fetchWithTimeout(buildBackendUrl(VALID_PATH), {
         cache: 'no-store',
-        headers: newCookieHeader ? { cookie: newCookieHeader } : {},
+        headers: buildAuthHeaders(newCookieHeader),
       });
 
       if (!retry.ok) redirect(PAGE_ROUTES.LOGIN);

--- a/apps/web/src/shared/ui/action-bar/ActionBar.tsx
+++ b/apps/web/src/shared/ui/action-bar/ActionBar.tsx
@@ -30,10 +30,11 @@ interface ActionBarProps {
   onChange?: (val: string) => void;
   placeholder?: string;
   onSend?: (val: string) => void | boolean | Promise<void | boolean>;
+  focusAfterSend?: boolean;
 }
 
 export const ActionBar = forwardRef<HTMLTextAreaElement, ActionBarProps>(
-  ({ value, defaultValue, onChange, placeholder, onSend }, ref) => {
+  ({ value, defaultValue, onChange, placeholder, onSend, focusAfterSend = true }, ref) => {
     const internalRef = useRef<HTMLTextAreaElement>(null);
     useImperativeHandle(ref, () => internalRef.current as HTMLTextAreaElement);
 
@@ -59,7 +60,11 @@ export const ActionBar = forwardRef<HTMLTextAreaElement, ActionBarProps>(
         internalRef.current.dispatchEvent(new Event('input', { bubbles: true }));
       }
 
-      internalRef.current?.focus(); // 포커스 유지
+      if (focusAfterSend) {
+        internalRef.current?.focus();
+      } else {
+        internalRef.current?.blur();
+      }
     };
 
     const handleSend = () => {

--- a/apps/web/src/widgets/comment-composer/ui/CommentComposer.tsx
+++ b/apps/web/src/widgets/comment-composer/ui/CommentComposer.tsx
@@ -259,6 +259,7 @@ export const CommentComposer = ({
             onChange={onChange}
             placeholder={replyParentId ? '답글을 입력해주세요' : '댓글을 입력해주세요'}
             onSend={onSend}
+            focusAfterSend={false}
           />
         </div>
       </div>

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "build": "turbo run build",
     "dev": "turbo run dev",
+    "dev:surf:local": "pnpm --filter surf-web dev:local",
     "lint": "turbo run lint",
     "lint:fix": "turbo run lint -- --fix",
     "format": "pnpm -w exec prettier --write .",


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 코드에 any가 사용되지 않았습니다
- [ ] 스토리북에 추가했습니다 (해당 시)
- [ ] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈

- close #

## 📌 작업 목적

- 작업 목적을 한 줄로 요약해주세요.

## 🔨 주요 작업 내용

- 서버 요청 로컬 프록시 경유 문제 수정

## ⚠️ 기존 문제 (선택)

- 로컬 도메인 변경 이후 로그인 시 OAuth code 교환, 홈 데이터 조회, 세션 검증 단계에서 `fetch failed`, `UNABLE_TO_VERIFY_LEAF_SIGNATURE` 계열 문제가 발생했고, 결과적으로 로그인 페이지로 다시 이동했습니다.

## ☑️ 해결 방법 (선택)

**원인: AS-IS 구조**
서버 코드가 백엔드를 직접 호출하지 않고 `NEXT_PUBLIC_APP_URL=https://tavesurf.site` 기반의 로컬 앱 오리진으로 다시 요청했습니다.

```txt
Server Runtime
 -> https://tavesurf.site/api/proxy/...
 -> Next.js proxy route
 -> API_BASE_URL backend
```

이 구조는 로컬에서 Node `fetch()`가 mkcert 인증서를 별도로 신뢰해야 하고, 443 포트/로컬 도메인/self-fetch 영향을 그대로 받습니다. 브라우저에서 인증서가 정상이어도 서버 런타임은 별도 신뢰 체계라서 실패할 수 있습니다.

**해결 방법: TO-BE 구조**
클라이언트와 서버 요청 경로를 분리합니다.

```txt
Client Component / Browser
 -> /api/proxy/...
 -> API_BASE_URL backend

Server Component / Route Handler / DAL
 -> API_BASE_URL backend
```

적용 방향:
- 서버 요청은 `API_BASE_URL` 직접 호출
- 서버 요청에는 `cookie`, `X-Client-Type: WEB`, 필요 시 `Authorization: Bearer accessToken` 포함
- 클라이언트 요청은 기존처럼 `/api/proxy` 유지
- OAuth callback의 code exchange도 route handler 내부 서버 요청이므로 백엔드 직접 호출
- 보호 라우트 세션 검증 `dal.ts`도 백엔드 직접 호출

## 🧪 테스트 방법

-  로컬 로그인 정상 작동 여부 확인 

## ✔️ 설치 라이브러리

-

## 📷 실행 영상 또는 스크린샷

-

## 💬 논의할 점

-

## 🙋🏻 참고 자료

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 로컬 HTTPS 환경에서 `surf-web`을 실행할 수 있는 개발 설정과 실행 명령을 추가했습니다.
  - 댓글 및 답글 전송 후 입력창 포커스가 자동으로 이동하지 않도록 개선했습니다.

- **버그 수정**
  - OAuth 로그인과 인증 갱신 과정의 쿠키·액세스 토큰 처리를 개선했습니다.
  - 백엔드 직접 통신 및 실패 상황의 오류 처리를 안정화했습니다.

- **문서**
  - 로컬 인증서 발급, 호스트 설정, 실행 방법을 포함한 HTTPS 개발 가이드를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->