### PR TITLE
[FIX] 예약 게시물 상호작용 제한 및 예약 취소 UX 개선

### DIFF
--- a/apps/admin/src/app-pages/badge/BadgeAssignPage.tsx
+++ b/apps/admin/src/app-pages/badge/BadgeAssignPage.tsx
@@ -20,7 +20,7 @@ export const BadgeAssignPage = ({ badgeId }: BadgeAssignPageProps) => {
         customBack={actions.handleBack}
         overrideHeader={{
           mode: HeaderMode.Default,
-          title: '활동 뱃지 부여',
+          title: '활동 배지 부여',
           hasLeftIcon: true,
         }}
       />

--- a/apps/admin/src/app-pages/badge/BadgeCreatePage.tsx
+++ b/apps/admin/src/app-pages/badge/BadgeCreatePage.tsx
@@ -14,7 +14,7 @@ export const BadgeCreatePage = () => {
   return (
     <div className="border-border-normal bg-background-normal flex min-h-dvh flex-col border-t-[0.4px]">
       <div className="flex flex-1 flex-col gap-18 px-13 py-11">
-        <FieldGroup title="뱃지 이미지 등록">
+        <FieldGroup title="배지 이미지 등록">
           <ImgUploader
             mode="create"
             onSelectFile={actions.setBadgeFile}
@@ -25,7 +25,7 @@ export const BadgeCreatePage = () => {
           />
         </FieldGroup>
 
-        <FieldGroup title="뱃지 이름" isRequired>
+        <FieldGroup title="배지 이름" isRequired>
           <TextArea
             mode="oneLine"
             value={state.badgeName}

--- a/apps/admin/src/app-pages/badge/BadgeDetailPage.tsx
+++ b/apps/admin/src/app-pages/badge/BadgeDetailPage.tsx
@@ -19,7 +19,7 @@ export const BadgeDetailPage = ({ badgeId }: BadgeDetailPageProps) => {
         customBack={() => router.push(PAGE_ROUTES.BADGE_MNG.LIST)}
         overrideHeader={{
           mode: HeaderMode.TextBtn,
-          title: '활동 뱃지 관리',
+          title: '활동 배지 관리',
           hasLeftIcon: true,
           text: '수정',
           btnVariant: 'primary',

--- a/apps/admin/src/app-pages/badge/BadgeEditPage.tsx
+++ b/apps/admin/src/app-pages/badge/BadgeEditPage.tsx
@@ -19,7 +19,7 @@ export const BadgeEditPage = ({ badgeId }: BadgeEditPageProps) => {
         customBack={() => router.push(PAGE_ROUTES.BADGE_MNG.DETAIL(badgeId))}
         overrideHeader={{
           mode: HeaderMode.Default,
-          title: '활동 뱃지 관리',
+          title: '활동 배지 관리',
           hasLeftIcon: true,
         }}
       />

--- a/apps/admin/src/app-pages/badge/BadgeListPage.tsx
+++ b/apps/admin/src/app-pages/badge/BadgeListPage.tsx
@@ -17,7 +17,7 @@ export const BadgeListPage = () => {
       <div className="pointer-events-none absolute inset-0 z-50">
         <div className="pointer-events-auto absolute right-15 bottom-15">
           <Fab
-            ariaLabel="신규 뱃지 생성 버튼"
+            ariaLabel="신규 배지 생성 버튼"
             onClick={() => router.push(PAGE_ROUTES.BADGE_MNG.CREATE)}
           />
         </div>

--- a/apps/admin/src/app-pages/badge/model/useBadgeAssignPage.ts
+++ b/apps/admin/src/app-pages/badge/model/useBadgeAssignPage.ts
@@ -58,7 +58,7 @@ export const useBadgeAssignPage = (badgeId: number) => {
     openAlert({
       state: 'default',
       title: '부여하시겠습니까?',
-      infoText: `부여하기 버튼을 누를 시, 선택한 ${selectedIds.size}명의 인원에게 활동 뱃지가 부여됩니다.`,
+      infoText: `부여하기 버튼을 누를 시, 선택한 ${selectedIds.size}명의 인원에게 활동 배지가 부여됩니다.`,
       actions: [
         { type: 'solid', variant: 'secondary', label: '취소', onClick: closeAlert },
         {

--- a/apps/admin/src/features/badge/model/useBadgeEditForm.ts
+++ b/apps/admin/src/features/badge/model/useBadgeEditForm.ts
@@ -187,7 +187,7 @@ export const useBadgeEditForm = (
       state: 'default',
       title: '삭제하시겠습니까?',
       infoText:
-        '삭제하기 버튼을 누를 시, 해당 뱃지 데이터와 함께 부여된 회원들의 뱃지 목록에서도 해당 뱃지가 삭제됩니다.',
+        '삭제하기 버튼을 누를 시, 해당 배지 데이터와 함께 부여된 회원들의 배지 목록에서도 해당 배지가 삭제됩니다.',
       actions: [
         { type: 'solid', variant: 'secondary', label: '취소', onClick: closeAlert },
         {

--- a/apps/admin/src/shared/config/routes.tsx
+++ b/apps/admin/src/shared/config/routes.tsx
@@ -78,7 +78,7 @@ export const createRouteConfig = (_router: RouterInstance): RouteConfig[] => [
     backPath: PAGE_ROUTES.HOME,
     header: {
       mode: HeaderMode.Default,
-      title: '활동 뱃지 관리',
+      title: '활동 배지 관리',
       hasLeftIcon: true,
     },
   },
@@ -88,7 +88,7 @@ export const createRouteConfig = (_router: RouterInstance): RouteConfig[] => [
     backPath: PAGE_ROUTES.BADGE_MNG.LIST,
     header: {
       mode: HeaderMode.Default,
-      title: '신규 뱃지 생성',
+      title: '신규 배지 생성',
       hasLeftIcon: true,
     },
   },

--- a/apps/admin/src/widgets/badge/ui/BadgeBasicSection.tsx
+++ b/apps/admin/src/widgets/badge/ui/BadgeBasicSection.tsx
@@ -38,7 +38,7 @@ export const BadgeBasicSection = ({
   return (
     <>
       {/* 배지 이미지 표시/수정 영역 */}
-      <FieldGroup title="뱃지 이미지 등록" className="px-13">
+      <FieldGroup title="배지 이미지 등록" className="px-13">
         {isEdit && onSelectFile ? (
           <ImgUploader
             mode="edit"
@@ -65,7 +65,7 @@ export const BadgeBasicSection = ({
       </FieldGroup>
 
       {/* 배지 이름 표시/수정 영역 */}
-      <FieldGroup title="뱃지 이름" className="px-13">
+      <FieldGroup title="배지 이름" className="px-13">
         {isEdit && onChangeName ? (
           <TextArea
             mode="oneLine"

--- a/apps/admin/src/widgets/badge/ui/BadgeEditActionSection.tsx
+++ b/apps/admin/src/widgets/badge/ui/BadgeEditActionSection.tsx
@@ -16,7 +16,7 @@ export const BadgeEditActionSection = ({
     // 배지 자체를 삭제하는 위험 액션 영역
     <div className="px-13">
       <SolidButton size="m" variant="warning" isDisabled={isDisabled} onClick={onDelete}>
-        해당 뱃지 삭제하기
+        해당 배지 삭제하기
       </SolidButton>
     </div>
   );

--- a/apps/admin/src/widgets/badge/ui/BadgeListWidget.tsx
+++ b/apps/admin/src/widgets/badge/ui/BadgeListWidget.tsx
@@ -32,7 +32,7 @@ export const BadgeListWidget = () => {
   if (badges.length === 0) {
     return (
       <div className="flex flex-1 items-center justify-center px-13">
-        <p className="text-body-body8 text-foreground-tertiary">등록된 뱃지가 없어요.</p>
+        <p className="text-body-body8 text-foreground-tertiary">등록된 배지가 없어요.</p>
       </div>
     );
   }

--- a/apps/web/src/app-pages/post/PostDetailPage.tsx
+++ b/apps/web/src/app-pages/post/PostDetailPage.tsx
@@ -210,6 +210,12 @@ const PostDetailPage = ({ postId }: PostDetailPageProps) => {
                 postId={numericPostId}
                 memberId={memberId ?? undefined}
                 scrollRootRef={scrollRootRef}
+                isInteractionDisabled={post.isReserved}
+                emptyMessage={
+                  post.isReserved
+                    ? '예약 게시물에는 댓글을 남길 수 없어요'
+                    : '첫 댓글을 남겨보세요!'
+                }
                 onStartReply={handleStartReply}
               />
             </div>
@@ -217,12 +223,14 @@ const PostDetailPage = ({ postId }: PostDetailPageProps) => {
         </div>
 
         {/* 댓글 입력창 */}
-        <CommentComposer
-          postId={numericPostId}
-          keyboardOffset={keyboardOffset}
-          pendingReply={pendingReply}
-          onConsumedReply={handleConsumedReply}
-        />
+        {!post.isReserved && (
+          <CommentComposer
+            postId={numericPostId}
+            keyboardOffset={keyboardOffset}
+            pendingReply={pendingReply}
+            onConsumedReply={handleConsumedReply}
+          />
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/app-pages/post/write/ui/PostPage.tsx
+++ b/apps/web/src/app-pages/post/write/ui/PostPage.tsx
@@ -224,8 +224,15 @@ const PostPage = (props: PostPageProps) => {
 
       {/* 예약중 태그 */}
       {reserved && (
-        <div className="px-13 pt-10">
+        <div className="flex items-center gap-8 px-13 pt-10">
           <PostBadge type="reservation" />
+          <button
+            type="button"
+            onClick={handleRemoveReservation}
+            className="text-caption-caption5 text-foreground-tertiary underline underline-offset-2"
+          >
+            예약 취소
+          </button>
         </div>
       )}
 

--- a/apps/web/src/app-pages/post/write/ui/PostPage.tsx
+++ b/apps/web/src/app-pages/post/write/ui/PostPage.tsx
@@ -150,10 +150,10 @@ const PostPage = (props: PostPageProps) => {
   const boardLabel = board ? board.label : '';
   const boardCategories = getCategoriesForBoard(Number(boardId));
   const isGeneralBoard = Number(boardId) === 2;
+  const canUseReservationTools = memberRole !== 'member' && !isGeneralBoard;
 
   const disabledToolbarKeys = [
-    ...(memberRole === 'member' || isGeneralBoard ? [TOOLBAR_KEY.CALENDAR] : []),
-    ...(isGeneralBoard ? [TOOLBAR_KEY.ALARM] : []),
+    ...(!canUseReservationTools ? [TOOLBAR_KEY.ALARM, TOOLBAR_KEY.CALENDAR] : []),
   ];
 
   const { MAX_TITLE_LENGTH } = POST_VALIDATION;

--- a/apps/web/src/app-pages/post/write/ui/PostPage.tsx
+++ b/apps/web/src/app-pages/post/write/ui/PostPage.tsx
@@ -18,10 +18,12 @@ import { useAuthStore } from '@/features/auth/model/useAuthStore';
 import { useGetPostScheduleQuery } from '@/features/post/model/useGetPostScheduleQuery';
 import { TOOLBAR_KEY } from '@/features/post/post-editor/ui/PostEditorToolbar';
 import { usePostForm } from '@/features/post/post-form/model/usePostForm';
+import { usePostFormExitGuard } from '@/features/post/post-form/model/usePostFormExitGuard';
 import { usePostFormStore } from '@/features/post/post-form/model/usePostFormStore';
 import { usePostInitialization } from '@/features/post/post-form/model/usePostInitialization';
 import { useCreatePostScheduleStore } from '@/features/schedule/create-post-schedule/model/useCreatePostScheduleStore';
 
+import { PAGE_ROUTES } from '@/shared/config/path';
 import { useBottomSheetStore } from '@/shared/store/bottomSheetStore';
 import { AppHeader } from '@/widgets/header/ui/AppHeader';
 import { PostEditor } from '@/widgets/post/post-editor/PostEditor';
@@ -79,7 +81,7 @@ const PostPage = (props: PostPageProps) => {
     showExitAlert,
     setShowExitAlert,
     isSubmitDisabled,
-    handleBack,
+    hasUnsavedChanges,
     handleSubmit,
     resetPostState,
     isPublished,
@@ -108,6 +110,26 @@ const PostPage = (props: PostPageProps) => {
     setShowExitAlert(false);
     closeAlert();
   }, [closeAlert, setShowExitAlert]);
+
+  const navigateOut = useCallback(() => {
+    resetPostState();
+
+    if (mode === 'edit' && postId) {
+      router.push(PAGE_ROUTES.BOARD.POST_DETAIL(boardId, postId));
+      return;
+    }
+
+    router.push(PAGE_ROUTES.BOARD.SELECT_CATEGORY(boardId));
+  }, [boardId, mode, postId, resetPostState, router]);
+
+  const requestExit = useCallback(() => {
+    if (hasUnsavedChanges()) {
+      setShowExitAlert(true);
+      return;
+    }
+
+    navigateOut();
+  }, [hasUnsavedChanges, navigateOut, setShowExitAlert]);
 
   const handleSaveReservation = (date: Date) => {
     setField('reservedAt', date);
@@ -172,14 +194,19 @@ const PostPage = (props: PostPageProps) => {
           variant: 'danger',
           onClick: () => {
             closeExitAlert();
-            resetPostState();
-            router.back();
+            navigateOut();
           },
         },
       ],
     });
     setShowExitAlert(false);
-  }, [closeExitAlert, openAlert, resetPostState, router, setShowExitAlert, showExitAlert]);
+  }, [closeExitAlert, navigateOut, openAlert, setShowExitAlert, showExitAlert]);
+
+  usePostFormExitGuard({
+    enabled: isInitialized,
+    hasUnsavedChanges,
+    onRequestExit: requestExit,
+  });
 
   if (!isInitialized) return <Loading />;
 
@@ -187,7 +214,7 @@ const PostPage = (props: PostPageProps) => {
     <div className="flex h-full w-full flex-1 flex-col">
       {/* 1. 상단 헤더 */}
       <AppHeader
-        customBack={handleBack}
+        customBack={requestExit}
         overrideHeader={{
           mode: HeaderMode.TextBtn,
           title: boardLabel,

--- a/apps/web/src/entities/calendar/ui/DailyActivityBadgeList/DailyActivityBadgeList.stories.tsx
+++ b/apps/web/src/entities/calendar/ui/DailyActivityBadgeList/DailyActivityBadgeList.stories.tsx
@@ -27,7 +27,7 @@ const meta: Meta<typeof DailyActivityBadgeList> = {
     },
     maxVisible: {
       control: { type: 'number', min: 2, max: 3 },
-      description: '한 셀에 최대로 보여줄 뱃지 개수 (나머지는 "더보기"로 표시)',
+      description: '한 셀에 최대로 보여줄 배지 개수 (나머지는 "더보기"로 표시)',
     },
     isCurrentMonth: {
       control: 'boolean',

--- a/apps/web/src/entities/notification/ui/NotificationItem.tsx
+++ b/apps/web/src/entities/notification/ui/NotificationItem.tsx
@@ -30,7 +30,7 @@ export const NotificationItem = ({
       onClick={onClick}
       className={`w-full p-13 ${isRead ? 'bg-background-normal' : 'bg-background-notification'} flex items-center gap-15`}
     >
-      {/* 아바타 + 뱃지 박스 */}
+      {/* 아바타 + 배지 박스 */}
       {badge && (
         <div className="relative">
           <Avatar src={userImageUrl} size="m" />

--- a/apps/web/src/entities/post/ui/post-card/PostCard.tsx
+++ b/apps/web/src/entities/post/ui/post-card/PostCard.tsx
@@ -56,7 +56,7 @@ const PostCardComponent = ({
       aria-label={`게시글: ${title}`}
     >
       <div className="flex flex-1 flex-col gap-8 self-stretch">
-        {/* 뱃지 */}
+        {/* 배지 */}
         <div className="flex gap-5">
           {shouldShowCategoryBadge && <PostBadge type="category" label={categoryName} />}
 

--- a/apps/web/src/entities/user/api/types.ts
+++ b/apps/web/src/entities/user/api/types.ts
@@ -26,7 +26,7 @@ export type UserProfileApiResponse = CommonResponse<{
   }>;
 }>;
 
-// 활동뱃지
+// 활동 배지
 export type BadgeItemDTO = {
   badgeId: number;
   badgeName: string;

--- a/apps/web/src/features/comment/ui/Comment.tsx
+++ b/apps/web/src/features/comment/ui/Comment.tsx
@@ -17,6 +17,7 @@ import type { MentionResponse } from '@/features/comment/api/types';
  * @prop onLikeToggle 좋아요 클릭 콜백 (newState: true=좋아요, false=취소)
  * @prop onReplyClick 답글 클릭 콜백
  * @prop onMoreClick 더보기 클릭 콜백
+ * @prop isActionDisabled 좋아요/답글 액션 비활성화 여부
  */
 
 interface CommentProps {
@@ -31,6 +32,7 @@ interface CommentProps {
   onProfileClick?: () => void;
   onReplyClick?: () => void;
   onMoreClick?: () => void;
+  isActionDisabled?: boolean;
 }
 
 function renderContentWithMentions(content: string, mentions: MentionResponse[] | undefined) {
@@ -65,8 +67,10 @@ export const Comment = ({
   onProfileClick,
   onReplyClick,
   onMoreClick,
+  isActionDisabled = false,
 }: CommentProps) => {
   const handleLikeToggle = () => {
+    if (isActionDisabled) return;
     onLikeToggle?.(!isLiked);
   };
   const isProfileClickable = Boolean(onProfileClick);
@@ -107,6 +111,7 @@ export const Comment = ({
             className="text-caption-caption4 text-foreground-secondary-lighter flex items-center gap-5"
             aria-label={`좋아요 ${likeCount}개`}
             onClick={handleLikeToggle}
+            disabled={isActionDisabled}
           >
             <SurfIcon
               name="Heart"
@@ -124,6 +129,7 @@ export const Comment = ({
             className="text-caption-caption4 text-foreground-secondary-lighter flex items-center gap-5"
             aria-label="답글 달기"
             onClick={onReplyClick}
+            disabled={isActionDisabled}
           >
             <SurfIcon name="Chat" size="s" aria-hidden="true" />
             <span aria-hidden="true">답글달기</span>

--- a/apps/web/src/features/feedback/model/usePostFeedback.ts
+++ b/apps/web/src/features/feedback/model/usePostFeedback.ts
@@ -1,4 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
+import { useAlertStore } from '@surf/ui/store/alertStore';
 import { useRouter } from 'next/navigation';
 import { PAGE_ROUTES } from '@/shared/config/path';
 import { AxiosError } from 'axios';
@@ -7,25 +8,38 @@ import { postFeedback } from '../api/postFeedback';
 // 피드백 보내기 훅
 export const usePostFeedback = () => {
   const router = useRouter();
+  const openAlert = useAlertStore((s) => s.open);
+  const closeAlert = useAlertStore((s) => s.close);
 
   return useMutation({
     mutationFn: postFeedback,
     onSuccess: () => {
-      // 피드백 보내기 성공 시 로직
-      alert('소중한 피드백 감사합니다.');
+      openAlert({
+        state: 'default',
+        title: '소중한 피드백 감사합니다.',
+        actions: [{ type: 'text', label: '확인', variant: 'primary', onClick: closeAlert }],
+      });
     },
     onError: (error: AxiosError) => {
       // 피드백 보내기 실패 시 로직
       let errorMessage = '피드백 전송에 실패했습니다.';
+      let onConfirm = closeAlert;
 
       if (error.response?.status === 429) {
         errorMessage = '피드백은 하루 3회로 제한됩니다! 설정 페이지로 이동합니다.';
-        router.push(PAGE_ROUTES.MYPAGE.SETTINGS);
+        onConfirm = () => {
+          closeAlert();
+          router.push(PAGE_ROUTES.MYPAGE.SETTINGS);
+        };
       } else if (error.response?.status === 500) {
         errorMessage = '서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
       }
 
-      alert(errorMessage);
+      openAlert({
+        state: 'error',
+        title: errorMessage,
+        actions: [{ type: 'text', label: '확인', variant: 'primary', onClick: onConfirm }],
+      });
     },
   });
 };

--- a/apps/web/src/features/post/post-form/model/usePostForm.ts
+++ b/apps/web/src/features/post/post-form/model/usePostForm.ts
@@ -79,15 +79,10 @@ export const usePostForm = ({ mode, boardId, postId, postDetail, postSchedule }:
   const isPublished = !!(mode === 'edit' && postDetail && !postDetail.isReserved);
 
   // 5. Event Handlers
-  const handleBack = () => {
+  const hasUnsavedChanges = useCallback(() => {
     const { hasChanges, isEmpty } = checkHasChanges();
-    if (hasChanges && !isEmpty) {
-      setShowExitAlert(true);
-    } else {
-      resetPostState();
-      router.back();
-    }
-  };
+    return hasChanges && !isEmpty;
+  }, [checkHasChanges]);
 
   const queryClient = useQueryClient();
 
@@ -273,7 +268,7 @@ export const usePostForm = ({ mode, boardId, postId, postDetail, postSchedule }:
     setShowExitAlert,
 
     // Handlers
-    handleBack,
+    hasUnsavedChanges,
     handleSubmit,
     handleScheduleRemove: clearLinkedSchedule,
     resetPostState,

--- a/apps/web/src/features/post/post-form/model/usePostForm.ts
+++ b/apps/web/src/features/post/post-form/model/usePostForm.ts
@@ -119,6 +119,8 @@ export const usePostForm = ({ mode, boardId, postId, postDetail, postSchedule }:
       }));
 
     const categoryId = categoryKeyToId(category, Number(boardId)) ?? 1;
+    const formattedReservedAt =
+      reserved && reservedAt ? format(reservedAt, "yyyy-MM-dd'T'HH:mm:ss") : null;
 
     try {
       let targetPostId = numericPostId;
@@ -130,7 +132,7 @@ export const usePostForm = ({ mode, boardId, postId, postDetail, postSchedule }:
           title,
           content,
           pinned: false,
-          reservedAt: reservedAt ? format(reservedAt, "yyyy-MM-dd'T'HH:mm:ss") : '',
+          reservedAt: formattedReservedAt,
           imageUrlList,
           fileList,
           hasSchedule: !!linkedSchedule,
@@ -157,7 +159,8 @@ export const usePostForm = ({ mode, boardId, postId, postDetail, postSchedule }:
           categoryId,
           pinned: false,
           isReservationChanged,
-          reservedAt: reservedAt ? format(reservedAt, "yyyy-MM-dd'T'HH:mm:ss") : '',
+          reserved,
+          reservedAt: formattedReservedAt,
           isContentChanged,
           isImageChanged: isImagesChanged,
           imageUrlList,

--- a/apps/web/src/features/post/post-form/model/usePostFormExitGuard.ts
+++ b/apps/web/src/features/post/post-form/model/usePostFormExitGuard.ts
@@ -1,0 +1,46 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+type UsePostFormExitGuardParams = {
+  enabled: boolean;
+  hasUnsavedChanges: () => boolean;
+  onRequestExit: () => void;
+};
+
+export const usePostFormExitGuard = ({
+  enabled,
+  hasUnsavedChanges,
+  onRequestExit,
+}: UsePostFormExitGuardParams) => {
+  const hasPushedExitGuardStateRef = useRef(false);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    if (!hasPushedExitGuardStateRef.current) {
+      hasPushedExitGuardStateRef.current = true;
+      history.pushState({ __postFormExitGuard: true }, '', window.location.href);
+    }
+
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (!hasUnsavedChanges()) return;
+
+      event.preventDefault();
+      event.returnValue = '';
+    };
+
+    const handlePopState = () => {
+      history.go(1);
+      onRequestExit();
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    window.addEventListener('popstate', handlePopState);
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+      window.removeEventListener('popstate', handlePopState);
+    };
+  }, [enabled, hasUnsavedChanges, onRequestExit]);
+};

--- a/apps/web/src/features/post/update-post/api/types.ts
+++ b/apps/web/src/features/post/update-post/api/types.ts
@@ -6,6 +6,7 @@ export type UpdatePostRequest = {
   categoryId?: number;
   pinned?: boolean;
   isReservationChanged?: boolean;
+  reserved?: boolean;
   reservedAt?: string | null;
   isContentChanged?: boolean;
   isImageChanged?: boolean;

--- a/apps/web/src/shared/ui/action-bar/ActionBar.tsx
+++ b/apps/web/src/shared/ui/action-bar/ActionBar.tsx
@@ -1,6 +1,6 @@
 import { SurfIcon } from '@surf/ui/icon';
 import { MentionTextInput } from '@surf/ui/text-input';
-import { forwardRef, useRef, useImperativeHandle } from 'react';
+import { forwardRef, useRef, useImperativeHandle, type KeyboardEventHandler } from 'react';
 
 /**
  * 범용 메시지 입력 및 전송 컴포넌트
@@ -32,11 +32,21 @@ interface ActionBarProps {
   onSend?: (val: string) => void | boolean | Promise<void | boolean>;
   focusAfterSend?: boolean;
   disabled?: boolean;
+  onKeyDown?: KeyboardEventHandler<HTMLTextAreaElement>;
 }
 
 export const ActionBar = forwardRef<HTMLTextAreaElement, ActionBarProps>(
   (
-    { value, defaultValue, onChange, placeholder, onSend, focusAfterSend = true, disabled },
+    {
+      value,
+      defaultValue,
+      onChange,
+      placeholder,
+      onSend,
+      focusAfterSend = true,
+      disabled,
+      onKeyDown,
+    },
     ref,
   ) => {
     const internalRef = useRef<HTMLTextAreaElement>(null);
@@ -90,6 +100,7 @@ export const ActionBar = forwardRef<HTMLTextAreaElement, ActionBarProps>(
           placeholder={placeholder}
           onEnter={handleSend}
           disabled={disabled}
+          onKeyDown={onKeyDown}
         />
         <button
           type="button"

--- a/apps/web/src/widgets/comment-composer/ui/CommentComposer.tsx
+++ b/apps/web/src/widgets/comment-composer/ui/CommentComposer.tsx
@@ -5,7 +5,7 @@ import { Avatar } from '@surf/ui/avatar';
 import { Sheet } from '@surf/ui/sheet';
 import { SheetItem } from '@surf/ui/sheet';
 import { useToastStore } from '@surf/ui/store/toastStore';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from 'react';
 import type { MentionSearchResponse } from '@/features/comment/api/types';
 import { trackCommentEvent } from '@/features/comment/lib/trackCommentEvent';
 import { COMMENT_EVENTS } from '@/features/comment/model/types';
@@ -38,6 +38,16 @@ function extractMentionNicknames(text: string) {
     if (nick) res.push(nick);
   }
   return res;
+}
+
+function getCompletedMentionDeleteRange(text: string, cursorIndex: number) {
+  const left = text.slice(0, cursorIndex);
+  const match = /(^|\s)(@[^\s@]+\s)$/.exec(left);
+
+  if (!match?.[2]) return null;
+
+  const tokenStart = cursorIndex - match[2].length;
+  return { start: tokenStart, end: cursorIndex };
 }
 
 interface Props {
@@ -132,6 +142,26 @@ export const CommentComposer = ({
       setMentionAtIndex(info.atIndex);
       setMentionKeyword(info.keyword);
     }
+  };
+
+  const handleKeyDown = (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key !== 'Backspace') return;
+
+    const target = event.currentTarget;
+    if (target.selectionStart !== target.selectionEnd) return;
+
+    const range = getCompletedMentionDeleteRange(value, target.selectionStart);
+    if (!range) return;
+
+    event.preventDefault();
+
+    const next = value.slice(0, range.start) + value.slice(range.end);
+    setValue(next);
+    closeMentionPanel();
+
+    requestAnimationFrame(() => {
+      inputRef.current?.setSelectionRange(range.start, range.start);
+    });
   };
 
   const pickMention = (user: MentionSearchResponse) => {
@@ -264,6 +294,7 @@ export const CommentComposer = ({
             onSend={onSend}
             focusAfterSend={false}
             disabled={createMutation.isPending}
+            onKeyDown={handleKeyDown}
           />
         </div>
       </div>

--- a/apps/web/src/widgets/comment-section/ui/CommentSection.tsx
+++ b/apps/web/src/widgets/comment-section/ui/CommentSection.tsx
@@ -32,11 +32,20 @@ interface Props {
   postId: number;
   memberId?: number;
   scrollRootRef?: React.RefObject<HTMLDivElement | null>;
+  isInteractionDisabled?: boolean;
+  emptyMessage?: string;
   // 답글 시작을 부모로 올림
   onStartReply: (info: { commentId: number; memberId: number; nickname: string }) => void;
 }
 
-export const CommentSection = ({ postId, memberId, scrollRootRef, onStartReply }: Props) => {
+export const CommentSection = ({
+  postId,
+  memberId,
+  scrollRootRef,
+  isInteractionDisabled = false,
+  emptyMessage = '첫 댓글을 남겨보세요!',
+  onStartReply,
+}: Props) => {
   const router = useRouter();
   const myId = useAuthStore((s) => s.memberId);
   const openBottomSheet = useBottomSheetStore((s) => s.open);
@@ -172,6 +181,7 @@ export const CommentSection = ({ postId, memberId, scrollRootRef, onStartReply }
                         : undefined
                     }
                     onLikeToggle={() => {
+                      if (isInteractionDisabled) return;
                       const nextState = c.liked ? 'off' : 'on';
                       trackCommentEvent(COMMENT_EVENTS.LIKE, {
                         target_type: 'comment',
@@ -182,10 +192,12 @@ export const CommentSection = ({ postId, memberId, scrollRootRef, onStartReply }
                         onError: () => showToast('좋아요 처리에 실패했어요'),
                       });
                     }}
-                    onReplyClick={() =>
-                      onStartReply({ commentId: c.id, memberId: c.memberId, nickname: c.nickname })
-                    }
+                    onReplyClick={() => {
+                      if (isInteractionDisabled) return;
+                      onStartReply({ commentId: c.id, memberId: c.memberId, nickname: c.nickname });
+                    }}
                     onMoreClick={() => openOptions(c)}
+                    isActionDisabled={isInteractionDisabled}
                   />
                 </div>
               );
@@ -198,9 +210,7 @@ export const CommentSection = ({ postId, memberId, scrollRootRef, onStartReply }
                   aria-hidden="true"
                   focusable="false"
                 />
-                <div className="text-body-body8 text-foreground-tertiary">
-                  첫 댓글을 남겨보세요!
-                </div>
+                <div className="text-body-body8 text-foreground-tertiary">{emptyMessage}</div>
               </div>
             )}
           </div>

--- a/apps/web/src/widgets/post-detail/PostBodySection.tsx
+++ b/apps/web/src/widgets/post-detail/PostBodySection.tsx
@@ -151,16 +151,18 @@ export const PostBodySection = ({ post, schedule, onClickLikeCount }: PostBodySe
       </div>
 
       {/* 좋아요 / 스크랩 */}
-      <div className="flex justify-between">
-        <ChipToggle
-          isClicked={post.likedByMe}
-          count={post.likeCount}
-          onToggleIcon={handleLikeToggle}
-          iconName="Heart"
-          activeColor="red"
-          onClickNumber={onClickLikeCount}
-          mode="count"
-        />
+      <div className={`flex ${post.isReserved ? 'justify-end' : 'justify-between'}`}>
+        {!post.isReserved && (
+          <ChipToggle
+            isClicked={post.likedByMe}
+            count={post.likeCount}
+            onToggleIcon={handleLikeToggle}
+            iconName="Heart"
+            activeColor="red"
+            onClickNumber={onClickLikeCount}
+            mode="count"
+          />
+        )}
 
         <ChipToggle
           isClicked={post.scrappedByMe}

--- a/apps/web/src/widgets/profile-badge/ui/ActivityBadge.stories.tsx
+++ b/apps/web/src/widgets/profile-badge/ui/ActivityBadge.stories.tsx
@@ -13,14 +13,14 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    badgeName: '17기 환영 뱃지',
+    badgeName: '17기 환영 배지',
     timestamp: '2026-06-30',
   },
 };
 
 export const Loading: Story = {
   args: {
-    badgeName: '17기 환영 뱃지',
+    badgeName: '17기 환영 배지',
     loading: true,
   },
 };
@@ -40,7 +40,7 @@ export const Many: Story = {
 
 export const Scaled: Story = {
   args: {
-    badgeName: '17기 환영 뱃지',
+    badgeName: '17기 환영 배지',
     timestamp: '2026-06-30',
     scale: 1.2,
   },

--- a/apps/web/src/widgets/profile-badge/ui/ProfileBadge.tsx
+++ b/apps/web/src/widgets/profile-badge/ui/ProfileBadge.tsx
@@ -16,7 +16,7 @@ import ActivityBadgeEmpty from '@/shared/assets/icons/empty-space/activity-badge
 // );
 
 interface Props {
-  memberId?: number; // 없으면 내 뱃지
+  memberId?: number; // 없으면 내 배지
 }
 
 export const ProfileBadge = ({ memberId }: Props) => {
@@ -35,7 +35,7 @@ export const ProfileBadge = ({ memberId }: Props) => {
   return (
     <section className="flex flex-col gap-16 px-13 py-13 pt-16">
       <div className="flex flex-col gap-10">
-        <h2 className="text-title-title2 text-foreground-normal">활동 뱃지</h2>
+        <h2 className="text-title-title2 text-foreground-normal">활동 배지</h2>
         {!isWaitingMemberId && !isLoading ? (
           <>
             {badges.length > 0 ? (
@@ -54,7 +54,7 @@ export const ProfileBadge = ({ memberId }: Props) => {
               <div className="flex flex-col items-center gap-3 py-16">
                 <ActivityBadgeEmpty aria-hidden="true" />
                 <span className="text-body-body8 text-foreground-tertiary">
-                  부여받은 활동 뱃지가 없어요
+                  부여받은 활동 배지가 없어요
                 </span>
               </div>
             )}

--- a/packages/ui/components/tab/Tab.stories.tsx
+++ b/packages/ui/components/tab/Tab.stories.tsx
@@ -18,7 +18,7 @@ export const Uncontrolled: Story = {
         defaultValue="profile"
         items={[
           { value: 'profile', label: '프로필' },
-          { value: 'badges', label: '활동뱃지' },
+          { value: 'badges', label: '활동 배지' },
         ]}
       />
     </div>
@@ -36,10 +36,10 @@ export const Controlled: Story = {
             onValueChange={setTab}
             items={[
               { value: 'profile', label: '프로필' },
-              { value: 'badges', label: '활동뱃지' },
+              { value: 'badges', label: '활동 배지' },
             ]}
           />
-          <div className="mt-4">{tab === 'profile' ? '프로필 탭' : '활동뱃지 탭'}</div>
+          <div className="mt-4">{tab === 'profile' ? '프로필 탭' : '활동 배지 탭'}</div>
         </div>
       );
     };


### PR DESCRIPTION
### 작업 내용

#### 예약 게시물 상호작용 제한
- 예약 게시물 상세에서 좋아요 버튼을 숨김 처리했습니다.
- 예약 게시물에서는 댓글 입력창을 렌더링하지 않도록 처리했습니다.
- 예약 게시물 댓글 영역에 `예약 게시물에는 댓글을 남길 수 없어요` 문구를 노출했습니다.
- 예약 게시물의 기존 댓글 액션도 비활성화할 수 있도록 댓글 컴포넌트 props를 확장했습니다.

#### 예약 취소 관련 개선
- 예약 게시글 수정 시 예약 취소 상태가 payload에 반영되도록 보강했습니다.
  - `reservedAt`은 예약 상태일 때만 날짜 문자열로 변환
  - 예약 취소 상태에서는 `reservedAt: null` 전송
  - 수정 payload에 `reserved` 포함
  - `UpdatePostRequest`에 `reserved?: boolean` 추가
- 글 작성 중 예약 설정 후 바로 취소할 수 있도록 `예약중` 배지 옆에 `예약 취소` 버튼을 추가했습니다.
- 기존 예약 취소 확인창을 재사용해 작성/수정 화면에서 동일한 취소 UX를 제공했습니다.

### 해결/개선 항목

- 예약 게시물인데 댓글·좋아요 등록 가능
- 공지사항 작성 중 예약 설정 후 취소 기능 없음
- 예약 취소 후 게시글 수정 payload 보강

### 검증
예약 취소 후 수정 저장은 브라우저 검증 중 `PATCH /v1/user/posts/{postId}`에서 500 응답이 발생했습니다. FE payload는 보강했지만, 최종 해결 여부는 백엔드가 예약 취소 수정 요청을 어떤 스펙으로 받는지 확인이 필요합니다.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/6820bcb9-c643-44d9-85ca-b57c6db3cd7d" />
