### PR TITLE
[FIX] 게시글 UI QA 항목 개선

### DIFF
--- a/apps/admin/src/app-pages/badge/BadgeAssignPage.tsx
+++ b/apps/admin/src/app-pages/badge/BadgeAssignPage.tsx
@@ -20,7 +20,7 @@ export const BadgeAssignPage = ({ badgeId }: BadgeAssignPageProps) => {
         customBack={actions.handleBack}
         overrideHeader={{
           mode: HeaderMode.Default,
-          title: '활동 뱃지 부여',
+          title: '활동 배지 부여',
           hasLeftIcon: true,
         }}
       />

--- a/apps/admin/src/app-pages/badge/BadgeCreatePage.tsx
+++ b/apps/admin/src/app-pages/badge/BadgeCreatePage.tsx
@@ -14,7 +14,7 @@ export const BadgeCreatePage = () => {
   return (
     <div className="border-border-normal bg-background-normal flex min-h-dvh flex-col border-t-[0.4px]">
       <div className="flex flex-1 flex-col gap-18 px-13 py-11">
-        <FieldGroup title="뱃지 이미지 등록">
+        <FieldGroup title="배지 이미지 등록">
           <ImgUploader
             mode="create"
             onSelectFile={actions.setBadgeFile}
@@ -25,7 +25,7 @@ export const BadgeCreatePage = () => {
           />
         </FieldGroup>
 
-        <FieldGroup title="뱃지 이름" isRequired>
+        <FieldGroup title="배지 이름" isRequired>
           <TextArea
             mode="oneLine"
             value={state.badgeName}

--- a/apps/admin/src/app-pages/badge/BadgeDetailPage.tsx
+++ b/apps/admin/src/app-pages/badge/BadgeDetailPage.tsx
@@ -19,7 +19,7 @@ export const BadgeDetailPage = ({ badgeId }: BadgeDetailPageProps) => {
         customBack={() => router.push(PAGE_ROUTES.BADGE_MNG.LIST)}
         overrideHeader={{
           mode: HeaderMode.TextBtn,
-          title: '활동 뱃지 관리',
+          title: '활동 배지 관리',
           hasLeftIcon: true,
           text: '수정',
           btnVariant: 'primary',

--- a/apps/admin/src/app-pages/badge/BadgeEditPage.tsx
+++ b/apps/admin/src/app-pages/badge/BadgeEditPage.tsx
@@ -19,7 +19,7 @@ export const BadgeEditPage = ({ badgeId }: BadgeEditPageProps) => {
         customBack={() => router.push(PAGE_ROUTES.BADGE_MNG.DETAIL(badgeId))}
         overrideHeader={{
           mode: HeaderMode.Default,
-          title: '활동 뱃지 관리',
+          title: '활동 배지 관리',
           hasLeftIcon: true,
         }}
       />

--- a/apps/admin/src/app-pages/badge/BadgeListPage.tsx
+++ b/apps/admin/src/app-pages/badge/BadgeListPage.tsx
@@ -17,7 +17,7 @@ export const BadgeListPage = () => {
       <div className="pointer-events-none absolute inset-0 z-50">
         <div className="pointer-events-auto absolute right-15 bottom-15">
           <Fab
-            ariaLabel="신규 뱃지 생성 버튼"
+            ariaLabel="신규 배지 생성 버튼"
             onClick={() => router.push(PAGE_ROUTES.BADGE_MNG.CREATE)}
           />
         </div>

--- a/apps/admin/src/app-pages/badge/model/useBadgeAssignPage.ts
+++ b/apps/admin/src/app-pages/badge/model/useBadgeAssignPage.ts
@@ -58,7 +58,7 @@ export const useBadgeAssignPage = (badgeId: number) => {
     openAlert({
       state: 'default',
       title: '부여하시겠습니까?',
-      infoText: `부여하기 버튼을 누를 시, 선택한 ${selectedIds.size}명의 인원에게 활동 뱃지가 부여됩니다.`,
+      infoText: `부여하기 버튼을 누를 시, 선택한 ${selectedIds.size}명의 인원에게 활동 배지가 부여됩니다.`,
       actions: [
         { type: 'solid', variant: 'secondary', label: '취소', onClick: closeAlert },
         {

--- a/apps/admin/src/features/badge/model/useBadgeEditForm.ts
+++ b/apps/admin/src/features/badge/model/useBadgeEditForm.ts
@@ -187,7 +187,7 @@ export const useBadgeEditForm = (
       state: 'default',
       title: '삭제하시겠습니까?',
       infoText:
-        '삭제하기 버튼을 누를 시, 해당 뱃지 데이터와 함께 부여된 회원들의 뱃지 목록에서도 해당 뱃지가 삭제됩니다.',
+        '삭제하기 버튼을 누를 시, 해당 배지 데이터와 함께 부여된 회원들의 배지 목록에서도 해당 배지가 삭제됩니다.',
       actions: [
         { type: 'solid', variant: 'secondary', label: '취소', onClick: closeAlert },
         {

--- a/apps/admin/src/shared/config/routes.tsx
+++ b/apps/admin/src/shared/config/routes.tsx
@@ -78,7 +78,7 @@ export const createRouteConfig = (_router: RouterInstance): RouteConfig[] => [
     backPath: PAGE_ROUTES.HOME,
     header: {
       mode: HeaderMode.Default,
-      title: '활동 뱃지 관리',
+      title: '활동 배지 관리',
       hasLeftIcon: true,
     },
   },
@@ -88,7 +88,7 @@ export const createRouteConfig = (_router: RouterInstance): RouteConfig[] => [
     backPath: PAGE_ROUTES.BADGE_MNG.LIST,
     header: {
       mode: HeaderMode.Default,
-      title: '신규 뱃지 생성',
+      title: '신규 배지 생성',
       hasLeftIcon: true,
     },
   },

--- a/apps/admin/src/widgets/badge/ui/BadgeBasicSection.tsx
+++ b/apps/admin/src/widgets/badge/ui/BadgeBasicSection.tsx
@@ -38,7 +38,7 @@ export const BadgeBasicSection = ({
   return (
     <>
       {/* 배지 이미지 표시/수정 영역 */}
-      <FieldGroup title="뱃지 이미지 등록" className="px-13">
+      <FieldGroup title="배지 이미지 등록" className="px-13">
         {isEdit && onSelectFile ? (
           <ImgUploader
             mode="edit"
@@ -65,7 +65,7 @@ export const BadgeBasicSection = ({
       </FieldGroup>
 
       {/* 배지 이름 표시/수정 영역 */}
-      <FieldGroup title="뱃지 이름" className="px-13">
+      <FieldGroup title="배지 이름" className="px-13">
         {isEdit && onChangeName ? (
           <TextArea
             mode="oneLine"

--- a/apps/admin/src/widgets/badge/ui/BadgeEditActionSection.tsx
+++ b/apps/admin/src/widgets/badge/ui/BadgeEditActionSection.tsx
@@ -16,7 +16,7 @@ export const BadgeEditActionSection = ({
     // 배지 자체를 삭제하는 위험 액션 영역
     <div className="px-13">
       <SolidButton size="m" variant="warning" isDisabled={isDisabled} onClick={onDelete}>
-        해당 뱃지 삭제하기
+        해당 배지 삭제하기
       </SolidButton>
     </div>
   );

--- a/apps/admin/src/widgets/badge/ui/BadgeListWidget.tsx
+++ b/apps/admin/src/widgets/badge/ui/BadgeListWidget.tsx
@@ -32,7 +32,7 @@ export const BadgeListWidget = () => {
   if (badges.length === 0) {
     return (
       <div className="flex flex-1 items-center justify-center px-13">
-        <p className="text-body-body8 text-foreground-tertiary">등록된 뱃지가 없어요.</p>
+        <p className="text-body-body8 text-foreground-tertiary">등록된 배지가 없어요.</p>
       </div>
     );
   }

--- a/apps/web/src/app-pages/post/PostDetailPage.tsx
+++ b/apps/web/src/app-pages/post/PostDetailPage.tsx
@@ -210,6 +210,12 @@ const PostDetailPage = ({ postId }: PostDetailPageProps) => {
                 postId={numericPostId}
                 memberId={memberId ?? undefined}
                 scrollRootRef={scrollRootRef}
+                isInteractionDisabled={post.isReserved}
+                emptyMessage={
+                  post.isReserved
+                    ? '예약 게시물에는 댓글을 남길 수 없어요'
+                    : '첫 댓글을 남겨보세요!'
+                }
                 onStartReply={handleStartReply}
               />
             </div>
@@ -217,12 +223,14 @@ const PostDetailPage = ({ postId }: PostDetailPageProps) => {
         </div>
 
         {/* 댓글 입력창 */}
-        <CommentComposer
-          postId={numericPostId}
-          keyboardOffset={keyboardOffset}
-          pendingReply={pendingReply}
-          onConsumedReply={handleConsumedReply}
-        />
+        {!post.isReserved && (
+          <CommentComposer
+            postId={numericPostId}
+            keyboardOffset={keyboardOffset}
+            pendingReply={pendingReply}
+            onConsumedReply={handleConsumedReply}
+          />
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/app-pages/post/write/ui/PostPage.tsx
+++ b/apps/web/src/app-pages/post/write/ui/PostPage.tsx
@@ -149,9 +149,11 @@ const PostPage = (props: PostPageProps) => {
   const board = POST_BOARDS.find((b) => b.id === Number(boardId));
   const boardLabel = board ? board.label : '';
   const boardCategories = getCategoriesForBoard(Number(boardId));
+  const isGeneralBoard = Number(boardId) === 2;
 
   const disabledToolbarKeys = [
-    ...(memberRole === 'member' || Number(boardId) === 2 ? [TOOLBAR_KEY.CALENDAR] : []),
+    ...(memberRole === 'member' || isGeneralBoard ? [TOOLBAR_KEY.CALENDAR] : []),
+    ...(isGeneralBoard ? [TOOLBAR_KEY.ALARM] : []),
   ];
 
   const { MAX_TITLE_LENGTH } = POST_VALIDATION;

--- a/apps/web/src/app-pages/post/write/ui/PostPage.tsx
+++ b/apps/web/src/app-pages/post/write/ui/PostPage.tsx
@@ -18,10 +18,12 @@ import { useAuthStore } from '@/features/auth/model/useAuthStore';
 import { useGetPostScheduleQuery } from '@/features/post/model/useGetPostScheduleQuery';
 import { TOOLBAR_KEY } from '@/features/post/post-editor/ui/PostEditorToolbar';
 import { usePostForm } from '@/features/post/post-form/model/usePostForm';
+import { usePostFormExitGuard } from '@/features/post/post-form/model/usePostFormExitGuard';
 import { usePostFormStore } from '@/features/post/post-form/model/usePostFormStore';
 import { usePostInitialization } from '@/features/post/post-form/model/usePostInitialization';
 import { useCreatePostScheduleStore } from '@/features/schedule/create-post-schedule/model/useCreatePostScheduleStore';
 
+import { PAGE_ROUTES } from '@/shared/config/path';
 import { useBottomSheetStore } from '@/shared/store/bottomSheetStore';
 import { AppHeader } from '@/widgets/header/ui/AppHeader';
 import { PostEditor } from '@/widgets/post/post-editor/PostEditor';
@@ -79,7 +81,7 @@ const PostPage = (props: PostPageProps) => {
     showExitAlert,
     setShowExitAlert,
     isSubmitDisabled,
-    handleBack,
+    hasUnsavedChanges,
     handleSubmit,
     resetPostState,
     isPublished,
@@ -108,6 +110,26 @@ const PostPage = (props: PostPageProps) => {
     setShowExitAlert(false);
     closeAlert();
   }, [closeAlert, setShowExitAlert]);
+
+  const navigateOut = useCallback(() => {
+    resetPostState();
+
+    if (mode === 'edit' && postId) {
+      router.push(PAGE_ROUTES.BOARD.POST_DETAIL(boardId, postId));
+      return;
+    }
+
+    router.push(PAGE_ROUTES.BOARD.SELECT_CATEGORY(boardId));
+  }, [boardId, mode, postId, resetPostState, router]);
+
+  const requestExit = useCallback(() => {
+    if (hasUnsavedChanges()) {
+      setShowExitAlert(true);
+      return;
+    }
+
+    navigateOut();
+  }, [hasUnsavedChanges, navigateOut, setShowExitAlert]);
 
   const handleSaveReservation = (date: Date) => {
     setField('reservedAt', date);
@@ -150,10 +172,10 @@ const PostPage = (props: PostPageProps) => {
   const boardLabel = board ? board.label : '';
   const boardCategories = getCategoriesForBoard(Number(boardId));
   const isGeneralBoard = Number(boardId) === 2;
+  const canUseReservationTools = memberRole !== 'member' && !isGeneralBoard;
 
   const disabledToolbarKeys = [
-    ...(memberRole === 'member' || isGeneralBoard ? [TOOLBAR_KEY.CALENDAR] : []),
-    ...(isGeneralBoard ? [TOOLBAR_KEY.ALARM] : []),
+    ...(!canUseReservationTools ? [TOOLBAR_KEY.ALARM, TOOLBAR_KEY.CALENDAR] : []),
   ];
 
   const { MAX_TITLE_LENGTH } = POST_VALIDATION;
@@ -172,14 +194,19 @@ const PostPage = (props: PostPageProps) => {
           variant: 'danger',
           onClick: () => {
             closeExitAlert();
-            resetPostState();
-            router.back();
+            navigateOut();
           },
         },
       ],
     });
     setShowExitAlert(false);
-  }, [closeExitAlert, openAlert, resetPostState, router, setShowExitAlert, showExitAlert]);
+  }, [closeExitAlert, navigateOut, openAlert, setShowExitAlert, showExitAlert]);
+
+  usePostFormExitGuard({
+    enabled: isInitialized,
+    hasUnsavedChanges,
+    onRequestExit: requestExit,
+  });
 
   if (!isInitialized) return <Loading />;
 
@@ -187,7 +214,7 @@ const PostPage = (props: PostPageProps) => {
     <div className="flex h-full w-full flex-1 flex-col">
       {/* 1. 상단 헤더 */}
       <AppHeader
-        customBack={handleBack}
+        customBack={requestExit}
         overrideHeader={{
           mode: HeaderMode.TextBtn,
           title: boardLabel,
@@ -224,8 +251,15 @@ const PostPage = (props: PostPageProps) => {
 
       {/* 예약중 태그 */}
       {reserved && (
-        <div className="px-13 pt-10">
+        <div className="flex items-center gap-8 px-13 pt-10">
           <PostBadge type="reservation" />
+          <button
+            type="button"
+            onClick={handleRemoveReservation}
+            className="text-caption-caption5 text-foreground-tertiary underline underline-offset-2"
+          >
+            예약 취소
+          </button>
         </div>
       )}
 

--- a/apps/web/src/entities/calendar/ui/DailyActivityBadgeList/DailyActivityBadgeList.stories.tsx
+++ b/apps/web/src/entities/calendar/ui/DailyActivityBadgeList/DailyActivityBadgeList.stories.tsx
@@ -27,7 +27,7 @@ const meta: Meta<typeof DailyActivityBadgeList> = {
     },
     maxVisible: {
       control: { type: 'number', min: 2, max: 3 },
-      description: '한 셀에 최대로 보여줄 뱃지 개수 (나머지는 "더보기"로 표시)',
+      description: '한 셀에 최대로 보여줄 배지 개수 (나머지는 "더보기"로 표시)',
     },
     isCurrentMonth: {
       control: 'boolean',

--- a/apps/web/src/entities/calendar/ui/EventCard/EventCard.tsx
+++ b/apps/web/src/entities/calendar/ui/EventCard/EventCard.tsx
@@ -21,6 +21,7 @@ import { useBottomSheetStore } from '@/shared/store/bottomSheetStore';
  * @param onClickCard - 카드 전체 클릭 시 호출되는 콜백 함수 (공지사항 바로가기)
  * @param onDeleteSchedule - 일정 삭제 클릭 시 호출되는 콜백 함수 (공지사항 작성 시 삭제하는 콜백 함수)
  * @param mode - 이벤트 카드 모드 (EventCardType: 'reservation', 'calendar' 중 하나)
+ * @param showNoticeLink - 공지사항 바로가기 노출 여부
  */
 export type EventCardProps = {
   category: ScheduleCategory;
@@ -35,6 +36,7 @@ export type EventCardProps = {
   onClickCard?: () => void;
   onDeleteSchedule?: () => void;
   mode?: EventCardType;
+  showNoticeLink?: boolean;
 };
 
 export const EventCard = ({
@@ -50,6 +52,7 @@ export const EventCard = ({
   onDeleteSchedule,
   mode,
   postId,
+  showNoticeLink: shouldShowNoticeLink,
 }: EventCardProps) => {
   const openBottomSheet = useBottomSheetStore((s) => s.open);
 
@@ -66,8 +69,8 @@ export const EventCard = ({
     }
   };
 
-  // 캘린더 화면에서 공지사항 바로가기 노출 여부
-  const showNoticeLink = mode === 'calendar' && hasNotice && postId !== undefined;
+  const showNoticeLink =
+    shouldShowNoticeLink ?? (mode === 'calendar' && hasNotice && postId !== undefined);
 
   // 시작일/종료일 포맷팅
   const formattedStartDate = formatScheduleDate(startDate);

--- a/apps/web/src/entities/calendar/ui/EventCard/EventCard.tsx
+++ b/apps/web/src/entities/calendar/ui/EventCard/EventCard.tsx
@@ -22,6 +22,7 @@ import { useBottomSheetStore } from '@/shared/store/bottomSheetStore';
  * @param onDeleteSchedule - 일정 삭제 클릭 시 호출되는 콜백 함수 (공지사항 작성 시 삭제하는 콜백 함수)
  * @param mode - 이벤트 카드 모드 (EventCardType: 'reservation', 'calendar' 중 하나)
  * @param showNoticeLink - 공지사항 바로가기 노출 여부
+ * @param noticeLinkLabel - 바로가기 문구
  */
 export type EventCardProps = {
   category: ScheduleCategory;
@@ -37,6 +38,7 @@ export type EventCardProps = {
   onDeleteSchedule?: () => void;
   mode?: EventCardType;
   showNoticeLink?: boolean;
+  noticeLinkLabel?: string;
 };
 
 export const EventCard = ({
@@ -53,6 +55,7 @@ export const EventCard = ({
   mode,
   postId,
   showNoticeLink: shouldShowNoticeLink,
+  noticeLinkLabel = '공지사항 바로가기',
 }: EventCardProps) => {
   const openBottomSheet = useBottomSheetStore((s) => s.open);
 
@@ -101,7 +104,7 @@ export const EventCard = ({
             {showNoticeLink && (
               <div className="flex h-[1.18rem] cursor-pointer flex-row items-center gap-3">
                 <span className="text-caption-caption5 text-foreground-tertiary">
-                  공지사항 바로가기
+                  {noticeLinkLabel}
                 </span>
                 <div className="relative flex items-center justify-center">
                   <SurfIcon size="s" name="ChevronRight" className="text-foreground-tertiary" />

--- a/apps/web/src/entities/notification/ui/NotificationItem.tsx
+++ b/apps/web/src/entities/notification/ui/NotificationItem.tsx
@@ -30,7 +30,7 @@ export const NotificationItem = ({
       onClick={onClick}
       className={`w-full p-13 ${isRead ? 'bg-background-normal' : 'bg-background-notification'} flex items-center gap-15`}
     >
-      {/* 아바타 + 뱃지 박스 */}
+      {/* 아바타 + 배지 박스 */}
       {badge && (
         <div className="relative">
           <Avatar src={userImageUrl} size="m" />

--- a/apps/web/src/entities/post/ui/post-card/PostCard.tsx
+++ b/apps/web/src/entities/post/ui/post-card/PostCard.tsx
@@ -56,7 +56,7 @@ const PostCardComponent = ({
       aria-label={`게시글: ${title}`}
     >
       <div className="flex flex-1 flex-col gap-8 self-stretch">
-        {/* 뱃지 */}
+        {/* 배지 */}
         <div className="flex gap-5">
           {shouldShowCategoryBadge && <PostBadge type="category" label={categoryName} />}
 

--- a/apps/web/src/entities/user/api/types.ts
+++ b/apps/web/src/entities/user/api/types.ts
@@ -26,7 +26,7 @@ export type UserProfileApiResponse = CommonResponse<{
   }>;
 }>;
 
-// 활동뱃지
+// 활동 배지
 export type BadgeItemDTO = {
   badgeId: number;
   badgeName: string;

--- a/apps/web/src/features/comment/ui/Comment.tsx
+++ b/apps/web/src/features/comment/ui/Comment.tsx
@@ -17,6 +17,7 @@ import type { MentionResponse } from '@/features/comment/api/types';
  * @prop onLikeToggle 좋아요 클릭 콜백 (newState: true=좋아요, false=취소)
  * @prop onReplyClick 답글 클릭 콜백
  * @prop onMoreClick 더보기 클릭 콜백
+ * @prop isActionDisabled 좋아요/답글 액션 비활성화 여부
  */
 
 interface CommentProps {
@@ -31,6 +32,7 @@ interface CommentProps {
   onProfileClick?: () => void;
   onReplyClick?: () => void;
   onMoreClick?: () => void;
+  isActionDisabled?: boolean;
 }
 
 function renderContentWithMentions(content: string, mentions: MentionResponse[] | undefined) {
@@ -65,8 +67,10 @@ export const Comment = ({
   onProfileClick,
   onReplyClick,
   onMoreClick,
+  isActionDisabled = false,
 }: CommentProps) => {
   const handleLikeToggle = () => {
+    if (isActionDisabled) return;
     onLikeToggle?.(!isLiked);
   };
   const isProfileClickable = Boolean(onProfileClick);
@@ -107,6 +111,7 @@ export const Comment = ({
             className="text-caption-caption4 text-foreground-secondary-lighter flex items-center gap-5"
             aria-label={`좋아요 ${likeCount}개`}
             onClick={handleLikeToggle}
+            disabled={isActionDisabled}
           >
             <SurfIcon
               name="Heart"
@@ -124,6 +129,7 @@ export const Comment = ({
             className="text-caption-caption4 text-foreground-secondary-lighter flex items-center gap-5"
             aria-label="답글 달기"
             onClick={onReplyClick}
+            disabled={isActionDisabled}
           >
             <SurfIcon name="Chat" size="s" aria-hidden="true" />
             <span aria-hidden="true">답글달기</span>

--- a/apps/web/src/features/feedback/model/usePostFeedback.ts
+++ b/apps/web/src/features/feedback/model/usePostFeedback.ts
@@ -1,4 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
+import { useAlertStore } from '@surf/ui/store/alertStore';
 import { useRouter } from 'next/navigation';
 import { PAGE_ROUTES } from '@/shared/config/path';
 import { AxiosError } from 'axios';
@@ -7,25 +8,38 @@ import { postFeedback } from '../api/postFeedback';
 // 피드백 보내기 훅
 export const usePostFeedback = () => {
   const router = useRouter();
+  const openAlert = useAlertStore((s) => s.open);
+  const closeAlert = useAlertStore((s) => s.close);
 
   return useMutation({
     mutationFn: postFeedback,
     onSuccess: () => {
-      // 피드백 보내기 성공 시 로직
-      alert('소중한 피드백 감사합니다.');
+      openAlert({
+        state: 'default',
+        title: '소중한 피드백 감사합니다.',
+        actions: [{ type: 'text', label: '확인', variant: 'primary', onClick: closeAlert }],
+      });
     },
     onError: (error: AxiosError) => {
       // 피드백 보내기 실패 시 로직
       let errorMessage = '피드백 전송에 실패했습니다.';
+      let onConfirm = closeAlert;
 
       if (error.response?.status === 429) {
         errorMessage = '피드백은 하루 3회로 제한됩니다! 설정 페이지로 이동합니다.';
-        router.push(PAGE_ROUTES.MYPAGE.SETTINGS);
+        onConfirm = () => {
+          closeAlert();
+          router.push(PAGE_ROUTES.MYPAGE.SETTINGS);
+        };
       } else if (error.response?.status === 500) {
         errorMessage = '서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
       }
 
-      alert(errorMessage);
+      openAlert({
+        state: 'error',
+        title: errorMessage,
+        actions: [{ type: 'text', label: '확인', variant: 'primary', onClick: onConfirm }],
+      });
     },
   });
 };

--- a/apps/web/src/features/post/post-form/model/usePostForm.ts
+++ b/apps/web/src/features/post/post-form/model/usePostForm.ts
@@ -79,15 +79,10 @@ export const usePostForm = ({ mode, boardId, postId, postDetail, postSchedule }:
   const isPublished = !!(mode === 'edit' && postDetail && !postDetail.isReserved);
 
   // 5. Event Handlers
-  const handleBack = () => {
+  const hasUnsavedChanges = useCallback(() => {
     const { hasChanges, isEmpty } = checkHasChanges();
-    if (hasChanges && !isEmpty) {
-      setShowExitAlert(true);
-    } else {
-      resetPostState();
-      router.back();
-    }
-  };
+    return hasChanges && !isEmpty;
+  }, [checkHasChanges]);
 
   const queryClient = useQueryClient();
 
@@ -119,6 +114,8 @@ export const usePostForm = ({ mode, boardId, postId, postDetail, postSchedule }:
       }));
 
     const categoryId = categoryKeyToId(category, Number(boardId)) ?? 1;
+    const formattedReservedAt =
+      reserved && reservedAt ? format(reservedAt, "yyyy-MM-dd'T'HH:mm:ss") : null;
 
     try {
       let targetPostId = numericPostId;
@@ -130,7 +127,7 @@ export const usePostForm = ({ mode, boardId, postId, postDetail, postSchedule }:
           title,
           content,
           pinned: false,
-          reservedAt: reservedAt ? format(reservedAt, "yyyy-MM-dd'T'HH:mm:ss") : '',
+          reservedAt: formattedReservedAt,
           imageUrlList,
           fileList,
           hasSchedule: !!linkedSchedule,
@@ -157,7 +154,8 @@ export const usePostForm = ({ mode, boardId, postId, postDetail, postSchedule }:
           categoryId,
           pinned: false,
           isReservationChanged,
-          reservedAt: reservedAt ? format(reservedAt, "yyyy-MM-dd'T'HH:mm:ss") : '',
+          reserved,
+          reservedAt: formattedReservedAt,
           isContentChanged,
           isImageChanged: isImagesChanged,
           imageUrlList,
@@ -270,7 +268,7 @@ export const usePostForm = ({ mode, boardId, postId, postDetail, postSchedule }:
     setShowExitAlert,
 
     // Handlers
-    handleBack,
+    hasUnsavedChanges,
     handleSubmit,
     handleScheduleRemove: clearLinkedSchedule,
     resetPostState,

--- a/apps/web/src/features/post/post-form/model/usePostFormExitGuard.ts
+++ b/apps/web/src/features/post/post-form/model/usePostFormExitGuard.ts
@@ -1,0 +1,46 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+type UsePostFormExitGuardParams = {
+  enabled: boolean;
+  hasUnsavedChanges: () => boolean;
+  onRequestExit: () => void;
+};
+
+export const usePostFormExitGuard = ({
+  enabled,
+  hasUnsavedChanges,
+  onRequestExit,
+}: UsePostFormExitGuardParams) => {
+  const hasPushedExitGuardStateRef = useRef(false);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    if (!hasPushedExitGuardStateRef.current) {
+      hasPushedExitGuardStateRef.current = true;
+      history.pushState({ __postFormExitGuard: true }, '', window.location.href);
+    }
+
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (!hasUnsavedChanges()) return;
+
+      event.preventDefault();
+      event.returnValue = '';
+    };
+
+    const handlePopState = () => {
+      history.go(1);
+      onRequestExit();
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    window.addEventListener('popstate', handlePopState);
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+      window.removeEventListener('popstate', handlePopState);
+    };
+  }, [enabled, hasUnsavedChanges, onRequestExit]);
+};

--- a/apps/web/src/features/post/post-like/ui/PostLikeBottomSheet.tsx
+++ b/apps/web/src/features/post/post-like/ui/PostLikeBottomSheet.tsx
@@ -37,7 +37,13 @@ export const PostLikeBottomSheet = ({
 
   return (
     <ModalSheet isOpen={isOpen} onClose={onClose}>
-      <ModalSheet.Container className="!right-0 !left-0 mx-auto w-full sm:max-w-[min(100dvw,calc(100dvh*375/812))]">
+      <ModalSheet.Container className="relative !right-0 !left-0 mx-auto w-full sm:max-w-[min(100dvw,calc(100dvh*375/812))]">
+        <ModalSheet.Header
+          unstyled
+          className="absolute top-0 right-0 left-0 z-10 h-[2.5rem] cursor-grab active:cursor-grabbing"
+        >
+          <div className="h-full w-full" aria-hidden="true" />
+        </ModalSheet.Header>
         <ModalSheet.Content>
           <Sheet title="좋아요를 누른 사람">
             <div className="flex flex-col pt-12">

--- a/apps/web/src/features/post/update-post/api/types.ts
+++ b/apps/web/src/features/post/update-post/api/types.ts
@@ -6,6 +6,7 @@ export type UpdatePostRequest = {
   categoryId?: number;
   pinned?: boolean;
   isReservationChanged?: boolean;
+  reserved?: boolean;
   reservedAt?: string | null;
   isContentChanged?: boolean;
   isImageChanged?: boolean;

--- a/apps/web/src/shared/ui/action-bar/ActionBar.tsx
+++ b/apps/web/src/shared/ui/action-bar/ActionBar.tsx
@@ -1,6 +1,6 @@
 import { SurfIcon } from '@surf/ui/icon';
 import { MentionTextInput } from '@surf/ui/text-input';
-import { forwardRef, useRef, useImperativeHandle } from 'react';
+import { forwardRef, useRef, useImperativeHandle, type KeyboardEventHandler } from 'react';
 
 /**
  * 범용 메시지 입력 및 전송 컴포넌트
@@ -32,11 +32,21 @@ interface ActionBarProps {
   onSend?: (val: string) => void | boolean | Promise<void | boolean>;
   focusAfterSend?: boolean;
   disabled?: boolean;
+  onKeyDown?: KeyboardEventHandler<HTMLTextAreaElement>;
 }
 
 export const ActionBar = forwardRef<HTMLTextAreaElement, ActionBarProps>(
   (
-    { value, defaultValue, onChange, placeholder, onSend, focusAfterSend = true, disabled },
+    {
+      value,
+      defaultValue,
+      onChange,
+      placeholder,
+      onSend,
+      focusAfterSend = true,
+      disabled,
+      onKeyDown,
+    },
     ref,
   ) => {
     const internalRef = useRef<HTMLTextAreaElement>(null);
@@ -90,6 +100,7 @@ export const ActionBar = forwardRef<HTMLTextAreaElement, ActionBarProps>(
           placeholder={placeholder}
           onEnter={handleSend}
           disabled={disabled}
+          onKeyDown={onKeyDown}
         />
         <button
           type="button"

--- a/apps/web/src/widgets/comment-composer/ui/CommentComposer.tsx
+++ b/apps/web/src/widgets/comment-composer/ui/CommentComposer.tsx
@@ -5,7 +5,7 @@ import { Avatar } from '@surf/ui/avatar';
 import { Sheet } from '@surf/ui/sheet';
 import { SheetItem } from '@surf/ui/sheet';
 import { useToastStore } from '@surf/ui/store/toastStore';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from 'react';
 import type { MentionSearchResponse } from '@/features/comment/api/types';
 import { trackCommentEvent } from '@/features/comment/lib/trackCommentEvent';
 import { COMMENT_EVENTS } from '@/features/comment/model/types';
@@ -38,6 +38,16 @@ function extractMentionNicknames(text: string) {
     if (nick) res.push(nick);
   }
   return res;
+}
+
+function getCompletedMentionDeleteRange(text: string, cursorIndex: number) {
+  const left = text.slice(0, cursorIndex);
+  const match = /(^|\s)(@[^\s@]+\s)$/.exec(left);
+
+  if (!match?.[2]) return null;
+
+  const tokenStart = cursorIndex - match[2].length;
+  return { start: tokenStart, end: cursorIndex };
 }
 
 interface Props {
@@ -132,6 +142,26 @@ export const CommentComposer = ({
       setMentionAtIndex(info.atIndex);
       setMentionKeyword(info.keyword);
     }
+  };
+
+  const handleKeyDown = (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key !== 'Backspace') return;
+
+    const target = event.currentTarget;
+    if (target.selectionStart !== target.selectionEnd) return;
+
+    const range = getCompletedMentionDeleteRange(value, target.selectionStart);
+    if (!range) return;
+
+    event.preventDefault();
+
+    const next = value.slice(0, range.start) + value.slice(range.end);
+    setValue(next);
+    closeMentionPanel();
+
+    requestAnimationFrame(() => {
+      inputRef.current?.setSelectionRange(range.start, range.start);
+    });
   };
 
   const pickMention = (user: MentionSearchResponse) => {
@@ -264,6 +294,7 @@ export const CommentComposer = ({
             onSend={onSend}
             focusAfterSend={false}
             disabled={createMutation.isPending}
+            onKeyDown={handleKeyDown}
           />
         </div>
       </div>

--- a/apps/web/src/widgets/comment-section/ui/CommentSection.tsx
+++ b/apps/web/src/widgets/comment-section/ui/CommentSection.tsx
@@ -32,11 +32,20 @@ interface Props {
   postId: number;
   memberId?: number;
   scrollRootRef?: React.RefObject<HTMLDivElement | null>;
+  isInteractionDisabled?: boolean;
+  emptyMessage?: string;
   // 답글 시작을 부모로 올림
   onStartReply: (info: { commentId: number; memberId: number; nickname: string }) => void;
 }
 
-export const CommentSection = ({ postId, memberId, scrollRootRef, onStartReply }: Props) => {
+export const CommentSection = ({
+  postId,
+  memberId,
+  scrollRootRef,
+  isInteractionDisabled = false,
+  emptyMessage = '첫 댓글을 남겨보세요!',
+  onStartReply,
+}: Props) => {
   const router = useRouter();
   const myId = useAuthStore((s) => s.memberId);
   const openBottomSheet = useBottomSheetStore((s) => s.open);
@@ -172,6 +181,7 @@ export const CommentSection = ({ postId, memberId, scrollRootRef, onStartReply }
                         : undefined
                     }
                     onLikeToggle={() => {
+                      if (isInteractionDisabled) return;
                       const nextState = c.liked ? 'off' : 'on';
                       trackCommentEvent(COMMENT_EVENTS.LIKE, {
                         target_type: 'comment',
@@ -182,10 +192,12 @@ export const CommentSection = ({ postId, memberId, scrollRootRef, onStartReply }
                         onError: () => showToast('좋아요 처리에 실패했어요'),
                       });
                     }}
-                    onReplyClick={() =>
-                      onStartReply({ commentId: c.id, memberId: c.memberId, nickname: c.nickname })
-                    }
+                    onReplyClick={() => {
+                      if (isInteractionDisabled) return;
+                      onStartReply({ commentId: c.id, memberId: c.memberId, nickname: c.nickname });
+                    }}
                     onMoreClick={() => openOptions(c)}
+                    isActionDisabled={isInteractionDisabled}
                   />
                 </div>
               );
@@ -198,9 +210,7 @@ export const CommentSection = ({ postId, memberId, scrollRootRef, onStartReply }
                   aria-hidden="true"
                   focusable="false"
                 />
-                <div className="text-body-body8 text-foreground-tertiary">
-                  첫 댓글을 남겨보세요!
-                </div>
+                <div className="text-body-body8 text-foreground-tertiary">{emptyMessage}</div>
               </div>
             )}
           </div>

--- a/apps/web/src/widgets/post-detail/PostBodySection.tsx
+++ b/apps/web/src/widgets/post-detail/PostBodySection.tsx
@@ -151,16 +151,18 @@ export const PostBodySection = ({ post, schedule, onClickLikeCount }: PostBodySe
       </div>
 
       {/* 좋아요 / 스크랩 */}
-      <div className="flex justify-between">
-        <ChipToggle
-          isClicked={post.likedByMe}
-          count={post.likeCount}
-          onToggleIcon={handleLikeToggle}
-          iconName="Heart"
-          activeColor="red"
-          onClickNumber={onClickLikeCount}
-          mode="count"
-        />
+      <div className={`flex ${post.isReserved ? 'justify-end' : 'justify-between'}`}>
+        {!post.isReserved && (
+          <ChipToggle
+            isClicked={post.likedByMe}
+            count={post.likeCount}
+            onToggleIcon={handleLikeToggle}
+            iconName="Heart"
+            activeColor="red"
+            onClickNumber={onClickLikeCount}
+            mode="count"
+          />
+        )}
 
         <ChipToggle
           isClicked={post.scrappedByMe}

--- a/apps/web/src/widgets/post-detail/PostBodySection.tsx
+++ b/apps/web/src/widgets/post-detail/PostBodySection.tsx
@@ -144,6 +144,7 @@ export const PostBodySection = ({ post, schedule, onClickLikeCount }: PostBodySe
             startDate={new Date(schedule.startAt)}
             endDate={new Date(schedule.endAt)}
             onClickCard={handleEventCardClick}
+            showNoticeLink
           />
         )}
       </div>

--- a/apps/web/src/widgets/post-detail/PostBodySection.tsx
+++ b/apps/web/src/widgets/post-detail/PostBodySection.tsx
@@ -145,6 +145,7 @@ export const PostBodySection = ({ post, schedule, onClickLikeCount }: PostBodySe
             endDate={new Date(schedule.endAt)}
             onClickCard={handleEventCardClick}
             showNoticeLink
+            noticeLinkLabel="일정 바로가기"
           />
         )}
       </div>

--- a/apps/web/src/widgets/post-list/ui/PostCardList.tsx
+++ b/apps/web/src/widgets/post-list/ui/PostCardList.tsx
@@ -64,7 +64,7 @@ const PostCardListComponent = ({
   }
 
   return (
-    <div className="flex flex-1 flex-col">
+    <div className="divide-border-normal flex flex-1 flex-col divide-y">
       {posts.map((post) => (
         <PostCard
           key={post.postId}

--- a/apps/web/src/widgets/profile-badge/ui/ActivityBadge.stories.tsx
+++ b/apps/web/src/widgets/profile-badge/ui/ActivityBadge.stories.tsx
@@ -13,14 +13,14 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    badgeName: '17기 환영 뱃지',
+    badgeName: '17기 환영 배지',
     timestamp: '2026-06-30',
   },
 };
 
 export const Loading: Story = {
   args: {
-    badgeName: '17기 환영 뱃지',
+    badgeName: '17기 환영 배지',
     loading: true,
   },
 };
@@ -40,7 +40,7 @@ export const Many: Story = {
 
 export const Scaled: Story = {
   args: {
-    badgeName: '17기 환영 뱃지',
+    badgeName: '17기 환영 배지',
     timestamp: '2026-06-30',
     scale: 1.2,
   },

--- a/apps/web/src/widgets/profile-badge/ui/ProfileBadge.tsx
+++ b/apps/web/src/widgets/profile-badge/ui/ProfileBadge.tsx
@@ -16,7 +16,7 @@ import ActivityBadgeEmpty from '@/shared/assets/icons/empty-space/activity-badge
 // );
 
 interface Props {
-  memberId?: number; // 없으면 내 뱃지
+  memberId?: number; // 없으면 내 배지
 }
 
 export const ProfileBadge = ({ memberId }: Props) => {
@@ -35,7 +35,7 @@ export const ProfileBadge = ({ memberId }: Props) => {
   return (
     <section className="flex flex-col gap-16 px-13 py-13 pt-16">
       <div className="flex flex-col gap-10">
-        <h2 className="text-title-title2 text-foreground-normal">활동 뱃지</h2>
+        <h2 className="text-title-title2 text-foreground-normal">활동 배지</h2>
         {!isWaitingMemberId && !isLoading ? (
           <>
             {badges.length > 0 ? (
@@ -54,7 +54,7 @@ export const ProfileBadge = ({ memberId }: Props) => {
               <div className="flex flex-col items-center gap-3 py-16">
                 <ActivityBadgeEmpty aria-hidden="true" />
                 <span className="text-body-body8 text-foreground-tertiary">
-                  부여받은 활동 뱃지가 없어요
+                  부여받은 활동 배지가 없어요
                 </span>
               </div>
             )}

--- a/packages/ui/components/tab/Tab.stories.tsx
+++ b/packages/ui/components/tab/Tab.stories.tsx
@@ -18,7 +18,7 @@ export const Uncontrolled: Story = {
         defaultValue="profile"
         items={[
           { value: 'profile', label: '프로필' },
-          { value: 'badges', label: '활동뱃지' },
+          { value: 'badges', label: '활동 배지' },
         ]}
       />
     </div>
@@ -36,10 +36,10 @@ export const Controlled: Story = {
             onValueChange={setTab}
             items={[
               { value: 'profile', label: '프로필' },
-              { value: 'badges', label: '활동뱃지' },
+              { value: 'badges', label: '활동 배지' },
             ]}
           />
-          <div className="mt-4">{tab === 'profile' ? '프로필 탭' : '활동뱃지 탭'}</div>
+          <div className="mt-4">{tab === 'profile' ? '프로필 탭' : '활동 배지 탭'}</div>
         </div>
       );
     };


### PR DESCRIPTION
### 작업 내용

- 게시글/공지 목록 카드 사이 구분선 추가
- 게시글 상세의 예약 일정 카드에서 바로가기 노출 조건 분리
- 예약 게시글 상세의 바로가기 문구를 `일정 바로가기`로 표시
- 일반 게시판 작성 화면에서 `예약`, `일정` 툴바 버튼 제거
- 좋아요 목록 바텀시트에 `ModalSheet.Header` 드래그 영역 추가

### 해결/개선 항목

- 게시글/공지 리스트 카드 사이 구분선 누락
- 예약 게시물에서 바로가기 안 나옴
- 일반 게시판에 일정 설정 버튼 자체가 없어야 함
  - 일반 게시판에서는 `일정`뿐 아니라 `예약` 버튼도 함께 제거
- 좋아요 목록 회색 바 드래그 잘 안 됨

### 설계 메모

- `EventCard`의 바로가기 노출 여부를 `showNoticeLink` prop으로 분리
  - 캘린더 화면은 기존 기본 조건 유지
  - 게시글 상세 예약 카드에서는 명시적으로 바로가기 노출
- 바로가기 문구는 `noticeLinkLabel` prop으로 분리
  - 캘린더 화면 기본값: `공지사항 바로가기`
  - 게시글 상세 예약 카드: `일정 바로가기`
- 좋아요 목록 바텀시트는 기존 시각 핸들은 유지하고, `react-modal-sheet`가 인식하는 투명 드래그 영역만 추가
  - 드래그 영역 높이: `40px`
