### PR TITLE
[FIX] 게시글, 댓글 동기화 관련 QA 대응 

### DIFF
--- a/apps/admin/src/app-pages/badge/BadgeAssignPage.tsx
+++ b/apps/admin/src/app-pages/badge/BadgeAssignPage.tsx
@@ -20,7 +20,7 @@ export const BadgeAssignPage = ({ badgeId }: BadgeAssignPageProps) => {
         customBack={actions.handleBack}
         overrideHeader={{
           mode: HeaderMode.Default,
-          title: '활동 뱃지 부여',
+          title: '활동 배지 부여',
           hasLeftIcon: true,
         }}
       />

--- a/apps/admin/src/app-pages/badge/BadgeCreatePage.tsx
+++ b/apps/admin/src/app-pages/badge/BadgeCreatePage.tsx
@@ -14,7 +14,7 @@ export const BadgeCreatePage = () => {
   return (
     <div className="border-border-normal bg-background-normal flex min-h-dvh flex-col border-t-[0.4px]">
       <div className="flex flex-1 flex-col gap-18 px-13 py-11">
-        <FieldGroup title="뱃지 이미지 등록">
+        <FieldGroup title="배지 이미지 등록">
           <ImgUploader
             mode="create"
             onSelectFile={actions.setBadgeFile}
@@ -25,7 +25,7 @@ export const BadgeCreatePage = () => {
           />
         </FieldGroup>
 
-        <FieldGroup title="뱃지 이름" isRequired>
+        <FieldGroup title="배지 이름" isRequired>
           <TextArea
             mode="oneLine"
             value={state.badgeName}

--- a/apps/admin/src/app-pages/badge/BadgeDetailPage.tsx
+++ b/apps/admin/src/app-pages/badge/BadgeDetailPage.tsx
@@ -19,7 +19,7 @@ export const BadgeDetailPage = ({ badgeId }: BadgeDetailPageProps) => {
         customBack={() => router.push(PAGE_ROUTES.BADGE_MNG.LIST)}
         overrideHeader={{
           mode: HeaderMode.TextBtn,
-          title: '활동 뱃지 관리',
+          title: '활동 배지 관리',
           hasLeftIcon: true,
           text: '수정',
           btnVariant: 'primary',

--- a/apps/admin/src/app-pages/badge/BadgeEditPage.tsx
+++ b/apps/admin/src/app-pages/badge/BadgeEditPage.tsx
@@ -19,7 +19,7 @@ export const BadgeEditPage = ({ badgeId }: BadgeEditPageProps) => {
         customBack={() => router.push(PAGE_ROUTES.BADGE_MNG.DETAIL(badgeId))}
         overrideHeader={{
           mode: HeaderMode.Default,
-          title: '활동 뱃지 관리',
+          title: '활동 배지 관리',
           hasLeftIcon: true,
         }}
       />

--- a/apps/admin/src/app-pages/badge/BadgeListPage.tsx
+++ b/apps/admin/src/app-pages/badge/BadgeListPage.tsx
@@ -17,7 +17,7 @@ export const BadgeListPage = () => {
       <div className="pointer-events-none absolute inset-0 z-50">
         <div className="pointer-events-auto absolute right-15 bottom-15">
           <Fab
-            ariaLabel="신규 뱃지 생성 버튼"
+            ariaLabel="신규 배지 생성 버튼"
             onClick={() => router.push(PAGE_ROUTES.BADGE_MNG.CREATE)}
           />
         </div>

--- a/apps/admin/src/app-pages/badge/model/useBadgeAssignPage.ts
+++ b/apps/admin/src/app-pages/badge/model/useBadgeAssignPage.ts
@@ -58,7 +58,7 @@ export const useBadgeAssignPage = (badgeId: number) => {
     openAlert({
       state: 'default',
       title: '부여하시겠습니까?',
-      infoText: `부여하기 버튼을 누를 시, 선택한 ${selectedIds.size}명의 인원에게 활동 뱃지가 부여됩니다.`,
+      infoText: `부여하기 버튼을 누를 시, 선택한 ${selectedIds.size}명의 인원에게 활동 배지가 부여됩니다.`,
       actions: [
         { type: 'solid', variant: 'secondary', label: '취소', onClick: closeAlert },
         {

--- a/apps/admin/src/features/badge/model/useBadgeEditForm.ts
+++ b/apps/admin/src/features/badge/model/useBadgeEditForm.ts
@@ -187,7 +187,7 @@ export const useBadgeEditForm = (
       state: 'default',
       title: '삭제하시겠습니까?',
       infoText:
-        '삭제하기 버튼을 누를 시, 해당 뱃지 데이터와 함께 부여된 회원들의 뱃지 목록에서도 해당 뱃지가 삭제됩니다.',
+        '삭제하기 버튼을 누를 시, 해당 배지 데이터와 함께 부여된 회원들의 배지 목록에서도 해당 배지가 삭제됩니다.',
       actions: [
         { type: 'solid', variant: 'secondary', label: '취소', onClick: closeAlert },
         {

--- a/apps/admin/src/shared/config/routes.tsx
+++ b/apps/admin/src/shared/config/routes.tsx
@@ -78,7 +78,7 @@ export const createRouteConfig = (_router: RouterInstance): RouteConfig[] => [
     backPath: PAGE_ROUTES.HOME,
     header: {
       mode: HeaderMode.Default,
-      title: '활동 뱃지 관리',
+      title: '활동 배지 관리',
       hasLeftIcon: true,
     },
   },
@@ -88,7 +88,7 @@ export const createRouteConfig = (_router: RouterInstance): RouteConfig[] => [
     backPath: PAGE_ROUTES.BADGE_MNG.LIST,
     header: {
       mode: HeaderMode.Default,
-      title: '신규 뱃지 생성',
+      title: '신규 배지 생성',
       hasLeftIcon: true,
     },
   },

--- a/apps/admin/src/widgets/badge/ui/BadgeBasicSection.tsx
+++ b/apps/admin/src/widgets/badge/ui/BadgeBasicSection.tsx
@@ -38,7 +38,7 @@ export const BadgeBasicSection = ({
   return (
     <>
       {/* 배지 이미지 표시/수정 영역 */}
-      <FieldGroup title="뱃지 이미지 등록" className="px-13">
+      <FieldGroup title="배지 이미지 등록" className="px-13">
         {isEdit && onSelectFile ? (
           <ImgUploader
             mode="edit"
@@ -65,7 +65,7 @@ export const BadgeBasicSection = ({
       </FieldGroup>
 
       {/* 배지 이름 표시/수정 영역 */}
-      <FieldGroup title="뱃지 이름" className="px-13">
+      <FieldGroup title="배지 이름" className="px-13">
         {isEdit && onChangeName ? (
           <TextArea
             mode="oneLine"

--- a/apps/admin/src/widgets/badge/ui/BadgeEditActionSection.tsx
+++ b/apps/admin/src/widgets/badge/ui/BadgeEditActionSection.tsx
@@ -16,7 +16,7 @@ export const BadgeEditActionSection = ({
     // 배지 자체를 삭제하는 위험 액션 영역
     <div className="px-13">
       <SolidButton size="m" variant="warning" isDisabled={isDisabled} onClick={onDelete}>
-        해당 뱃지 삭제하기
+        해당 배지 삭제하기
       </SolidButton>
     </div>
   );

--- a/apps/admin/src/widgets/badge/ui/BadgeListWidget.tsx
+++ b/apps/admin/src/widgets/badge/ui/BadgeListWidget.tsx
@@ -32,7 +32,7 @@ export const BadgeListWidget = () => {
   if (badges.length === 0) {
     return (
       <div className="flex flex-1 items-center justify-center px-13">
-        <p className="text-body-body8 text-foreground-tertiary">등록된 뱃지가 없어요.</p>
+        <p className="text-body-body8 text-foreground-tertiary">등록된 배지가 없어요.</p>
       </div>
     );
   }

--- a/apps/web/src/app-pages/post/PostDetailPage.tsx
+++ b/apps/web/src/app-pages/post/PostDetailPage.tsx
@@ -210,6 +210,12 @@ const PostDetailPage = ({ postId }: PostDetailPageProps) => {
                 postId={numericPostId}
                 memberId={memberId ?? undefined}
                 scrollRootRef={scrollRootRef}
+                isInteractionDisabled={post.isReserved}
+                emptyMessage={
+                  post.isReserved
+                    ? '예약 게시물에는 댓글을 남길 수 없어요'
+                    : '첫 댓글을 남겨보세요!'
+                }
                 onStartReply={handleStartReply}
               />
             </div>
@@ -217,12 +223,14 @@ const PostDetailPage = ({ postId }: PostDetailPageProps) => {
         </div>
 
         {/* 댓글 입력창 */}
-        <CommentComposer
-          postId={numericPostId}
-          keyboardOffset={keyboardOffset}
-          pendingReply={pendingReply}
-          onConsumedReply={handleConsumedReply}
-        />
+        {!post.isReserved && (
+          <CommentComposer
+            postId={numericPostId}
+            keyboardOffset={keyboardOffset}
+            pendingReply={pendingReply}
+            onConsumedReply={handleConsumedReply}
+          />
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/app-pages/post/write/ui/PostPage.tsx
+++ b/apps/web/src/app-pages/post/write/ui/PostPage.tsx
@@ -18,10 +18,12 @@ import { useAuthStore } from '@/features/auth/model/useAuthStore';
 import { useGetPostScheduleQuery } from '@/features/post/model/useGetPostScheduleQuery';
 import { TOOLBAR_KEY } from '@/features/post/post-editor/ui/PostEditorToolbar';
 import { usePostForm } from '@/features/post/post-form/model/usePostForm';
+import { usePostFormExitGuard } from '@/features/post/post-form/model/usePostFormExitGuard';
 import { usePostFormStore } from '@/features/post/post-form/model/usePostFormStore';
 import { usePostInitialization } from '@/features/post/post-form/model/usePostInitialization';
 import { useCreatePostScheduleStore } from '@/features/schedule/create-post-schedule/model/useCreatePostScheduleStore';
 
+import { PAGE_ROUTES } from '@/shared/config/path';
 import { useBottomSheetStore } from '@/shared/store/bottomSheetStore';
 import { AppHeader } from '@/widgets/header/ui/AppHeader';
 import { PostEditor } from '@/widgets/post/post-editor/PostEditor';
@@ -79,7 +81,7 @@ const PostPage = (props: PostPageProps) => {
     showExitAlert,
     setShowExitAlert,
     isSubmitDisabled,
-    handleBack,
+    hasUnsavedChanges,
     handleSubmit,
     resetPostState,
     isPublished,
@@ -108,6 +110,26 @@ const PostPage = (props: PostPageProps) => {
     setShowExitAlert(false);
     closeAlert();
   }, [closeAlert, setShowExitAlert]);
+
+  const navigateOut = useCallback(() => {
+    resetPostState();
+
+    if (mode === 'edit' && postId) {
+      router.push(PAGE_ROUTES.BOARD.POST_DETAIL(boardId, postId));
+      return;
+    }
+
+    router.push(PAGE_ROUTES.BOARD.SELECT_CATEGORY(boardId));
+  }, [boardId, mode, postId, resetPostState, router]);
+
+  const requestExit = useCallback(() => {
+    if (hasUnsavedChanges()) {
+      setShowExitAlert(true);
+      return;
+    }
+
+    navigateOut();
+  }, [hasUnsavedChanges, navigateOut, setShowExitAlert]);
 
   const handleSaveReservation = (date: Date) => {
     setField('reservedAt', date);
@@ -149,9 +171,11 @@ const PostPage = (props: PostPageProps) => {
   const board = POST_BOARDS.find((b) => b.id === Number(boardId));
   const boardLabel = board ? board.label : '';
   const boardCategories = getCategoriesForBoard(Number(boardId));
+  const isGeneralBoard = Number(boardId) === 2;
+  const canUseReservationTools = memberRole !== 'member' && !isGeneralBoard;
 
   const disabledToolbarKeys = [
-    ...(memberRole === 'member' || Number(boardId) === 2 ? [TOOLBAR_KEY.CALENDAR] : []),
+    ...(!canUseReservationTools ? [TOOLBAR_KEY.ALARM, TOOLBAR_KEY.CALENDAR] : []),
   ];
 
   const { MAX_TITLE_LENGTH } = POST_VALIDATION;
@@ -170,14 +194,19 @@ const PostPage = (props: PostPageProps) => {
           variant: 'danger',
           onClick: () => {
             closeExitAlert();
-            resetPostState();
-            router.back();
+            navigateOut();
           },
         },
       ],
     });
     setShowExitAlert(false);
-  }, [closeExitAlert, openAlert, resetPostState, router, setShowExitAlert, showExitAlert]);
+  }, [closeExitAlert, navigateOut, openAlert, setShowExitAlert, showExitAlert]);
+
+  usePostFormExitGuard({
+    enabled: isInitialized,
+    hasUnsavedChanges,
+    onRequestExit: requestExit,
+  });
 
   if (!isInitialized) return <Loading />;
 
@@ -185,7 +214,7 @@ const PostPage = (props: PostPageProps) => {
     <div className="flex h-full w-full flex-1 flex-col">
       {/* 1. 상단 헤더 */}
       <AppHeader
-        customBack={handleBack}
+        customBack={requestExit}
         overrideHeader={{
           mode: HeaderMode.TextBtn,
           title: boardLabel,
@@ -222,8 +251,15 @@ const PostPage = (props: PostPageProps) => {
 
       {/* 예약중 태그 */}
       {reserved && (
-        <div className="px-13 pt-10">
+        <div className="flex items-center gap-8 px-13 pt-10">
           <PostBadge type="reservation" />
+          <button
+            type="button"
+            onClick={handleRemoveReservation}
+            className="text-caption-caption5 text-foreground-tertiary underline underline-offset-2"
+          >
+            예약 취소
+          </button>
         </div>
       )}
 

--- a/apps/web/src/entities/calendar/ui/DailyActivityBadgeList/DailyActivityBadgeList.stories.tsx
+++ b/apps/web/src/entities/calendar/ui/DailyActivityBadgeList/DailyActivityBadgeList.stories.tsx
@@ -27,7 +27,7 @@ const meta: Meta<typeof DailyActivityBadgeList> = {
     },
     maxVisible: {
       control: { type: 'number', min: 2, max: 3 },
-      description: '한 셀에 최대로 보여줄 뱃지 개수 (나머지는 "더보기"로 표시)',
+      description: '한 셀에 최대로 보여줄 배지 개수 (나머지는 "더보기"로 표시)',
     },
     isCurrentMonth: {
       control: 'boolean',

--- a/apps/web/src/entities/calendar/ui/EventCard/EventCard.tsx
+++ b/apps/web/src/entities/calendar/ui/EventCard/EventCard.tsx
@@ -21,6 +21,8 @@ import { useBottomSheetStore } from '@/shared/store/bottomSheetStore';
  * @param onClickCard - 카드 전체 클릭 시 호출되는 콜백 함수 (공지사항 바로가기)
  * @param onDeleteSchedule - 일정 삭제 클릭 시 호출되는 콜백 함수 (공지사항 작성 시 삭제하는 콜백 함수)
  * @param mode - 이벤트 카드 모드 (EventCardType: 'reservation', 'calendar' 중 하나)
+ * @param showNoticeLink - 공지사항 바로가기 노출 여부
+ * @param noticeLinkLabel - 바로가기 문구
  */
 export type EventCardProps = {
   category: ScheduleCategory;
@@ -35,6 +37,8 @@ export type EventCardProps = {
   onClickCard?: () => void;
   onDeleteSchedule?: () => void;
   mode?: EventCardType;
+  showNoticeLink?: boolean;
+  noticeLinkLabel?: string;
 };
 
 export const EventCard = ({
@@ -50,6 +54,8 @@ export const EventCard = ({
   onDeleteSchedule,
   mode,
   postId,
+  showNoticeLink: shouldShowNoticeLink,
+  noticeLinkLabel = '공지사항 바로가기',
 }: EventCardProps) => {
   const openBottomSheet = useBottomSheetStore((s) => s.open);
 
@@ -66,8 +72,8 @@ export const EventCard = ({
     }
   };
 
-  // 캘린더 화면에서 공지사항 바로가기 노출 여부
-  const showNoticeLink = mode === 'calendar' && hasNotice && postId !== undefined;
+  const showNoticeLink =
+    shouldShowNoticeLink ?? (mode === 'calendar' && hasNotice && postId !== undefined);
 
   // 시작일/종료일 포맷팅
   const formattedStartDate = formatScheduleDate(startDate);
@@ -98,7 +104,7 @@ export const EventCard = ({
             {showNoticeLink && (
               <div className="flex h-[1.18rem] cursor-pointer flex-row items-center gap-3">
                 <span className="text-caption-caption5 text-foreground-tertiary">
-                  공지사항 바로가기
+                  {noticeLinkLabel}
                 </span>
                 <div className="relative flex items-center justify-center">
                   <SurfIcon size="s" name="ChevronRight" className="text-foreground-tertiary" />

--- a/apps/web/src/entities/notification/ui/NotificationItem.tsx
+++ b/apps/web/src/entities/notification/ui/NotificationItem.tsx
@@ -30,7 +30,7 @@ export const NotificationItem = ({
       onClick={onClick}
       className={`w-full p-13 ${isRead ? 'bg-background-normal' : 'bg-background-notification'} flex items-center gap-15`}
     >
-      {/* 아바타 + 뱃지 박스 */}
+      {/* 아바타 + 배지 박스 */}
       {badge && (
         <div className="relative">
           <Avatar src={userImageUrl} size="m" />

--- a/apps/web/src/entities/post/ui/post-card/PostCard.tsx
+++ b/apps/web/src/entities/post/ui/post-card/PostCard.tsx
@@ -56,7 +56,7 @@ const PostCardComponent = ({
       aria-label={`게시글: ${title}`}
     >
       <div className="flex flex-1 flex-col gap-8 self-stretch">
-        {/* 뱃지 */}
+        {/* 배지 */}
         <div className="flex gap-5">
           {shouldShowCategoryBadge && <PostBadge type="category" label={categoryName} />}
 

--- a/apps/web/src/entities/user/api/types.ts
+++ b/apps/web/src/entities/user/api/types.ts
@@ -26,7 +26,7 @@ export type UserProfileApiResponse = CommonResponse<{
   }>;
 }>;
 
-// 활동뱃지
+// 활동 배지
 export type BadgeItemDTO = {
   badgeId: number;
   badgeName: string;

--- a/apps/web/src/features/comment/model/useCreateCommentMutation.ts
+++ b/apps/web/src/features/comment/model/useCreateCommentMutation.ts
@@ -3,18 +3,45 @@ import { CommentCreateRequest } from '../api/types';
 import { createComment } from '../api/createComment.client';
 import { postQueryKeys } from '@/entities/post/api/queryKeys';
 
+type PostCommentCountFields = {
+  commentCount: number;
+};
+
 export function useCreateCommentMutation(postId: number) {
   const queryClient = useQueryClient();
   const baseKey = ['comments', postId, 'list'] as const;
   return useMutation({
     mutationFn: (body: CommentCreateRequest) => createComment(postId, body),
+    onMutate: async () => {
+      const detailKey = postQueryKeys.detail(postId);
+
+      await queryClient.cancelQueries({ queryKey: detailKey });
+      await queryClient.cancelQueries({ queryKey: postQueryKeys.lists() });
+
+      const previousDetail = queryClient.getQueryData<PostCommentCountFields>(detailKey);
+
+      queryClient.setQueryData<PostCommentCountFields>(detailKey, (old) => {
+        if (!old) return old;
+        return {
+          ...old,
+          commentCount: old.commentCount + 1,
+        };
+      });
+
+      return { previousDetail };
+    },
+    onError: (error, _variables, context) => {
+      console.error('댓글 생성 실패:', error);
+      if (context?.previousDetail) {
+        queryClient.setQueryData(postQueryKeys.detail(postId), context.previousDetail);
+      }
+    },
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: baseKey });
-      await queryClient.invalidateQueries({ queryKey: postQueryKeys.lists() });
       await queryClient.invalidateQueries({ queryKey: postQueryKeys.detail(postId) });
     },
-    onError: (error) => {
-      console.error('댓글 생성 실패:', error);
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: postQueryKeys.lists() });
     },
   });
 }

--- a/apps/web/src/features/comment/model/useDeleteCommentMutation.ts
+++ b/apps/web/src/features/comment/model/useDeleteCommentMutation.ts
@@ -9,6 +9,10 @@ const isInfiniteData = (
   return 'pages' in data && Array.isArray(data.pages);
 };
 
+type PostCommentCountFields = {
+  commentCount: number;
+};
+
 export function useDeleteCommentMutation(postId: number) {
   const queryClient = useQueryClient();
   const baseKey = ['comments', postId, 'list'] as const;
@@ -20,11 +24,17 @@ export function useDeleteCommentMutation(postId: number) {
     mutationFn: (commentId: number) => deleteComment(postId, commentId),
 
     onMutate: async (commentId) => {
+      const detailKey = postQueryKeys.detail(postId);
+
       await queryClient.cancelQueries({ queryKey: baseKey });
+      await queryClient.cancelQueries({ queryKey: detailKey });
+      await queryClient.cancelQueries({ queryKey: postQueryKeys.lists() });
 
       const previousAll = queryClient.getQueriesData<
         CommentListResponse | InfiniteData<CommentListResponse>
       >({ queryKey: baseKey });
+      const previousDetail = queryClient.getQueryData<PostCommentCountFields>(detailKey);
+      let didRemoveComment = false;
 
       queryClient.setQueriesData<CommentListResponse | InfiniteData<CommentListResponse>>(
         { queryKey: baseKey },
@@ -37,6 +47,7 @@ export function useDeleteCommentMutation(postId: number) {
               pageData.comments.some((c) => c.id === commentId),
             );
             if (!hasComment) return data;
+            didRemoveComment = true;
 
             return {
               ...data,
@@ -54,6 +65,7 @@ export function useDeleteCommentMutation(postId: number) {
             const data = old;
             const existed = data.comments.some((c) => c.id === commentId);
             if (!existed) return data;
+            didRemoveComment = true;
             return {
               ...data,
               comments: removeComment(data.comments, commentId),
@@ -64,7 +76,17 @@ export function useDeleteCommentMutation(postId: number) {
         },
       );
 
-      return { previousAll };
+      if (didRemoveComment) {
+        queryClient.setQueryData<PostCommentCountFields>(detailKey, (old) => {
+          if (!old) return old;
+          return {
+            ...old,
+            commentCount: Math.max(0, old.commentCount - 1),
+          };
+        });
+      }
+
+      return { previousAll, previousDetail };
     },
 
     onError: (_err, _vars, ctx) => {
@@ -74,11 +96,14 @@ export function useDeleteCommentMutation(postId: number) {
           queryClient.setQueryData(key, data);
         });
       }
+      if (ctx?.previousDetail) {
+        queryClient.setQueryData(postQueryKeys.detail(postId), ctx.previousDetail);
+      }
     },
 
     onSettled: async () => {
       await queryClient.invalidateQueries({ queryKey: baseKey });
-      await queryClient.invalidateQueries({ queryKey: postQueryKeys.lists() });
+      void queryClient.invalidateQueries({ queryKey: postQueryKeys.lists() });
       await queryClient.invalidateQueries({ queryKey: postQueryKeys.detail(postId) });
     },
   });

--- a/apps/web/src/features/comment/ui/Comment.tsx
+++ b/apps/web/src/features/comment/ui/Comment.tsx
@@ -17,6 +17,7 @@ import type { MentionResponse } from '@/features/comment/api/types';
  * @prop onLikeToggle 좋아요 클릭 콜백 (newState: true=좋아요, false=취소)
  * @prop onReplyClick 답글 클릭 콜백
  * @prop onMoreClick 더보기 클릭 콜백
+ * @prop isActionDisabled 좋아요/답글 액션 비활성화 여부
  */
 
 interface CommentProps {
@@ -31,6 +32,7 @@ interface CommentProps {
   onProfileClick?: () => void;
   onReplyClick?: () => void;
   onMoreClick?: () => void;
+  isActionDisabled?: boolean;
 }
 
 function renderContentWithMentions(content: string, mentions: MentionResponse[] | undefined) {
@@ -65,8 +67,10 @@ export const Comment = ({
   onProfileClick,
   onReplyClick,
   onMoreClick,
+  isActionDisabled = false,
 }: CommentProps) => {
   const handleLikeToggle = () => {
+    if (isActionDisabled) return;
     onLikeToggle?.(!isLiked);
   };
   const isProfileClickable = Boolean(onProfileClick);
@@ -107,6 +111,7 @@ export const Comment = ({
             className="text-caption-caption4 text-foreground-secondary-lighter flex items-center gap-5"
             aria-label={`좋아요 ${likeCount}개`}
             onClick={handleLikeToggle}
+            disabled={isActionDisabled}
           >
             <SurfIcon
               name="Heart"
@@ -124,6 +129,7 @@ export const Comment = ({
             className="text-caption-caption4 text-foreground-secondary-lighter flex items-center gap-5"
             aria-label="답글 달기"
             onClick={onReplyClick}
+            disabled={isActionDisabled}
           >
             <SurfIcon name="Chat" size="s" aria-hidden="true" />
             <span aria-hidden="true">답글달기</span>

--- a/apps/web/src/features/feedback/model/usePostFeedback.ts
+++ b/apps/web/src/features/feedback/model/usePostFeedback.ts
@@ -1,4 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
+import { useAlertStore } from '@surf/ui/store/alertStore';
 import { useRouter } from 'next/navigation';
 import { PAGE_ROUTES } from '@/shared/config/path';
 import { AxiosError } from 'axios';
@@ -7,25 +8,38 @@ import { postFeedback } from '../api/postFeedback';
 // 피드백 보내기 훅
 export const usePostFeedback = () => {
   const router = useRouter();
+  const openAlert = useAlertStore((s) => s.open);
+  const closeAlert = useAlertStore((s) => s.close);
 
   return useMutation({
     mutationFn: postFeedback,
     onSuccess: () => {
-      // 피드백 보내기 성공 시 로직
-      alert('소중한 피드백 감사합니다.');
+      openAlert({
+        state: 'default',
+        title: '소중한 피드백 감사합니다.',
+        actions: [{ type: 'text', label: '확인', variant: 'primary', onClick: closeAlert }],
+      });
     },
     onError: (error: AxiosError) => {
       // 피드백 보내기 실패 시 로직
       let errorMessage = '피드백 전송에 실패했습니다.';
+      let onConfirm = closeAlert;
 
       if (error.response?.status === 429) {
         errorMessage = '피드백은 하루 3회로 제한됩니다! 설정 페이지로 이동합니다.';
-        router.push(PAGE_ROUTES.MYPAGE.SETTINGS);
+        onConfirm = () => {
+          closeAlert();
+          router.push(PAGE_ROUTES.MYPAGE.SETTINGS);
+        };
       } else if (error.response?.status === 500) {
         errorMessage = '서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
       }
 
-      alert(errorMessage);
+      openAlert({
+        state: 'error',
+        title: errorMessage,
+        actions: [{ type: 'text', label: '확인', variant: 'primary', onClick: onConfirm }],
+      });
     },
   });
 };

--- a/apps/web/src/features/post/model/useToggleLikeMutation.ts
+++ b/apps/web/src/features/post/model/useToggleLikeMutation.ts
@@ -1,8 +1,11 @@
-import { InfiniteData, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toggleLike } from '../api/toggleLike';
-import { PostDetail } from '@/entities/post/model/types';
 import { postQueryKeys } from '@/entities/post/api/queryKeys';
-import { PostListApiResponse } from '@/entities/post/api/types';
+
+type PostLikeFields = {
+  likedByMe: boolean;
+  likeCount: number;
+};
 
 export const useToggleLikeMutation = () => {
   const queryClient = useQueryClient();
@@ -19,78 +22,24 @@ export const useToggleLikeMutation = () => {
       await queryClient.cancelQueries({ queryKey: detailKey });
       await queryClient.cancelQueries({ queryKey: listKey });
 
-      const prevDetail = queryClient.getQueryData<PostDetail>(detailKey);
-      const prevLists = queryClient.getQueriesData({ queryKey: listKey });
+      const previousDetail = queryClient.getQueryData<PostLikeFields>(detailKey);
 
-      // 1. 상세 페이지 캐시 업데이트
-      queryClient.setQueryData<PostDetail>(detailKey, (old) => {
+      queryClient.setQueryData<PostLikeFields>(detailKey, (old) => {
         if (!old) return old;
         return {
           ...old,
           likedByMe: !liked,
-          likeCount: liked ? old.likeCount - 1 : old.likeCount + 1,
+          likeCount: Math.max(0, old.likeCount + (liked ? -1 : 1)),
         };
       });
 
-      // 2. 목록 캐시 업데이트
-      queryClient.setQueriesData<InfiniteData<PostListApiResponse> | PostListApiResponse>(
-        { queryKey: listKey },
-        (old) => {
-          if (!old) return old;
-
-          // 무한 스크롤 데이터 구조인 경우 (InfiniteData)
-          if ('pages' in old) {
-            return {
-              ...old,
-              pages: old.pages.map((page) => ({
-                ...page,
-                content: page.content.map((post) =>
-                  post.postId === postId
-                    ? {
-                        ...post,
-                        likedByMe: !liked,
-                        likeCount: liked ? post.likeCount - 1 : post.likeCount + 1,
-                      }
-                    : post,
-                ),
-              })),
-            };
-          }
-
-          // 일반 페이징 데이터 구조인 경우 (PostListApiResponse)
-          if ('content' in old) {
-            return {
-              ...old,
-              content: old.content.map((post) =>
-                post.postId === postId
-                  ? {
-                      ...post,
-                      likedByMe: !liked,
-                      likeCount: liked ? post.likeCount - 1 : post.likeCount + 1,
-                    }
-                  : post,
-              ),
-            };
-          }
-
-          return old;
-        },
-      );
-
-      return { prevDetail, prevLists };
+      return { previousDetail };
     },
 
     // 실패 시 롤백
     onError: (_err, variables, context) => {
-      // 상세 데이터 롤백
-      if (context?.prevDetail) {
-        queryClient.setQueryData(postQueryKeys.detail(variables.postId), context.prevDetail);
-      }
-      // 목록 데이터들 롤백 (getQueriesData로 백업한 모든 리스트 복구)
-      if (context?.prevLists) {
-        context.prevLists.forEach(([queryKey, oldData]) => {
-          queryClient.setQueryData(queryKey, oldData);
-        });
+      if (context?.previousDetail) {
+        queryClient.setQueryData(postQueryKeys.detail(variables.postId), context.previousDetail);
       }
     },
     onSettled: (_data, _error, variables) => {
@@ -99,6 +48,9 @@ export const useToggleLikeMutation = () => {
       // 게시글 상세 무효화
       void queryClient.invalidateQueries({
         queryKey: postQueryKeys.detail(postId),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: postQueryKeys.lists(),
       });
     },
   });

--- a/apps/web/src/features/post/post-form/model/usePostForm.ts
+++ b/apps/web/src/features/post/post-form/model/usePostForm.ts
@@ -79,15 +79,10 @@ export const usePostForm = ({ mode, boardId, postId, postDetail, postSchedule }:
   const isPublished = !!(mode === 'edit' && postDetail && !postDetail.isReserved);
 
   // 5. Event Handlers
-  const handleBack = () => {
+  const hasUnsavedChanges = useCallback(() => {
     const { hasChanges, isEmpty } = checkHasChanges();
-    if (hasChanges && !isEmpty) {
-      setShowExitAlert(true);
-    } else {
-      resetPostState();
-      router.back();
-    }
-  };
+    return hasChanges && !isEmpty;
+  }, [checkHasChanges]);
 
   const queryClient = useQueryClient();
 
@@ -119,6 +114,8 @@ export const usePostForm = ({ mode, boardId, postId, postDetail, postSchedule }:
       }));
 
     const categoryId = categoryKeyToId(category, Number(boardId)) ?? 1;
+    const formattedReservedAt =
+      reserved && reservedAt ? format(reservedAt, "yyyy-MM-dd'T'HH:mm:ss") : null;
 
     try {
       let targetPostId = numericPostId;
@@ -130,7 +127,7 @@ export const usePostForm = ({ mode, boardId, postId, postDetail, postSchedule }:
           title,
           content,
           pinned: false,
-          reservedAt: reservedAt ? format(reservedAt, "yyyy-MM-dd'T'HH:mm:ss") : '',
+          reservedAt: formattedReservedAt,
           imageUrlList,
           fileList,
           hasSchedule: !!linkedSchedule,
@@ -157,7 +154,8 @@ export const usePostForm = ({ mode, boardId, postId, postDetail, postSchedule }:
           categoryId,
           pinned: false,
           isReservationChanged,
-          reservedAt: reservedAt ? format(reservedAt, "yyyy-MM-dd'T'HH:mm:ss") : '',
+          reserved,
+          reservedAt: formattedReservedAt,
           isContentChanged,
           isImageChanged: isImagesChanged,
           imageUrlList,
@@ -270,7 +268,7 @@ export const usePostForm = ({ mode, boardId, postId, postDetail, postSchedule }:
     setShowExitAlert,
 
     // Handlers
-    handleBack,
+    hasUnsavedChanges,
     handleSubmit,
     handleScheduleRemove: clearLinkedSchedule,
     resetPostState,

--- a/apps/web/src/features/post/post-form/model/usePostFormExitGuard.ts
+++ b/apps/web/src/features/post/post-form/model/usePostFormExitGuard.ts
@@ -1,0 +1,46 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+type UsePostFormExitGuardParams = {
+  enabled: boolean;
+  hasUnsavedChanges: () => boolean;
+  onRequestExit: () => void;
+};
+
+export const usePostFormExitGuard = ({
+  enabled,
+  hasUnsavedChanges,
+  onRequestExit,
+}: UsePostFormExitGuardParams) => {
+  const hasPushedExitGuardStateRef = useRef(false);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    if (!hasPushedExitGuardStateRef.current) {
+      hasPushedExitGuardStateRef.current = true;
+      history.pushState({ __postFormExitGuard: true }, '', window.location.href);
+    }
+
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (!hasUnsavedChanges()) return;
+
+      event.preventDefault();
+      event.returnValue = '';
+    };
+
+    const handlePopState = () => {
+      history.go(1);
+      onRequestExit();
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    window.addEventListener('popstate', handlePopState);
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+      window.removeEventListener('popstate', handlePopState);
+    };
+  }, [enabled, hasUnsavedChanges, onRequestExit]);
+};

--- a/apps/web/src/features/post/post-like/ui/PostLikeBottomSheet.tsx
+++ b/apps/web/src/features/post/post-like/ui/PostLikeBottomSheet.tsx
@@ -37,7 +37,13 @@ export const PostLikeBottomSheet = ({
 
   return (
     <ModalSheet isOpen={isOpen} onClose={onClose}>
-      <ModalSheet.Container className="!right-0 !left-0 mx-auto w-full sm:max-w-[min(100dvw,calc(100dvh*375/812))]">
+      <ModalSheet.Container className="relative !right-0 !left-0 mx-auto w-full sm:max-w-[min(100dvw,calc(100dvh*375/812))]">
+        <ModalSheet.Header
+          unstyled
+          className="absolute top-0 right-0 left-0 z-10 h-[2.5rem] cursor-grab active:cursor-grabbing"
+        >
+          <div className="h-full w-full" aria-hidden="true" />
+        </ModalSheet.Header>
         <ModalSheet.Content>
           <Sheet title="좋아요를 누른 사람">
             <div className="flex flex-col pt-12">

--- a/apps/web/src/features/post/update-post/api/types.ts
+++ b/apps/web/src/features/post/update-post/api/types.ts
@@ -6,6 +6,7 @@ export type UpdatePostRequest = {
   categoryId?: number;
   pinned?: boolean;
   isReservationChanged?: boolean;
+  reserved?: boolean;
   reservedAt?: string | null;
   isContentChanged?: boolean;
   isImageChanged?: boolean;

--- a/apps/web/src/shared/ui/action-bar/ActionBar.tsx
+++ b/apps/web/src/shared/ui/action-bar/ActionBar.tsx
@@ -31,25 +31,33 @@ interface ActionBarProps {
   placeholder?: string;
   onSend?: (val: string) => void | boolean | Promise<void | boolean>;
   focusAfterSend?: boolean;
+  disabled?: boolean;
 }
 
 export const ActionBar = forwardRef<HTMLTextAreaElement, ActionBarProps>(
-  ({ value, defaultValue, onChange, placeholder, onSend, focusAfterSend = true }, ref) => {
+  (
+    { value, defaultValue, onChange, placeholder, onSend, focusAfterSend = true, disabled },
+    ref,
+  ) => {
     const internalRef = useRef<HTMLTextAreaElement>(null);
+    const isSendingRef = useRef(false);
     useImperativeHandle(ref, () => internalRef.current as HTMLTextAreaElement);
 
     /** 메시지 전송 및 입력 초기화 */
     const runSend = async () => {
       const rawValue = internalRef.current?.value ?? '';
       const trimmedValue = rawValue.trim();
-      if (!trimmedValue) return;
+      if (disabled || isSendingRef.current || !trimmedValue) return;
 
       try {
+        isSendingRef.current = true;
         const result = await onSend?.(trimmedValue);
         if (result === false) return;
       } catch (error) {
         console.error('[ActionBar] onSend failed:', error);
         return;
+      } finally {
+        isSendingRef.current = false;
       }
 
       // 전송 후 입력 초기화
@@ -81,11 +89,13 @@ export const ActionBar = forwardRef<HTMLTextAreaElement, ActionBarProps>(
           onChange={onChange}
           placeholder={placeholder}
           onEnter={handleSend}
+          disabled={disabled}
         />
         <button
           type="button"
           onClick={handleSend}
-          className="bg-background-primary hover:bg-background-primary-darker rounded-max group flex h-[2.25rem] w-[2.25rem] shrink-0 items-center justify-center self-end p-7"
+          disabled={disabled}
+          className="bg-background-primary hover:bg-background-primary-darker rounded-max group flex h-[2.25rem] w-[2.25rem] shrink-0 items-center justify-center self-end p-7 disabled:cursor-not-allowed disabled:opacity-50"
         >
           <SurfIcon
             name="ArrowUp"

--- a/apps/web/src/shared/ui/action-bar/ActionBar.tsx
+++ b/apps/web/src/shared/ui/action-bar/ActionBar.tsx
@@ -1,6 +1,6 @@
 import { SurfIcon } from '@surf/ui/icon';
 import { MentionTextInput } from '@surf/ui/text-input';
-import { forwardRef, useRef, useImperativeHandle } from 'react';
+import { forwardRef, useRef, useImperativeHandle, type KeyboardEventHandler } from 'react';
 
 /**
  * 범용 메시지 입력 및 전송 컴포넌트
@@ -32,11 +32,21 @@ interface ActionBarProps {
   onSend?: (val: string) => void | boolean | Promise<void | boolean>;
   focusAfterSend?: boolean;
   disabled?: boolean;
+  onKeyDown?: KeyboardEventHandler<HTMLTextAreaElement>;
 }
 
 export const ActionBar = forwardRef<HTMLTextAreaElement, ActionBarProps>(
   (
-    { value, defaultValue, onChange, placeholder, onSend, focusAfterSend = true, disabled },
+    {
+      value,
+      defaultValue,
+      onChange,
+      placeholder,
+      onSend,
+      focusAfterSend = true,
+      disabled,
+      onKeyDown,
+    },
     ref,
   ) => {
     const internalRef = useRef<HTMLTextAreaElement>(null);
@@ -90,6 +100,7 @@ export const ActionBar = forwardRef<HTMLTextAreaElement, ActionBarProps>(
           placeholder={placeholder}
           onEnter={handleSend}
           disabled={disabled}
+          onKeyDown={onKeyDown}
         />
         <button
           type="button"

--- a/apps/web/src/widgets/comment-composer/ui/CommentComposer.tsx
+++ b/apps/web/src/widgets/comment-composer/ui/CommentComposer.tsx
@@ -5,7 +5,7 @@ import { Avatar } from '@surf/ui/avatar';
 import { Sheet } from '@surf/ui/sheet';
 import { SheetItem } from '@surf/ui/sheet';
 import { useToastStore } from '@surf/ui/store/toastStore';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from 'react';
 import type { MentionSearchResponse } from '@/features/comment/api/types';
 import { trackCommentEvent } from '@/features/comment/lib/trackCommentEvent';
 import { COMMENT_EVENTS } from '@/features/comment/model/types';
@@ -38,6 +38,16 @@ function extractMentionNicknames(text: string) {
     if (nick) res.push(nick);
   }
   return res;
+}
+
+function getCompletedMentionDeleteRange(text: string, cursorIndex: number) {
+  const left = text.slice(0, cursorIndex);
+  const match = /(^|\s)(@[^\s@]+\s)$/.exec(left);
+
+  if (!match?.[2]) return null;
+
+  const tokenStart = cursorIndex - match[2].length;
+  return { start: tokenStart, end: cursorIndex };
 }
 
 interface Props {
@@ -132,6 +142,26 @@ export const CommentComposer = ({
       setMentionAtIndex(info.atIndex);
       setMentionKeyword(info.keyword);
     }
+  };
+
+  const handleKeyDown = (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key !== 'Backspace') return;
+
+    const target = event.currentTarget;
+    if (target.selectionStart !== target.selectionEnd) return;
+
+    const range = getCompletedMentionDeleteRange(value, target.selectionStart);
+    if (!range) return;
+
+    event.preventDefault();
+
+    const next = value.slice(0, range.start) + value.slice(range.end);
+    setValue(next);
+    closeMentionPanel();
+
+    requestAnimationFrame(() => {
+      inputRef.current?.setSelectionRange(range.start, range.start);
+    });
   };
 
   const pickMention = (user: MentionSearchResponse) => {
@@ -264,6 +294,7 @@ export const CommentComposer = ({
             onSend={onSend}
             focusAfterSend={false}
             disabled={createMutation.isPending}
+            onKeyDown={handleKeyDown}
           />
         </div>
       </div>

--- a/apps/web/src/widgets/comment-composer/ui/CommentComposer.tsx
+++ b/apps/web/src/widgets/comment-composer/ui/CommentComposer.tsx
@@ -184,6 +184,8 @@ export const CommentComposer = ({
   }, [mentionOpen]);
 
   const onSend = async (text: string) => {
+    if (createMutation.isPending) return false;
+
     trackCommentEvent(COMMENT_EVENTS.CLICK_COMMENT_SUBMIT, {
       post_id: postId,
       comment_length: text.length,
@@ -199,6 +201,7 @@ export const CommentComposer = ({
       setMentionMap({});
       setMentionMemberIds([]);
       closeMentionPanel();
+      inputRef.current?.blur();
       return true;
     } catch (e) {
       console.error(e);
@@ -260,6 +263,7 @@ export const CommentComposer = ({
             placeholder={replyParentId ? '답글을 입력해주세요' : '댓글을 입력해주세요'}
             onSend={onSend}
             focusAfterSend={false}
+            disabled={createMutation.isPending}
           />
         </div>
       </div>

--- a/apps/web/src/widgets/comment-section/ui/CommentSection.tsx
+++ b/apps/web/src/widgets/comment-section/ui/CommentSection.tsx
@@ -32,11 +32,20 @@ interface Props {
   postId: number;
   memberId?: number;
   scrollRootRef?: React.RefObject<HTMLDivElement | null>;
+  isInteractionDisabled?: boolean;
+  emptyMessage?: string;
   // 답글 시작을 부모로 올림
   onStartReply: (info: { commentId: number; memberId: number; nickname: string }) => void;
 }
 
-export const CommentSection = ({ postId, memberId, scrollRootRef, onStartReply }: Props) => {
+export const CommentSection = ({
+  postId,
+  memberId,
+  scrollRootRef,
+  isInteractionDisabled = false,
+  emptyMessage = '첫 댓글을 남겨보세요!',
+  onStartReply,
+}: Props) => {
   const router = useRouter();
   const myId = useAuthStore((s) => s.memberId);
   const openBottomSheet = useBottomSheetStore((s) => s.open);
@@ -172,6 +181,7 @@ export const CommentSection = ({ postId, memberId, scrollRootRef, onStartReply }
                         : undefined
                     }
                     onLikeToggle={() => {
+                      if (isInteractionDisabled) return;
                       const nextState = c.liked ? 'off' : 'on';
                       trackCommentEvent(COMMENT_EVENTS.LIKE, {
                         target_type: 'comment',
@@ -182,10 +192,12 @@ export const CommentSection = ({ postId, memberId, scrollRootRef, onStartReply }
                         onError: () => showToast('좋아요 처리에 실패했어요'),
                       });
                     }}
-                    onReplyClick={() =>
-                      onStartReply({ commentId: c.id, memberId: c.memberId, nickname: c.nickname })
-                    }
+                    onReplyClick={() => {
+                      if (isInteractionDisabled) return;
+                      onStartReply({ commentId: c.id, memberId: c.memberId, nickname: c.nickname });
+                    }}
                     onMoreClick={() => openOptions(c)}
+                    isActionDisabled={isInteractionDisabled}
                   />
                 </div>
               );
@@ -198,9 +210,7 @@ export const CommentSection = ({ postId, memberId, scrollRootRef, onStartReply }
                   aria-hidden="true"
                   focusable="false"
                 />
-                <div className="text-body-body8 text-foreground-tertiary">
-                  첫 댓글을 남겨보세요!
-                </div>
+                <div className="text-body-body8 text-foreground-tertiary">{emptyMessage}</div>
               </div>
             )}
           </div>

--- a/apps/web/src/widgets/post-detail/PostBodySection.tsx
+++ b/apps/web/src/widgets/post-detail/PostBodySection.tsx
@@ -144,21 +144,25 @@ export const PostBodySection = ({ post, schedule, onClickLikeCount }: PostBodySe
             startDate={new Date(schedule.startAt)}
             endDate={new Date(schedule.endAt)}
             onClickCard={handleEventCardClick}
+            showNoticeLink
+            noticeLinkLabel="일정 바로가기"
           />
         )}
       </div>
 
       {/* 좋아요 / 스크랩 */}
-      <div className="flex justify-between">
-        <ChipToggle
-          isClicked={post.likedByMe}
-          count={post.likeCount}
-          onToggleIcon={handleLikeToggle}
-          iconName="Heart"
-          activeColor="red"
-          onClickNumber={onClickLikeCount}
-          mode="count"
-        />
+      <div className={`flex ${post.isReserved ? 'justify-end' : 'justify-between'}`}>
+        {!post.isReserved && (
+          <ChipToggle
+            isClicked={post.likedByMe}
+            count={post.likeCount}
+            onToggleIcon={handleLikeToggle}
+            iconName="Heart"
+            activeColor="red"
+            onClickNumber={onClickLikeCount}
+            mode="count"
+          />
+        )}
 
         <ChipToggle
           isClicked={post.scrappedByMe}

--- a/apps/web/src/widgets/post-list/ui/PostCardList.tsx
+++ b/apps/web/src/widgets/post-list/ui/PostCardList.tsx
@@ -64,7 +64,7 @@ const PostCardListComponent = ({
   }
 
   return (
-    <div className="flex flex-1 flex-col">
+    <div className="divide-border-normal flex flex-1 flex-col divide-y">
       {posts.map((post) => (
         <PostCard
           key={post.postId}

--- a/apps/web/src/widgets/profile-badge/ui/ActivityBadge.stories.tsx
+++ b/apps/web/src/widgets/profile-badge/ui/ActivityBadge.stories.tsx
@@ -13,14 +13,14 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    badgeName: '17기 환영 뱃지',
+    badgeName: '17기 환영 배지',
     timestamp: '2026-06-30',
   },
 };
 
 export const Loading: Story = {
   args: {
-    badgeName: '17기 환영 뱃지',
+    badgeName: '17기 환영 배지',
     loading: true,
   },
 };
@@ -40,7 +40,7 @@ export const Many: Story = {
 
 export const Scaled: Story = {
   args: {
-    badgeName: '17기 환영 뱃지',
+    badgeName: '17기 환영 배지',
     timestamp: '2026-06-30',
     scale: 1.2,
   },

--- a/apps/web/src/widgets/profile-badge/ui/ProfileBadge.tsx
+++ b/apps/web/src/widgets/profile-badge/ui/ProfileBadge.tsx
@@ -16,7 +16,7 @@ import ActivityBadgeEmpty from '@/shared/assets/icons/empty-space/activity-badge
 // );
 
 interface Props {
-  memberId?: number; // 없으면 내 뱃지
+  memberId?: number; // 없으면 내 배지
 }
 
 export const ProfileBadge = ({ memberId }: Props) => {
@@ -35,7 +35,7 @@ export const ProfileBadge = ({ memberId }: Props) => {
   return (
     <section className="flex flex-col gap-16 px-13 py-13 pt-16">
       <div className="flex flex-col gap-10">
-        <h2 className="text-title-title2 text-foreground-normal">활동 뱃지</h2>
+        <h2 className="text-title-title2 text-foreground-normal">활동 배지</h2>
         {!isWaitingMemberId && !isLoading ? (
           <>
             {badges.length > 0 ? (
@@ -54,7 +54,7 @@ export const ProfileBadge = ({ memberId }: Props) => {
               <div className="flex flex-col items-center gap-3 py-16">
                 <ActivityBadgeEmpty aria-hidden="true" />
                 <span className="text-body-body8 text-foreground-tertiary">
-                  부여받은 활동 뱃지가 없어요
+                  부여받은 활동 배지가 없어요
                 </span>
               </div>
             )}

--- a/packages/ui/components/tab/Tab.stories.tsx
+++ b/packages/ui/components/tab/Tab.stories.tsx
@@ -18,7 +18,7 @@ export const Uncontrolled: Story = {
         defaultValue="profile"
         items={[
           { value: 'profile', label: '프로필' },
-          { value: 'badges', label: '활동뱃지' },
+          { value: 'badges', label: '활동 배지' },
         ]}
       />
     </div>
@@ -36,10 +36,10 @@ export const Controlled: Story = {
             onValueChange={setTab}
             items={[
               { value: 'profile', label: '프로필' },
-              { value: 'badges', label: '활동뱃지' },
+              { value: 'badges', label: '활동 배지' },
             ]}
           />
-          <div className="mt-4">{tab === 'profile' ? '프로필 탭' : '활동뱃지 탭'}</div>
+          <div className="mt-4">{tab === 'profile' ? '프로필 탭' : '활동 배지 탭'}</div>
         </div>
       );
     };


### PR DESCRIPTION
### 작업 내용

- 댓글 작성/삭제 시 게시글 상세의 `commentCount`를 낙관 업데이트하도록 개선
- 댓글 작성/삭제/좋아요 처리 후 게시글 목록 query를 invalidate하여 서버 최신값으로 재조회되도록 정리
- 좋아요 mutation에서 목록 캐시 직접 갱신 로직 제거
- 댓글 전송 중 중복 submit 방지를 위해 `ActionBar`에 disabled 및 내부 sending lock 추가
- 댓글 작성 성공 후 입력창 blur 처리로 모바일 키보드가 내려가도록 개선

### 해결/개선 항목

- 댓글 삭제 시 게시글 목록에 미반영
  - 목록 캐시를 직접 조작하지 않고 `postQueryKeys.lists()` invalidate로 서버 최신값을 다시 가져오도록 개선

- 게시글 목록 댓글·좋아요 실시간 동기화 [FE 선대응]
  - 상세에서 발생한 댓글/좋아요 액션 이후 목록 query를 invalidate

- 댓글 작성 후 키보드 안 내려감
  - 댓글 작성 성공 후 입력창 blur 처리

- 댓글 작성 멱등 처리 / 중복 등록 방지 [FE 선대응]
  - 전송 중 `ActionBar` disabled 처리
  - 내부 sending lock으로 더블탭/Enter 연타 중복 submit 방지
  - 백엔드 멱등키 적용 전까지의 1차 방어

### 설계 메모

- 게시글 목록은 직접 캐시 보정하지 않고 invalidate로 최신성을 우선함
- 게시글 상세는 사용자 액션 직후 피드백이 필요하므로 `commentCount`, `likeCount`, `likedByMe`만 낙관 업데이트
- 실패 시 mutation별 `previousDetail` snapshot으로 상세 캐시 rollback


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 예약 게시글의 댓글 작성·상호작용을 제한하고 안내 문구를 제공합니다.
  * 게시글 작성 중 변경사항이 있으면 이탈 확인을 표시합니다.
  * 일정 카드의 바로가기 링크와 예약 취소 UI를 개선했습니다.
  * 완료된 멘션을 Backspace로 한 번에 삭제할 수 있습니다.

* **버그 수정**
  * 댓글·좋아요 수가 즉시 반영되고 실패 시 복구됩니다.
  * 댓글 및 피드백의 중복 전송을 방지합니다.
  * 배지 관련 화면 문구를 ‘배지’로 통일했습니다.
  * 게시글 목록에 카드 구분선을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->