### PR TITLE
[FEAT] 계정 통합 플로우 추가

### DIFF
--- a/apps/web/src/app-pages/onboarding/ui/OnBoardingPage.tsx
+++ b/apps/web/src/app-pages/onboarding/ui/OnBoardingPage.tsx
@@ -49,7 +49,9 @@ const OnBoardingPage = () => {
           allAgreed: isAllRequiredChecked,
         },
       });
-    } else {
+    } else if (useBottomSheetStore.getState().current?.type === 'law') {
+      // 바텀시트 슬롯은 전역에 하나뿐이므로, 이 이펙트는 자기가 연 약관 시트만 닫는다.
+      // (계정 통합 시트 등 다른 시트가 열려 있을 때 닫아버리지 않도록 한다)
       closeBottomSheet();
     }
   }, [

--- a/apps/web/src/entities/search/ui/MemberItem.tsx
+++ b/apps/web/src/entities/search/ui/MemberItem.tsx
@@ -1,8 +1,8 @@
 import { Avatar } from '@surf/ui/avatar';
 import { InfoBadge } from '@surf/ui/info-badge';
 import { MemberSearchItem } from '../model/types';
-import { useDynamicVisibleCount } from '../model/useDynamicVisibleCount';
 import { USER_LEVEL_BADGE } from '@/entities/user/ui/user-level/UserLevelBadges';
+import { useDynamicVisibleCount } from '@/shared/hooks/useDynamicVisibleCount';
 
 interface MemberItemProps {
   user: MemberSearchItem;

--- a/apps/web/src/features/account-integration/api/getIntegrationTarget.ts
+++ b/apps/web/src/features/account-integration/api/getIntegrationTarget.ts
@@ -1,0 +1,18 @@
+import { axiosInstance } from '@/shared/lib/axiosInstance';
+import type { IntegrationTargetApiResponse } from './types';
+import { mapIntegrationTarget } from '../model/mappers';
+import type { IntegrationTarget } from '../model/types';
+
+/**
+ * 온보딩 중 감지된 통합 대상(기존 계정)의 프로필과 연결된 소셜 로그인 수단을 조회한다.
+ *
+ * `REGISTERING` 상태 임시 회원의 Access Token으로만 호출 가능하며,
+ * 통합 대기 정보가 없거나 만료된 경우 404 / 410 으로 실패한다.
+ */
+export async function getIntegrationTarget(): Promise<IntegrationTarget> {
+  const res = await axiosInstance.get<IntegrationTargetApiResponse>(
+    'v1/user/social-accounts/integrate/target',
+  );
+
+  return mapIntegrationTarget(res.data.data);
+}

--- a/apps/web/src/features/account-integration/api/integrateAccount.ts
+++ b/apps/web/src/features/account-integration/api/integrateAccount.ts
@@ -1,0 +1,14 @@
+import { axiosInstance } from '@/shared/lib/axiosInstance';
+import type { SocialAccountIntegrateApiResponse, SocialAccountIntegrateReqDTO } from './types';
+
+/**
+ * 1회성 통합 토큰으로 계정 통합을 실행한다.
+ */
+export async function integrateAccount(body: SocialAccountIntegrateReqDTO) {
+  const res = await axiosInstance.post<SocialAccountIntegrateApiResponse>(
+    'v1/user/social-accounts/integrate',
+    body,
+  );
+
+  return res.data;
+}

--- a/apps/web/src/features/account-integration/api/types.ts
+++ b/apps/web/src/features/account-integration/api/types.ts
@@ -1,0 +1,31 @@
+import type { TrackPart } from '@/entities/user/model/types';
+import type { CommonResponse } from '@/shared/api/types';
+
+export type SocialProvider = 'KAKAO' | 'APPLE';
+
+export type TrackResDTO = {
+  generation: number;
+  part: TrackPart | (string & {});
+};
+
+export type IntegrationTargetResDTO = {
+  providers: SocialProvider[];
+  email: string;
+  phoneNumber: string;
+  username: string;
+  profileImageUrl: string | null;
+  trackList: TrackResDTO[];
+  selfIntroduction: string | null;
+};
+
+export type IntegrationTargetApiResponse = CommonResponse<IntegrationTargetResDTO>;
+
+export type SocialAccountIntegrateReqDTO = {
+  integrationToken: string;
+};
+
+export type SocialAccountIntegrateResDTO = {
+  provider: SocialProvider;
+};
+
+export type SocialAccountIntegrateApiResponse = CommonResponse<SocialAccountIntegrateResDTO>;

--- a/apps/web/src/features/account-integration/index.ts
+++ b/apps/web/src/features/account-integration/index.ts
@@ -1,0 +1,5 @@
+export { AccountIntegrationBottomSheet } from './ui/AccountIntegrationBottomSheet';
+export { IntegrationTargetCard } from './ui/IntegrationTargetCard';
+export { useAccountIntegrationFlow } from './model/useAccountIntegrationFlow';
+export { useIntegrateAccount } from './model/useIntegrateAccount';
+export type { IntegrationTarget } from './model/types';

--- a/apps/web/src/features/account-integration/lib/getSocialAccountIntegrationErrorMessage.ts
+++ b/apps/web/src/features/account-integration/lib/getSocialAccountIntegrationErrorMessage.ts
@@ -1,0 +1,15 @@
+import axios from 'axios';
+
+export function getSocialAccountIntegrationErrorMessage(error: unknown) {
+  const status = axios.isAxiosError(error) ? error.response?.status : undefined;
+
+  if (status === 410 || status === 404) {
+    return '연동 가능 시간이 지났습니다. 처음부터 다시 시도해주세요.';
+  }
+
+  if (status === 409) {
+    return '기존 계정과 연동할 수 없습니다. 입력하신 정보를 확인하시거나 운영진에게 문의해주세요.';
+  }
+
+  return '계정 연동에 실패했습니다. 잠시 후 다시 시도해주세요.';
+}

--- a/apps/web/src/features/account-integration/lib/pendingSocialAccountIntegration.ts
+++ b/apps/web/src/features/account-integration/lib/pendingSocialAccountIntegration.ts
@@ -1,0 +1,96 @@
+import type { SocialProvider } from '../api/types';
+
+const STORAGE_KEY = 'surf:pending-social-account-integration';
+const MAX_AGE_MS = 30 * 60 * 1000;
+
+export type PendingSocialAccountIntegration = {
+  integrationToken: string;
+  provider: SocialProvider;
+  createdAt: number;
+};
+
+function getSessionStorage(): Storage | null {
+  if (typeof window === 'undefined') return null;
+
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+function parsePendingSocialAccountIntegration(
+  value: string | null,
+): PendingSocialAccountIntegration | null {
+  if (!value) return null;
+
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (typeof parsed !== 'object' || parsed === null) return null;
+
+    const data = parsed as Record<string, unknown>;
+    if (typeof data.integrationToken !== 'string') return null;
+    if (data.provider !== 'KAKAO' && data.provider !== 'APPLE') return null;
+    if (typeof data.createdAt !== 'number') return null;
+
+    return {
+      integrationToken: data.integrationToken,
+      provider: data.provider,
+      createdAt: data.createdAt,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function savePendingSocialAccountIntegration(
+  integration: Omit<PendingSocialAccountIntegration, 'createdAt'>,
+) {
+  const storage = getSessionStorage();
+  if (!storage) return;
+
+  try {
+    storage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        ...integration,
+        createdAt: Date.now(),
+      }),
+    );
+  } catch {
+    // OAuth 로그인 자체는 진행할 수 있게 둔다.
+  }
+}
+
+export function getPendingSocialAccountIntegration(): PendingSocialAccountIntegration | null {
+  const storage = getSessionStorage();
+  if (!storage) return null;
+
+  let value: string | null = null;
+  try {
+    value = storage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+
+  const integration = parsePendingSocialAccountIntegration(value);
+  if (!integration) return null;
+
+  if (Date.now() - integration.createdAt > MAX_AGE_MS) {
+    clearPendingSocialAccountIntegration();
+    return null;
+  }
+
+  return integration;
+}
+
+export function clearPendingSocialAccountIntegration() {
+  const storage = getSessionStorage();
+  if (!storage) return;
+
+  try {
+    storage.removeItem(STORAGE_KEY);
+  } catch {
+    // noop
+  }
+}

--- a/apps/web/src/features/account-integration/lib/pendingSocialAccountIntegration.ts
+++ b/apps/web/src/features/account-integration/lib/pendingSocialAccountIntegration.ts
@@ -9,6 +9,10 @@ export type PendingSocialAccountIntegration = {
   createdAt: number;
 };
 
+export type SavePendingSocialAccountIntegrationResult =
+  | { ok: true }
+  | { ok: false; reason: 'storage_unavailable' | 'write_failed' };
+
 function getSessionStorage(): Storage | null {
   if (typeof window === 'undefined') return null;
 
@@ -45,9 +49,9 @@ function parsePendingSocialAccountIntegration(
 
 export function savePendingSocialAccountIntegration(
   integration: Omit<PendingSocialAccountIntegration, 'createdAt'>,
-) {
+): SavePendingSocialAccountIntegrationResult {
   const storage = getSessionStorage();
-  if (!storage) return;
+  if (!storage) return { ok: false, reason: 'storage_unavailable' };
 
   try {
     storage.setItem(
@@ -57,8 +61,9 @@ export function savePendingSocialAccountIntegration(
         createdAt: Date.now(),
       }),
     );
+    return { ok: true };
   } catch {
-    // OAuth 로그인 자체는 진행할 수 있게 둔다.
+    return { ok: false, reason: 'write_failed' };
   }
 }
 

--- a/apps/web/src/features/account-integration/lib/startSocialAccountIntegrationLogin.ts
+++ b/apps/web/src/features/account-integration/lib/startSocialAccountIntegrationLogin.ts
@@ -1,0 +1,18 @@
+import type { SocialProvider } from '../api/types';
+import { savePendingSocialAccountIntegration } from './pendingSocialAccountIntegration';
+import { appleLogin } from '@/features/auth/lib/appleLogin';
+import { kakaoLogin } from '@/features/auth/lib/kakaoLogin';
+
+export function startSocialAccountIntegrationLogin(
+  provider: SocialProvider,
+  integrationToken: string,
+) {
+  savePendingSocialAccountIntegration({ provider, integrationToken });
+
+  if (provider === 'KAKAO') {
+    kakaoLogin();
+    return;
+  }
+
+  appleLogin();
+}

--- a/apps/web/src/features/account-integration/lib/startSocialAccountIntegrationLogin.ts
+++ b/apps/web/src/features/account-integration/lib/startSocialAccountIntegrationLogin.ts
@@ -1,18 +1,23 @@
 import type { SocialProvider } from '../api/types';
-import { savePendingSocialAccountIntegration } from './pendingSocialAccountIntegration';
+import {
+  savePendingSocialAccountIntegration,
+  type SavePendingSocialAccountIntegrationResult,
+} from './pendingSocialAccountIntegration';
 import { appleLogin } from '@/features/auth/lib/appleLogin';
 import { kakaoLogin } from '@/features/auth/lib/kakaoLogin';
 
 export function startSocialAccountIntegrationLogin(
   provider: SocialProvider,
   integrationToken: string,
-) {
-  savePendingSocialAccountIntegration({ provider, integrationToken });
+): SavePendingSocialAccountIntegrationResult {
+  const saveResult = savePendingSocialAccountIntegration({ provider, integrationToken });
+  if (!saveResult.ok) return saveResult;
 
   if (provider === 'KAKAO') {
     kakaoLogin();
-    return;
+    return saveResult;
   }
 
   appleLogin();
+  return saveResult;
 }

--- a/apps/web/src/features/account-integration/model/mappers.ts
+++ b/apps/web/src/features/account-integration/model/mappers.ts
@@ -1,0 +1,20 @@
+import { isTrackPart, toLabelPartMap } from '@/entities/user/model/mappers';
+import type { IntegrationTargetResDTO, TrackResDTO } from '../api/types';
+import type { IntegrationTarget } from './types';
+
+function toChip({ generation, part }: TrackResDTO) {
+  const partLabel = isTrackPart(part) ? toLabelPartMap[part] : part;
+  return `${generation}기 ${partLabel}`;
+}
+
+export function mapIntegrationTarget(dto: IntegrationTargetResDTO): IntegrationTarget {
+  return {
+    username: dto.username,
+    profileImageUrl: dto.profileImageUrl,
+    selfIntroduction: dto.selfIntroduction,
+    email: dto.email,
+    phoneNumber: dto.phoneNumber,
+    providers: dto.providers ?? [],
+    chips: dto.trackList.map(toChip),
+  };
+}

--- a/apps/web/src/features/account-integration/model/types.ts
+++ b/apps/web/src/features/account-integration/model/types.ts
@@ -1,0 +1,11 @@
+import type { SocialProvider } from '../api/types';
+
+export type IntegrationTarget = {
+  username: string;
+  profileImageUrl: string | null;
+  selfIntroduction: string | null;
+  email: string;
+  phoneNumber: string;
+  providers: SocialProvider[];
+  chips: string[];
+};

--- a/apps/web/src/features/account-integration/model/useAccountIntegrationFlow.ts
+++ b/apps/web/src/features/account-integration/model/useAccountIntegrationFlow.ts
@@ -1,0 +1,43 @@
+'use client';
+
+import { useAlertStore } from '@surf/ui/store/alertStore';
+import { useCallback } from 'react';
+import { getIntegrationTarget } from '../api/getIntegrationTarget';
+import { useBottomSheetStore } from '@/shared/store/bottomSheetStore';
+
+/**
+ * 온보딩 제출이 `ACCOUNT_INTEGRATION_REQUIRED`로 실패했을 때의 진입점
+ *
+ * 통합 대상 프로필을 조회한 뒤 재확인용 바텀시트를 연다.
+ * 조회 실패(토큰 만료·대상 없음 등) 시에는 에러 알럿만 노출한다.
+ */
+export const useAccountIntegrationFlow = () => {
+  const openBottomSheet = useBottomSheetStore((s) => s.open);
+  const openAlert = useAlertStore((s) => s.open);
+  const closeAlert = useAlertStore((s) => s.close);
+
+  const start = useCallback(
+    async (integrationToken: string) => {
+      try {
+        const target = await getIntegrationTarget();
+
+        openBottomSheet({
+          type: 'accountIntegration',
+          props: { integrationToken, target },
+        });
+      } catch (error) {
+        console.error('통합 대상 조회 실패:', error);
+
+        openAlert({
+          state: 'error',
+          title: '계정 연동을 진행할 수 없습니다',
+          infoText: '기존 계정 정보를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.',
+          actions: [{ type: 'text', label: '확인', onClick: () => closeAlert() }],
+        });
+      }
+    },
+    [openBottomSheet, openAlert, closeAlert],
+  );
+
+  return { start };
+};

--- a/apps/web/src/features/account-integration/model/useIntegrateAccount.ts
+++ b/apps/web/src/features/account-integration/model/useIntegrateAccount.ts
@@ -1,0 +1,58 @@
+'use client';
+
+import { useMutation } from '@tanstack/react-query';
+import { useAlertStore } from '@surf/ui/store/alertStore';
+import { useRouter } from 'next/navigation';
+import { integrateAccount } from '../api/integrateAccount';
+import { getSocialAccountIntegrationErrorMessage } from '../lib/getSocialAccountIntegrationErrorMessage';
+import { PAGE_ROUTES } from '@/shared/config/path';
+import { useBottomSheetStore } from '@/shared/store/bottomSheetStore';
+
+/**
+ * 1회성 통합 토큰으로 계정 통합을 실행한다.
+ *
+ * 성공 시 바텀시트를 닫고 완료 알럿을 띄우며, 확인 시 로그인 화면으로 이동한다.
+ * (통합된 계정으로 다시 로그인해야 하므로 온보딩으로 돌아가지 않는다.)
+ */
+export const useIntegrateAccount = () => {
+  const router = useRouter();
+  const openAlert = useAlertStore((s) => s.open);
+  const closeAlert = useAlertStore((s) => s.close);
+  const closeBottomSheet = useBottomSheetStore((s) => s.close);
+
+  return useMutation({
+    mutationFn: (integrationToken: string) => integrateAccount({ integrationToken }),
+    onSuccess: () => {
+      closeBottomSheet();
+
+      openAlert({
+        state: 'default',
+        title: '기존 계정으로 연동이 완료되었습니다!',
+        infoText: '이제 연동된 계정을 편하게 사용하시면 됩니다.',
+        actions: [
+          {
+            type: 'text',
+            variant: 'primary',
+            label: '확인',
+            onClick: () => {
+              closeAlert({ restoreFocus: false });
+              router.replace(PAGE_ROUTES.LOGIN);
+            },
+          },
+        ],
+      });
+    },
+    onError: (error) => {
+      // 서버 메시지는 원인을 일부러 감추도록 설계돼 있고(계정 정보 유추 방지)
+      // 사용자에게 그대로 노출할 문구가 아니므로, 콘솔에만 남기고 화면에는 자체 문구를 쓴다.
+      console.error('계정 통합 실패:', error);
+
+      openAlert({
+        state: 'error',
+        title: '연동 실패',
+        infoText: getSocialAccountIntegrationErrorMessage(error),
+        actions: [{ type: 'text', label: '확인', onClick: () => closeAlert() }],
+      });
+    },
+  });
+};

--- a/apps/web/src/features/account-integration/model/useIntegrateAccount.ts
+++ b/apps/web/src/features/account-integration/model/useIntegrateAccount.ts
@@ -23,7 +23,9 @@ export const useIntegrateAccount = () => {
   return useMutation({
     mutationFn: (integrationToken: string) => integrateAccount({ integrationToken }),
     onSuccess: () => {
-      closeBottomSheet();
+      if (useBottomSheetStore.getState().current?.type === 'accountIntegration') {
+        closeBottomSheet();
+      }
 
       openAlert({
         state: 'default',
@@ -43,8 +45,6 @@ export const useIntegrateAccount = () => {
       });
     },
     onError: (error) => {
-      // 서버 메시지는 원인을 일부러 감추도록 설계돼 있고(계정 정보 유추 방지)
-      // 사용자에게 그대로 노출할 문구가 아니므로, 콘솔에만 남기고 화면에는 자체 문구를 쓴다.
       console.error('계정 통합 실패:', error);
 
       openAlert({

--- a/apps/web/src/features/account-integration/ui/AccountIntegrationBottomSheet.tsx
+++ b/apps/web/src/features/account-integration/ui/AccountIntegrationBottomSheet.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { Sheet } from '@surf/ui/sheet';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { Sheet as ModalSheet } from 'react-modal-sheet';
+import type { SocialProvider } from '../api/types';
+import { startSocialAccountIntegrationLogin } from '../lib/startSocialAccountIntegrationLogin';
+import type { IntegrationTarget } from '../model/types';
+import { IntegrationTargetCard } from './IntegrationTargetCard';
+import { SocialAccountIntegrationLoginButton } from './SocialAccountIntegrationLoginButton';
+import { PAGE_ROUTES } from '@/shared/config/path';
+
+declare module '@/shared/store/bottomSheetStore' {
+  interface BottomSheetMap {
+    accountIntegration: Omit<AccountIntegrationBottomSheetProps, 'isOpen' | 'onClose'>;
+  }
+}
+
+export type AccountIntegrationBottomSheetProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  /** 온보딩 제출 409 응답으로 발급받은 1회성 통합 토큰 */
+  integrationToken: string;
+  target: IntegrationTarget;
+};
+
+export const AccountIntegrationBottomSheet = ({
+  isOpen,
+  onClose,
+  integrationToken,
+  target,
+}: AccountIntegrationBottomSheetProps) => {
+  const router = useRouter();
+  const [isRedirecting, setIsRedirecting] = useState(false);
+
+  if (!isOpen) return null;
+
+  const visibleProviders = (['KAKAO', 'APPLE'] satisfies SocialProvider[]).filter((provider) =>
+    target.providers.includes(provider),
+  );
+
+  const handleBackToLogin = () => {
+    onClose();
+    router.replace(PAGE_ROUTES.LOGIN);
+  };
+
+  const handleProviderLogin = (provider: SocialProvider) => {
+    setIsRedirecting(true);
+    startSocialAccountIntegrationLogin(provider, integrationToken);
+  };
+
+  return (
+    <ModalSheet
+      isOpen={isOpen}
+      onClose={onClose}
+      disableDrag={true}
+      className="mx-auto flex w-full sm:w-[min(100dvw,calc(100dvh*375/812))]"
+    >
+      <ModalSheet.Container>
+        <ModalSheet.Content>
+          <Sheet
+            title="기존 가입 정보가 확인되었습니다."
+            description="안전한 데이터 유지를 위해 현재의 로그인을 아래 기존 계정에 연결할까요? 연결 시 기존 활동 점수와 프로필이 그대로 유지됩니다."
+            textBtn={{
+              label: '로그인 화면으로 돌아가기',
+              onClick: handleBackToLogin,
+              disabled: isRedirecting,
+            }}
+          >
+            <div className="flex w-full flex-col gap-15 py-15">
+              <IntegrationTargetCard target={target} />
+
+              {visibleProviders.length > 0 && (
+                <div className="flex w-full flex-col gap-10">
+                  {visibleProviders.map((provider) => (
+                    <SocialAccountIntegrationLoginButton
+                      key={provider}
+                      provider={provider}
+                      disabled={isRedirecting}
+                      onClick={handleProviderLogin}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+          </Sheet>
+        </ModalSheet.Content>
+      </ModalSheet.Container>
+      <ModalSheet.Backdrop onTap={isRedirecting ? undefined : onClose} />
+    </ModalSheet>
+  );
+};

--- a/apps/web/src/features/account-integration/ui/AccountIntegrationBottomSheet.tsx
+++ b/apps/web/src/features/account-integration/ui/AccountIntegrationBottomSheet.tsx
@@ -33,6 +33,7 @@ export const AccountIntegrationBottomSheet = ({
 }: AccountIntegrationBottomSheetProps) => {
   const router = useRouter();
   const [isRedirecting, setIsRedirecting] = useState(false);
+  const [loginErrorMessage, setLoginErrorMessage] = useState<string | null>(null);
 
   if (!isOpen) return null;
 
@@ -47,7 +48,15 @@ export const AccountIntegrationBottomSheet = ({
 
   const handleProviderLogin = (provider: SocialProvider) => {
     setIsRedirecting(true);
-    startSocialAccountIntegrationLogin(provider, integrationToken);
+    setLoginErrorMessage(null);
+
+    const result = startSocialAccountIntegrationLogin(provider, integrationToken);
+    if (!result.ok) {
+      setIsRedirecting(false);
+      setLoginErrorMessage(
+        '로그인 정보를 임시 저장하지 못했어요. 브라우저 설정을 확인한 뒤 다시 시도해주세요.',
+      );
+    }
   };
 
   return (
@@ -81,6 +90,16 @@ export const AccountIntegrationBottomSheet = ({
                       onClick={handleProviderLogin}
                     />
                   ))}
+
+                  {loginErrorMessage && (
+                    <p
+                      role="alert"
+                      aria-live="polite"
+                      className="text-caption-caption6 text-foreground-danger px-2"
+                    >
+                      {loginErrorMessage}
+                    </p>
+                  )}
                 </div>
               )}
             </div>

--- a/apps/web/src/features/account-integration/ui/IntegrationTargetCard.tsx
+++ b/apps/web/src/features/account-integration/ui/IntegrationTargetCard.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { Avatar } from '@surf/ui/avatar';
+import { InfoBadge } from '@surf/ui/info-badge';
+import type { IntegrationTarget } from '../model/types';
+import { useDynamicVisibleCount } from '@/entities/search/model/useDynamicVisibleCount';
+
+interface IntegrationTargetCardProps {
+  target: IntegrationTarget;
+}
+
+export const IntegrationTargetCard = ({ target }: IntegrationTargetCardProps) => {
+  const { username, profileImageUrl, selfIntroduction, chips } = target;
+
+  const { visibleCount, containerRef, ghostContainerRef } = useDynamicVisibleCount({
+    items: chips,
+    gap: 4,
+    moreBadgeWidth: 28,
+  });
+
+  const visibleChips = chips.slice(0, visibleCount);
+  const remainingCount = chips.length - visibleCount;
+
+  return (
+    <div className="border-border-secondary flex w-full gap-11 overflow-hidden border-b px-13 py-12">
+      <Avatar size="m" src={profileImageUrl ?? undefined} />
+
+      <div className="flex w-full flex-col justify-center gap-7 overflow-hidden">
+        <header className="flex w-full items-center gap-8">
+          <h3 className="text-foreground-normal text-body-body6 shrink-0">{username}</h3>
+
+          <ul ref={containerRef} className="flex min-w-0 flex-1 gap-5 overflow-hidden">
+            {visibleChips.map((chip) => (
+              <li key={chip} className="flex shrink-0 items-center">
+                <InfoBadge text={chip} />
+              </li>
+            ))}
+
+            {remainingCount > 0 && (
+              <li className="flex shrink-0 items-center">
+                <InfoBadge text={`+${remainingCount}`} />
+              </li>
+            )}
+          </ul>
+        </header>
+
+        {selfIntroduction && (
+          <p className="text-foreground-normal text-caption-caption4 w-full min-w-0 truncate text-left">
+            {selfIntroduction}
+          </p>
+        )}
+      </div>
+
+      {/* [Ghost Container] 배지 노출 개수 계산용. 화면에는 보이지 않는다. */}
+      <ul
+        ref={ghostContainerRef}
+        aria-hidden="true"
+        className="pointer-events-none invisible absolute flex items-center gap-5 opacity-0"
+        style={{ top: 0, left: 0, width: 'max-content' }}
+      >
+        {chips.map((chip) => (
+          <li key={`ghost-${chip}`}>
+            <InfoBadge text={chip} />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};

--- a/apps/web/src/features/account-integration/ui/IntegrationTargetCard.tsx
+++ b/apps/web/src/features/account-integration/ui/IntegrationTargetCard.tsx
@@ -3,7 +3,7 @@
 import { Avatar } from '@surf/ui/avatar';
 import { InfoBadge } from '@surf/ui/info-badge';
 import type { IntegrationTarget } from '../model/types';
-import { useDynamicVisibleCount } from '@/entities/search/model/useDynamicVisibleCount';
+import { useDynamicVisibleCount } from '@/shared/hooks/useDynamicVisibleCount';
 
 interface IntegrationTargetCardProps {
   target: IntegrationTarget;

--- a/apps/web/src/features/account-integration/ui/SocialAccountIntegrationLoginButton.tsx
+++ b/apps/web/src/features/account-integration/ui/SocialAccountIntegrationLoginButton.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import Apple from '../../../../public/images/apple.svg';
+import Kakao from '../../../../public/images/kakao.svg';
+import type { SocialProvider } from '../api/types';
+
+type SocialAccountIntegrationLoginButtonProps = {
+  provider: SocialProvider;
+  disabled?: boolean;
+  onClick: (provider: SocialProvider) => void;
+};
+
+const PROVIDER_LABEL_MAP: Record<SocialProvider, string> = {
+  KAKAO: '카카오',
+  APPLE: '애플',
+};
+
+export const SocialAccountIntegrationLoginButton = ({
+  provider,
+  disabled = false,
+  onClick,
+}: SocialAccountIntegrationLoginButtonProps) => {
+  const isKakao = provider === 'KAKAO';
+  const Icon = isKakao ? Kakao : Apple;
+
+  const className = [
+    'rounded-4 flex h-[3rem] w-full cursor-pointer items-center justify-center gap-[0.5rem]',
+    'disabled:cursor-not-allowed disabled:opacity-50',
+    isKakao
+      ? 'bg-[#FEE500] text-foreground-static-black hover:bg-[#FADA0A]'
+      : 'bg-background-normal-inverse text-foreground-normal-reverse hover:bg-[#1F2128]',
+  ].join(' ');
+
+  return (
+    <button
+      type="button"
+      className={className}
+      disabled={disabled}
+      onClick={() => onClick(provider)}
+    >
+      <Icon width={24} height={24} className={isKakao ? undefined : 'shrink-0'} />
+      <span
+        className={isKakao ? 'text-foreground-static-black text-title-title2' : 'text-title-title2'}
+      >
+        {PROVIDER_LABEL_MAP[provider]}로 로그인해서 연동하기
+      </span>
+    </button>
+  );
+};

--- a/apps/web/src/features/auth/model/useOAuthCallback.ts
+++ b/apps/web/src/features/auth/model/useOAuthCallback.ts
@@ -1,7 +1,14 @@
+import { useAlertStore } from '@surf/ui/store/alertStore';
 import { useToastStore } from '@surf/ui/store/toastStore';
 import { useRouter } from 'next/navigation';
 import { useEffect, useRef } from 'react';
 
+import { integrateAccount } from '@/features/account-integration/api/integrateAccount';
+import { getSocialAccountIntegrationErrorMessage } from '@/features/account-integration/lib/getSocialAccountIntegrationErrorMessage';
+import {
+  clearPendingSocialAccountIntegration,
+  getPendingSocialAccountIntegration,
+} from '@/features/account-integration/lib/pendingSocialAccountIntegration';
 import { getOAuthOnboarding } from '@/features/auth/api/getOAuthOnboarding';
 import { useOnboardingStore } from '@/features/onboarding/model/useOnboardingStore';
 import { PAGE_ROUTES } from '@/shared/config/path';
@@ -10,6 +17,8 @@ export const useOAuthCallback = () => {
   const router = useRouter();
   const didRun = useRef(false);
   const setOnboarding = useOnboardingStore((s) => s.setOnboarding);
+  const openAlert = useAlertStore((s) => s.open);
+  const closeAlert = useAlertStore((s) => s.close);
   const showToast = useToastStore((s) => s.show);
 
   useEffect(() => {
@@ -20,6 +29,56 @@ export const useOAuthCallback = () => {
     let cancelled = false;
 
     void (async () => {
+      const pendingIntegration = getPendingSocialAccountIntegration();
+
+      if (pendingIntegration) {
+        try {
+          await integrateAccount({ integrationToken: pendingIntegration.integrationToken });
+          clearPendingSocialAccountIntegration();
+          if (cancelled) return;
+
+          openAlert({
+            state: 'default',
+            title: '기존 계정으로 연동이 완료되었습니다!',
+            infoText: '이제 편안하게 SURF를 이용하시면 됩니다.',
+            actions: [
+              {
+                type: 'text',
+                variant: 'primary',
+                label: '확인',
+                onClick: () => {
+                  closeAlert({ restoreFocus: false });
+                  router.replace(PAGE_ROUTES.HOME);
+                },
+              },
+            ],
+          });
+        } catch (error) {
+          clearPendingSocialAccountIntegration();
+          if (cancelled) return;
+
+          console.error('계정 통합 실패:', error);
+
+          openAlert({
+            state: 'error',
+            title: '연동 실패',
+            infoText: getSocialAccountIntegrationErrorMessage(error),
+            actions: [
+              {
+                type: 'text',
+                label: '확인',
+                onClick: () => {
+                  closeAlert({ restoreFocus: false });
+                  router.replace(PAGE_ROUTES.LOGIN);
+                },
+              },
+            ],
+          });
+        }
+
+        return;
+      }
+
       try {
         const { nickname, email, profileImageUrl } = await getOAuthOnboarding(controller.signal);
         if (cancelled) return;
@@ -40,5 +99,5 @@ export const useOAuthCallback = () => {
       cancelled = true;
       controller.abort();
     };
-  }, [router, setOnboarding, showToast]);
+  }, [router, setOnboarding, openAlert, closeAlert, showToast]);
 };

--- a/apps/web/src/features/onboarding/api/submitOnBoarding.ts
+++ b/apps/web/src/features/onboarding/api/submitOnBoarding.ts
@@ -1,12 +1,28 @@
+import axios from 'axios';
 import { handleApiError } from '@/shared/lib/handleApiError';
 import { OnBoardingRequest, OnBoardingResponse } from '../model/types';
 import { axiosInstance } from '@/shared/lib/axiosInstance';
+import { AccountIntegrationRequiredError } from '../lib/accountIntegrationError';
+import { SIGNUP_CONFLICT_REASONS, SignupConflictResponse } from './types';
 
 export async function submitOnBoarding(data: OnBoardingRequest) {
   try {
     const res = await axiosInstance.post<OnBoardingResponse>('v1/user/members/signup', data);
     return res.data;
   } catch (error) {
+    // 409 + ACCOUNT_INTEGRATION_REQUIRED -> 계정 통합 플로우
+    if (axios.isAxiosError(error) && error.response?.status === 409) {
+      const body = error.response.data as SignupConflictResponse | undefined;
+
+      if (body?.data?.reason === SIGNUP_CONFLICT_REASONS.INTEGRATION_REQUIRED) {
+        throw new AccountIntegrationRequiredError({
+          integrationToken: body.data.integrationToken,
+          expiresInSeconds: body.data.expiresInSeconds,
+          guideMessage: body.data.guideMessage || body.message,
+        });
+      }
+    }
+
     throw handleApiError(error, '회원가입에 실패했습니다.');
   }
 }

--- a/apps/web/src/features/onboarding/api/types.ts
+++ b/apps/web/src/features/onboarding/api/types.ts
@@ -1,0 +1,25 @@
+export const SIGNUP_CONFLICT_REASONS = {
+  /** 이메일·전화번호가 모두 기존 회원과 일치 -> 계정 통합 플로우로 분기 */
+  INTEGRATION_REQUIRED: 'ACCOUNT_INTEGRATION_REQUIRED',
+  /** 이메일 또는 전화번호 중 하나만 겹침 -> 가입 차단 */
+  CONFLICT_BLOCKED: 'ACCOUNT_CONFLICT_BLOCKED',
+} as const;
+
+export type AccountIntegrationRequiredData = {
+  reason: typeof SIGNUP_CONFLICT_REASONS.INTEGRATION_REQUIRED;
+  /** 1회성 통합 토큰. 불투명 문자열이므로 파싱하지 않는다. */
+  integrationToken: string;
+  /** 잔여 유효시간(초). 발급 직후 1800(30분) */
+  expiresInSeconds: number;
+  guideMessage: string;
+};
+
+export type AccountConflictBlockedData = {
+  reason: typeof SIGNUP_CONFLICT_REASONS.CONFLICT_BLOCKED;
+};
+
+export type SignupConflictResponse = {
+  code: number;
+  message: string;
+  data: AccountIntegrationRequiredData | AccountConflictBlockedData | null;
+};

--- a/apps/web/src/features/onboarding/lib/accountIntegrationError.ts
+++ b/apps/web/src/features/onboarding/lib/accountIntegrationError.ts
@@ -1,0 +1,29 @@
+import type { AccountIntegrationRequiredData } from '../api/types';
+
+/**
+ * 회원가입 제출 시 이메일·전화번호가 모두 기존 회원과 일치해
+ * 계정 통합이 필요한 경우 던지는 도메인 에러
+ */
+export class AccountIntegrationRequiredError extends Error {
+  readonly integrationToken: string;
+  readonly expiresInSeconds: number;
+  readonly guideMessage: string;
+
+  constructor({
+    integrationToken,
+    expiresInSeconds,
+    guideMessage,
+  }: Omit<AccountIntegrationRequiredData, 'reason'>) {
+    super(guideMessage);
+    this.name = 'AccountIntegrationRequiredError';
+    this.integrationToken = integrationToken;
+    this.expiresInSeconds = expiresInSeconds;
+    this.guideMessage = guideMessage;
+  }
+}
+
+export function isAccountIntegrationRequiredError(
+  error: unknown,
+): error is AccountIntegrationRequiredError {
+  return error instanceof AccountIntegrationRequiredError;
+}

--- a/apps/web/src/shared/hooks/useDynamicVisibleCount.ts
+++ b/apps/web/src/shared/hooks/useDynamicVisibleCount.ts
@@ -1,9 +1,9 @@
-import { useState, useRef, useLayoutEffect } from 'react';
+import { useLayoutEffect, useRef, useState } from 'react';
 
 interface UseDynamicVisibleCountProps<T> {
-  items: T[]; // 측정할 아이템 배열
-  gap?: number; // 아이템 사이의 간격 (px)
-  moreBadgeWidth?: number; // '+N' 배지가 차지할 예상 너비 (px)
+  items: T[];
+  gap?: number;
+  moreBadgeWidth?: number;
 }
 
 export const useDynamicVisibleCount = <T>({
@@ -11,10 +11,7 @@ export const useDynamicVisibleCount = <T>({
   gap = 4,
   moreBadgeWidth = 28,
 }: UseDynamicVisibleCountProps<T>) => {
-  // 실제 보여줄 개수 상태
   const [visibleCount, setVisibleCount] = useState(items.length);
-
-  // 컨테이너와 Ghost 요소를 연결할 Ref
   const containerRef = useRef<HTMLUListElement>(null);
   const ghostContainerRef = useRef<HTMLUListElement>(null);
 
@@ -23,7 +20,6 @@ export const useDynamicVisibleCount = <T>({
       if (!containerRef.current || !ghostContainerRef.current) return;
 
       const containerWidth = containerRef.current.offsetWidth;
-      // Ghost 컨테이너의 자식들(칩)의 DOM 요소 가져오기
       const chipNodes = Array.from(ghostContainerRef.current.children) as HTMLElement[];
 
       let currentWidth = 0;
@@ -32,38 +28,26 @@ export const useDynamicVisibleCount = <T>({
       for (let i = 0; i < chipNodes.length; i++) {
         const chipWidth = chipNodes[i].offsetWidth;
         const isLastItem = i === chipNodes.length - 1;
-
-        // 아이템이 추가될 때마다 너비 누적 (첫 아이템이 아니면 gap 추가)
         const itemWidthWithGap = chipWidth + (i > 0 ? gap : 0);
         const nextTotalWidth = currentWidth + itemWidthWithGap;
-
-        // 로직:
-        // 1. 마지막 아이템인 경우: 그냥 컨테이너 안에 들어가는지만 확인
-        // 2. 중간 아이템인 경우: 이 아이템 + (+N 배지 너비)가 들어갈 공간이 있는지 확인
 
         if (isLastItem) {
           if (nextTotalWidth <= containerWidth) {
             count++;
           }
+        } else if (nextTotalWidth + gap + moreBadgeWidth <= containerWidth) {
+          currentWidth = nextTotalWidth;
+          count++;
         } else {
-          // 다음 아이템이 더 있으므로, '+N' 배지 공간도 확보해야 함 (gap 포함)
-          if (nextTotalWidth + gap + moreBadgeWidth <= containerWidth) {
-            currentWidth = nextTotalWidth;
-            count++;
-          } else {
-            // 공간 부족하면 여기서 카운팅 멈춤
-            break;
-          }
+          break;
         }
       }
 
       setVisibleCount(count);
     };
 
-    // 초기 계산
     calculate();
 
-    // 리사이즈 감지
     const observer = new ResizeObserver(calculate);
     if (containerRef.current) {
       observer.observe(containerRef.current);

--- a/apps/web/src/shared/lib/handleApiError.ts
+++ b/apps/web/src/shared/lib/handleApiError.ts
@@ -15,7 +15,14 @@ export type LoginCallBackError = {
   requestId: string;
 };
 
-export type ErrorResponse = DefaultError | LoginCallBackError;
+/** `errorCode` 없이 내려오는 백엔드 공통 응답 (예: 409 계정 충돌) */
+export type EnvelopeError = {
+  code: number;
+  message: string;
+  data?: unknown;
+};
+
+export type ErrorResponse = DefaultError | LoginCallBackError | EnvelopeError;
 
 export function handleApiError(
   error: unknown,
@@ -38,6 +45,10 @@ export function handleApiError(
           console.error(
             `[Backend Error - LoginCallback] ${data.message} (error=${data.error}, path=${data.path}, requestId=${data.requestId})`,
           );
+        } else if (typeof data.message === 'string' && data.message) {
+          // errorCode 없이 { code, message, data }만 내려오는 응답
+          message = data.message;
+          console.error(`[Backend Error] ${data.message} (code=${data.code})`);
         }
       }
 

--- a/apps/web/src/widgets/bottom-sheet/model/constants.ts
+++ b/apps/web/src/widgets/bottom-sheet/model/constants.ts
@@ -8,6 +8,7 @@ import { ScheduleActionSheet } from '@/features/schedule/ui/ScheduleActionSheet/
 import { CommentOptionBottomSheet } from '@/features/comment/ui/CommentOptionBottomSheet';
 import { ScheduleCategoryBottomSheet } from '@/features/schedule/ui/ScheduleCategoryBottomSheet';
 import { ScheduleDateBottomSheet } from '@/features/schedule/ui/ScheduleDateBottomSheet';
+import { AccountIntegrationBottomSheet } from '@/features/account-integration/ui/AccountIntegrationBottomSheet';
 import type { BottomSheetMap, BottomSheetType } from '@/shared/store/bottomSheetStore';
 import type { ComponentType } from 'react';
 
@@ -31,4 +32,5 @@ export const SHEET_COMPONENTS = {
   commentOption: CommentOptionBottomSheet,
   scheduleCategory: ScheduleCategoryBottomSheet,
   scheduleDate: ScheduleDateBottomSheet,
+  accountIntegration: AccountIntegrationBottomSheet,
 } satisfies BottomSheetComponents;

--- a/apps/web/src/widgets/onboarding/ui/OnBoardingForm.tsx
+++ b/apps/web/src/widgets/onboarding/ui/OnBoardingForm.tsx
@@ -1,20 +1,20 @@
 import { useAlertStore } from '@surf/ui/store/alertStore';
 import { safeUUID } from '@surf/utils';
-import axios from 'axios';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { OnBoardingLayout } from './OnBoardingLayout';
 import { useImageUploader } from '@/entities/image/model/useImageUploader';
+import { useAccountIntegrationFlow } from '@/features/account-integration';
 import { useAgreementStore } from '@/features/laws/model/useAgreementStore';
 import { submitOnBoarding } from '@/features/onboarding/api/submitOnBoarding';
+import { isAccountIntegrationRequiredError } from '@/features/onboarding/lib/accountIntegrationError';
 import { trackOnBoardingEvent } from '@/features/onboarding/lib/trackOnBoardingEvent';
 import { ONBOARDING_EVENTS, OnBoardingFormData } from '@/features/onboarding/model/types';
 import { EmailPhoneStep } from '@/features/onboarding/ui/EmailPhoneStep';
 import { ProfileStep } from '@/features/onboarding/ui/ProfileStep';
 import { TrackUnivStep } from '@/features/onboarding/ui/TrackUnivStep';
 import { PAGE_ROUTES } from '@/shared/config/path';
-import { DefaultError } from '@/shared/lib/handleApiError';
 
 const STEP_ANALYTICS_NAMES: Record<number, 'nickname' | 'track' | 'contact'> = {
   0: 'nickname',
@@ -33,6 +33,7 @@ export const OnBoardingForm = ({ step, setStep }: OnBoardingFormProps) => {
   const closeAlert = useAlertStore((s) => s.close);
   const methods = useFormContext<OnBoardingFormData>();
   const router = useRouter();
+  const { start: startAccountIntegration } = useAccountIntegrationFlow();
   type StepConfig = {
     component: React.FC;
     title: string;
@@ -180,6 +181,12 @@ export const OnBoardingForm = ({ step, setStep }: OnBoardingFormProps) => {
       // 여기서 이동시키면 가입 요청 없이도 화면이 넘어간다.
       await methods.handleSubmit(onSubmit)();
     } catch (error) {
+      // 이메일·전화번호가 모두 기존 회원과 일치 -> 계정 통합 플로우
+      if (isAccountIntegrationRequiredError(error)) {
+        await startAccountIntegration(error.integrationToken);
+        return;
+      }
+
       if (error instanceof Error && error.message === 'PROFILE_IMAGE_UPLOAD_FAILED') {
         openAlert({
           title: '업로드 실패',
@@ -189,34 +196,15 @@ export const OnBoardingForm = ({ step, setStep }: OnBoardingFormProps) => {
         return;
       }
 
-      if (axios.isAxiosError(error) && error.response) {
-        const status = error.response.status;
-        const data = error.response.data as DefaultError;
-
-        switch (status) {
-          case 400:
-            openAlert({
-              title: '오류',
-              infoText: data.message || '입력한 정보가 올바르지 않습니다.',
-              actions: [{ type: 'text', label: '확인', onClick: closeAlert }],
-            });
-            break;
-          case 409:
-            openAlert({
-              title: '알림',
-              infoText: data.message || '이미 존재하는 회원입니다. 로그인 페이지로 이동합니다.',
-              actions: [
-                { type: 'text', label: '확인', onClick: () => router.push(PAGE_ROUTES.LOGIN) },
-              ],
-            });
-            break;
-          default:
-            openAlert({
-              title: '오류',
-              infoText: data.message || '알 수 없는 오류가 발생했습니다.',
-              actions: [{ type: 'text', label: '확인', onClick: closeAlert }],
-            });
-        }
+      // submitOnBoarding 은 handleApiError 로 서버 메시지를 담은 Error 를 던진다.
+      // (예: 409 ACCOUNT_CONFLICT_BLOCKED → "이미 사용 중인 [이메일]입니다.")
+      // 사용자가 입력값을 고쳐야 하는 경우가 대부분이므로 화면 이동 없이 안내만 한다.
+      if (error instanceof Error && error.message) {
+        openAlert({
+          title: '오류',
+          infoText: error.message,
+          actions: [{ type: 'text', label: '확인', onClick: closeAlert }],
+        });
       } else {
         openAlert({
           title: '오류',

--- a/packages/ui/components/check-list/CheckList.tsx
+++ b/packages/ui/components/check-list/CheckList.tsx
@@ -18,10 +18,10 @@ export const CheckList = ({
   onClickItem,
 }: CheckListProps) => {
   return (
-    <div className="flex w-full items-center gap-[0.35rem] pr-[0.62rem]">
+    <div className="flex w-full items-center gap-7 pr-10">
       {/* 체크 토글 버튼 및 제목 */}
       <button
-        className="flex w-full cursor-pointer items-center justify-center gap-[0.35rem]"
+        className="flex w-full cursor-pointer items-center justify-center gap-7 py-2"
         type="button"
         aria-pressed={!!isChecked}
         aria-label={`${title} 체크 전환`}
@@ -38,7 +38,7 @@ export const CheckList = ({
         </div>
       </button>
       {/* 우측 버튼*/}
-      <button onClick={() => onClickItem?.(id)} className="cursor-pointer">
+      <button onClick={() => onClickItem?.(id)} className="cursor-pointer py-2">
         <SurfIcon name="ChevronRight" size="m" className="text-foreground-tertiary" />
       </button>
     </div>


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 any가 사용되지 않았습니다
- [ ] 스토리북에 추가했습니다 (해당 시)
- [ ] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈

- close #632

## 📌 작업 목적

## 문제

온보딩 과정에서 이미 가입된 기존 계정이 확인되면 사용자가 현재 소셜 계정을 기존 계정에 연결할 수 있는 플로우를 추가했습니다.

## 🔨 주요 작업 내용

- 온보딩 409 응답에서 계정 통합 필요 상태를 감지하도록 처리했습니다.
- 통합 대상 조회 API를 호출해 기존 계정 정보와 사용 가능한 소셜 provider를 바텀시트에 표시했습니다.
- 사용자가 기존 계정의 소셜 provider로 로그인하면 OAuth 콜백 이후 계정 통합 API를 호출하도록 분기했습니다.
- 계정 통합을 위해 OAuth 로그인을 시작할 때 대기 정보를 `sessionStorage`에 저장하는데, 저장 실패를 무시하면 OAuth 콜백 이후 계정 통합 상태를 잃고 일반 온보딩 플로우로 잘못 이어질 수 있었습니다. 따라서`sessionStorage` 저장 실패 시 OAuth 리다이렉트를 중단하고, 바텀시트에서 재시도 가능한 오류를 표시하도록 수정했습니다.
- 검색 도메인에 있던 `useDynamicVisibleCount`를 `shared/hooks`로 이동해 계정 통합 UI가 검색 도메인에 의존하지 않도록 정리했습니다.

## ⚠️ 기존 문제 (선택)

- 

## ☑️ 해결 방법 (선택)

- 

## 🧪 테스트 방법

- 

## ✔️ 설치 라이브러리

-

## 📷 실행 영상 또는 스크린샷

-

## 💬 논의할 점

-

## 🙋🏻 참고 자료

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 기존 계정이 발견된 경우, 카카오·Apple 로그인을 통해 계정을 통합할 수 있습니다.
  * 계정 통합 대상의 프로필과 연결 가능한 로그인 수단을 확인할 수 있습니다.
  * 통합 진행 상태를 안전하게 저장하고, 성공·실패 결과에 따른 안내를 제공합니다.

* **버그 수정**
  * 다른 바텀시트가 열려 있을 때 약관 바텀시트가 잘못 닫히지 않도록 수정했습니다.
  * 다양한 서버 오류 응답이 적절한 메시지로 표시되도록 개선했습니다.

* **UI 개선**
  * 체크리스트 간격과 버튼 여백을 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->