### PR TITLE
[FEAT] 어드민 대시보드 기능 구현

### DIFF
--- a/apps/admin/src/app-pages/dashboard/ui/DashboardPage.tsx
+++ b/apps/admin/src/app-pages/dashboard/ui/DashboardPage.tsx
@@ -625,7 +625,6 @@ export const DashboardPage = () => {
               );
             })}
           </div>
-          <div className="from-background-normal pointer-events-none absolute bottom-4 right-0 top-0 w-24 bg-gradient-to-l to-transparent" />
         </div>
       </div>
 

--- a/apps/admin/src/app-pages/dashboard/ui/DashboardPage.tsx
+++ b/apps/admin/src/app-pages/dashboard/ui/DashboardPage.tsx
@@ -3,31 +3,35 @@
 import { Input } from '@surf/ui/input';
 import { useMemo, useState, type ReactNode } from 'react';
 import type {
+  ChurnUserResponse,
   DashboardResponse,
-  EventDistributionResponse,
-  PathDistributionResponse,
+  FunnelResponse,
+  KpiDailyResponse,
+  NoticeSampleRowResponse,
 } from '@/features/dashboard/api/types';
 import { useDashboardDateRange } from '@/features/dashboard/model/useDashboardDateRange';
 import { useDashboardQuery } from '@/features/dashboard/model/useDashboardQuery';
 
-type DashboardTab = 'traffic' | 'kpi' | 'funnel' | 'content' | 'debug';
+type DashboardTab = 'traffic' | 'kpi' | 'funnel' | 'churn' | 'content' | 'notice' | 'debug';
 
 type CountItem = {
   label: string;
   count: number;
 };
 
-type FunnelItem = {
-  funnel: string;
-  attemptEvents: number;
-  successEvents: number;
+type LineSeries = {
+  label: string;
+  color: string;
+  points: CountItem[];
 };
 
 const DASHBOARD_TABS: { value: DashboardTab; label: string }[] = [
   { value: 'traffic', label: '1.1 Traffic' },
   { value: 'kpi', label: '1.2 KPI' },
   { value: 'funnel', label: '1.3 Funnel' },
+  { value: 'churn', label: '1.4 Churn' },
   { value: 'content', label: '1.5 Content' },
+  { value: 'notice', label: '1.6 Notice' },
   { value: 'debug', label: 'Debug' },
 ];
 
@@ -37,99 +41,65 @@ const PRESETS = [
   { value: 'month', label: '이번 달' },
 ] as const;
 
-const POST_KEYWORDS = ['post.create', 'post.created', 'post.submit', 'post.add'];
-const COMMENT_KEYWORDS = ['comment.create', 'comment.submit', 'comment.add'];
-const LIKE_KEYWORDS = ['like.add', 'like.create', 'like'];
-const SCRAP_KEYWORDS = ['scrap.add', 'scrap.create', 'scrap'];
-const PAGE_VIEW_KEYWORDS = ['page.view', 'page_view'];
-
-function formatNumber(value?: number) {
-  if (value === undefined || Number.isNaN(value)) return '-';
+function formatNumber(value?: number | null) {
+  if (value === undefined || value === null || Number.isNaN(value)) return '-';
   return value.toLocaleString('ko-KR');
 }
 
-function normalizeEventLabel(event: string) {
-  return event.toLowerCase().replaceAll('_', '.');
+function formatPercent(value?: number | null) {
+  if (value === undefined || value === null || Number.isNaN(value)) return '-';
+  return `${value.toFixed(1)}%`;
 }
 
-function sumMatchingEvents(events: EventDistributionResponse[], keywords: string[]) {
-  return events.reduce((sum, item) => {
-    const label = normalizeEventLabel(item.event);
-    const isMatched = keywords.some((keyword) =>
-      label.includes(keyword.toLowerCase().replaceAll('_', '.')),
-    );
-
-    return isMatched ? sum + item.count : sum;
-  }, 0);
+function formatMs(value?: number | null) {
+  if (value === undefined || value === null || Number.isNaN(value)) return '-';
+  return `${(value / 1000).toFixed(2)}s`;
 }
 
-function toCountItems(items: EventDistributionResponse[] | PathDistributionResponse[]) {
-  return items.map((item) => ({
-    label: 'event' in item ? item.event : item.path,
-    count: item.count,
-  }));
+function formatDateTime(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+
+  return date.toLocaleString('ko-KR', {
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
 }
 
-function getKpiMetrics(data: DashboardResponse) {
-  const posts = sumMatchingEvents(data.event_distribution, POST_KEYWORDS);
-  const comments = sumMatchingEvents(data.event_distribution, COMMENT_KEYWORDS);
-  const likes = sumMatchingEvents(data.event_distribution, LIKE_KEYWORDS);
-  const scraps = sumMatchingEvents(data.event_distribution, SCRAP_KEYWORDS);
-
-  return {
-    posts,
-    comments,
-    likes,
-    scraps,
-    activityIndex: posts * 3 + comments * 2 + (likes + scraps),
-  };
+function sumKpi(data: KpiDailyResponse[], key: keyof Omit<KpiDailyResponse, 'date'>) {
+  return data.reduce((sum, item) => sum + item[key], 0);
 }
 
-function getFunnelItems(data: DashboardResponse): FunnelItem[] {
-  const definitions = [
-    {
-      funnel: 'Post Create',
-      attemptKeywords: POST_KEYWORDS,
-      successKeywords: ['post.succeeded', 'post.success', 'post.created'],
-    },
-    {
-      funnel: 'Comment Create',
-      attemptKeywords: COMMENT_KEYWORDS,
-      successKeywords: ['comment.succeeded', 'comment.success', 'comment.created'],
-    },
-    {
-      funnel: 'Like',
-      attemptKeywords: LIKE_KEYWORDS,
-      successKeywords: ['like.succeeded', 'like.success'],
-    },
-    {
-      funnel: 'Scrap',
-      attemptKeywords: SCRAP_KEYWORDS,
-      successKeywords: ['scrap.succeeded', 'scrap.success'],
-    },
-  ];
+function buildLinePath(points: CountItem[], width: number, height: number, padding: number, max: number) {
+  return points
+    .map((item, index) => {
+      const x =
+        points.length <= 1
+          ? width / 2
+          : padding + (index / (points.length - 1)) * (width - padding * 2);
+      const y = height - padding - (item.count / max) * (height - padding * 2);
 
-  return definitions.map((item) => ({
-    funnel: item.funnel,
-    attemptEvents: sumMatchingEvents(data.event_distribution, item.attemptKeywords),
-    successEvents: sumMatchingEvents(data.event_distribution, item.successKeywords),
-  }));
+      return `${index === 0 ? 'M' : 'L'} ${x} ${y}`;
+    })
+    .join(' ');
 }
 
-function getHomeMatchRows(data: DashboardResponse) {
-  return (
-    sumMatchingEvents(data.event_distribution, ['home.view']) +
-    data.path_distribution
-      .filter((item) => item.path.includes('/home'))
-      .reduce((sum, item) => sum + item.count, 0)
-  );
-}
-
-const MetricCard = ({ label, value }: { label: string; value: string }) => {
+const MetricCard = ({
+  label,
+  value,
+  helper,
+}: {
+  label: string;
+  value: string;
+  helper?: string;
+}) => {
   return (
     <div className="border-border-normal bg-background-normal-lighter rounded-6 border p-12">
       <div className="text-caption-caption6 text-foreground-tertiary">{label}</div>
       <div className="text-title-title2 text-foreground-normal mt-8">{value}</div>
+      {helper ? <div className="text-caption-caption6 text-foreground-tertiary mt-6">{helper}</div> : null}
     </div>
   );
 };
@@ -143,23 +113,22 @@ const Section = ({ title, children }: { title: string; children: ReactNode }) =>
   );
 };
 
-const SimpleLineChart = ({ items }: { items: CountItem[] }) => {
+const EmptyState = ({ children = '데이터 없음' }: { children?: ReactNode }) => {
+  return (
+    <div className="border-border-normal rounded-6 border p-16 text-center text-body-body9 text-foreground-tertiary">
+      {children}
+    </div>
+  );
+};
+
+const SingleLineChart = ({ items }: { items: CountItem[] }) => {
+  if (items.length === 0) return <EmptyState />;
+
   const width = 320;
   const height = 156;
   const padding = 18;
   const max = Math.max(...items.map((item) => item.count), 1);
-  const points = items.map((item, index) => {
-    const x =
-      items.length <= 1
-        ? width / 2
-        : padding + (index / (items.length - 1)) * (width - padding * 2);
-    const y = height - padding - (item.count / max) * (height - padding * 2);
-
-    return { x, y, item };
-  });
-  const path = points
-    .map((point, index) => `${index === 0 ? 'M' : 'L'} ${point.x} ${point.y}`)
-    .join(' ');
+  const path = buildLinePath(items, width, height, padding, max);
 
   return (
     <div className="border-border-normal rounded-6 border p-12">
@@ -179,15 +148,6 @@ const SimpleLineChart = ({ items }: { items: CountItem[] }) => {
           className="stroke-border-normal"
         />
         <path d={path} fill="none" className="stroke-foreground-normal" strokeWidth="2" />
-        {points.map((point) => (
-          <circle
-            key={point.item.label}
-            cx={point.x}
-            cy={point.y}
-            r="3"
-            className="fill-foreground-normal"
-          />
-        ))}
       </svg>
       <div className="mt-8 flex justify-between gap-8">
         {items.slice(0, 4).map((item) => (
@@ -200,12 +160,74 @@ const SimpleLineChart = ({ items }: { items: CountItem[] }) => {
   );
 };
 
-const SimpleBarChart = ({ items }: { items: CountItem[] }) => {
-  const max = Math.max(...items.map((item) => item.count), 1);
+const MultiLineChart = ({ series }: { series: LineSeries[] }) => {
+  const visibleSeries = series.filter((item) => item.points.length > 0);
+  if (visibleSeries.length === 0) return <EmptyState />;
+
+  const width = 320;
+  const height = 168;
+  const padding = 18;
+  const max = Math.max(
+    ...visibleSeries.flatMap((item) => item.points.map((point) => point.count)),
+    1,
+  );
+  const labels = visibleSeries[0]?.points ?? [];
+
+  return (
+    <div className="border-border-normal rounded-6 border p-12">
+      <svg viewBox={`0 0 ${width} ${height}`} className="h-168 w-full" role="img">
+        <line
+          x1={padding}
+          y1={height - padding}
+          x2={width - padding}
+          y2={height - padding}
+          className="stroke-border-normal"
+        />
+        <line
+          x1={padding}
+          y1={padding}
+          x2={padding}
+          y2={height - padding}
+          className="stroke-border-normal"
+        />
+        {visibleSeries.map((item) => (
+          <path
+            key={item.label}
+            d={buildLinePath(item.points, width, height, padding, max)}
+            fill="none"
+            stroke={item.color}
+            strokeWidth="2"
+          />
+        ))}
+      </svg>
+      <div className="mt-8 flex flex-wrap gap-x-10 gap-y-4">
+        {visibleSeries.map((item) => (
+          <div key={item.label} className="flex items-center gap-4 text-caption-caption6 text-foreground-tertiary">
+            <span className="h-6 w-6 rounded-full" style={{ backgroundColor: item.color }} />
+            {item.label}
+          </div>
+        ))}
+      </div>
+      <div className="mt-8 flex justify-between gap-8">
+        {labels.slice(0, 4).map((item) => (
+          <div key={item.label} className="text-caption-caption6 text-foreground-tertiary">
+            {item.label.slice(5)}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const HorizontalBarChart = ({ items, maxItems = 10 }: { items: CountItem[]; maxItems?: number }) => {
+  const slicedItems = items.slice(0, maxItems);
+  if (slicedItems.length === 0) return <EmptyState />;
+
+  const max = Math.max(...slicedItems.map((item) => item.count), 1);
 
   return (
     <div className="flex flex-col gap-9">
-      {items.map((item) => (
+      {slicedItems.map((item) => (
         <div key={item.label} className="grid grid-cols-[minmax(0,1fr)_3rem] items-center gap-8">
           <div className="min-w-0">
             <div className="mb-5 truncate text-caption-caption6 text-foreground-tertiary">
@@ -227,20 +249,92 @@ const SimpleBarChart = ({ items }: { items: CountItem[] }) => {
   );
 };
 
-const DistributionTable = ({ items }: { items: CountItem[] }) => {
+const VerticalBarChart = ({ items }: { items: CountItem[] }) => {
+  if (items.length === 0) return <EmptyState />;
+
+  const max = Math.max(...items.map((item) => item.count), 1);
+
+  return (
+    <div className="border-border-normal rounded-6 border p-12">
+      <div className="flex h-156 items-end gap-8">
+        {items.map((item) => (
+          <div key={item.label} className="flex min-w-0 flex-1 flex-col items-center gap-6">
+            <div className="text-caption-caption6 text-foreground-tertiary">
+              {formatNumber(item.count)}
+            </div>
+            <div
+              className="bg-foreground-normal w-full rounded-t-3"
+              style={{ height: `${Math.max((item.count / max) * 112, 4)}px` }}
+            />
+            <div className="text-caption-caption6 text-foreground-tertiary w-full truncate text-center">
+              {item.label}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const DonutChart = ({ percent }: { percent: number | null }) => {
+  if (percent === null) return <EmptyState>Open Rate 데이터 없음</EmptyState>;
+
+  const radius = 46;
+  const circumference = 2 * Math.PI * radius;
+  const dash = (percent / 100) * circumference;
+
+  return (
+    <div className="border-border-normal flex items-center justify-center rounded-6 border p-18">
+      <svg viewBox="0 0 120 120" className="h-140 w-140" role="img">
+        <circle
+          cx="60"
+          cy="60"
+          r={radius}
+          fill="none"
+          className="stroke-background-quaternary"
+          strokeWidth="14"
+        />
+        <circle
+          cx="60"
+          cy="60"
+          r={radius}
+          fill="none"
+          className="stroke-foreground-normal"
+          strokeDasharray={`${dash} ${circumference - dash}`}
+          strokeLinecap="round"
+          strokeWidth="14"
+          transform="rotate(-90 60 60)"
+        />
+        <text x="60" y="65" textAnchor="middle" className="fill-foreground-normal text-body-body8">
+          {formatPercent(percent)}
+        </text>
+      </svg>
+    </div>
+  );
+};
+
+const DistributionTable = ({
+  items,
+  labelHeader = 'name',
+  countHeader = 'cnt',
+}: {
+  items: CountItem[];
+  labelHeader?: string;
+  countHeader?: string;
+}) => {
   return (
     <div className="border-border-normal overflow-hidden rounded-6 border">
       <table className="w-full table-fixed border-collapse">
         <thead className="bg-background-quaternary">
           <tr>
-            <th className="text-caption-caption6 text-foreground-tertiary w-44 px-8 py-8 text-left">
+            <th className="text-caption-caption6 text-foreground-tertiary w-36 px-8 py-8 text-left">
               #
             </th>
             <th className="text-caption-caption6 text-foreground-tertiary px-8 py-8 text-left">
-              name
+              {labelHeader}
             </th>
             <th className="text-caption-caption6 text-foreground-tertiary w-70 px-8 py-8 text-right">
-              cnt
+              {countHeader}
             </th>
           </tr>
         </thead>
@@ -255,7 +349,7 @@ const DistributionTable = ({ items }: { items: CountItem[] }) => {
               </td>
             </tr>
           ) : (
-            items.slice(0, 10).map((item, index) => (
+            items.slice(0, 20).map((item, index) => (
               <tr key={`${item.label}-${index}`} className="border-border-normal border-t">
                 <td className="text-caption-caption6 text-foreground-tertiary px-8 py-8">
                   {index}
@@ -275,21 +369,22 @@ const DistributionTable = ({ items }: { items: CountItem[] }) => {
   );
 };
 
-const FunnelTable = ({ items }: { items: FunnelItem[] }) => {
+const FunnelTable = ({ items }: { items: FunnelResponse[] }) => {
   return (
-    <div className="border-border-normal overflow-hidden rounded-6 border">
-      <table className="w-full table-fixed border-collapse">
+    <div className="dashboard-wide-table border-border-normal overflow-x-auto rounded-6 border">
+      <table className="min-w-[42rem] table-fixed border-collapse">
         <thead className="bg-background-quaternary">
           <tr>
-            <th className="text-caption-caption6 text-foreground-tertiary px-8 py-8 text-left">
-              funnel
-            </th>
-            <th className="text-caption-caption6 text-foreground-tertiary w-92 px-8 py-8 text-right">
-              attempt
-            </th>
-            <th className="text-caption-caption6 text-foreground-tertiary w-92 px-8 py-8 text-right">
-              success
-            </th>
+            {['funnel', 'attempt_events', 'attempt_users', 'success_events', 'matched', 'conversion'].map(
+              (header) => (
+                <th
+                  key={header}
+                  className="text-caption-caption6 text-foreground-tertiary px-8 py-8 text-left"
+                >
+                  {header}
+                </th>
+              ),
+            )}
           </tr>
         </thead>
         <tbody>
@@ -299,10 +394,109 @@ const FunnelTable = ({ items }: { items: FunnelItem[] }) => {
                 {item.funnel}
               </td>
               <td className="text-caption-caption6 text-foreground-normal px-8 py-8 text-right">
-                {formatNumber(item.attemptEvents)}
+                {formatNumber(item.attempt_events)}
               </td>
               <td className="text-caption-caption6 text-foreground-normal px-8 py-8 text-right">
-                {formatNumber(item.successEvents)}
+                {formatNumber(item.attempt_users)}
+              </td>
+              <td className="text-caption-caption6 text-foreground-normal px-8 py-8 text-right">
+                {formatNumber(item.success_events)}
+              </td>
+              <td className="text-caption-caption6 text-foreground-normal px-8 py-8 text-right">
+                {formatNumber(item.matched)}
+              </td>
+              <td className="text-caption-caption6 text-foreground-normal px-8 py-8 text-right">
+                {formatPercent(item.conversion)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+const ChurnUserTable = ({ users }: { users: ChurnUserResponse[] }) => {
+  return (
+    <div className="dashboard-wide-table border-border-normal overflow-x-auto rounded-6 border">
+      <table className="min-w-[34rem] table-fixed border-collapse">
+        <thead className="bg-background-quaternary">
+          <tr>
+            <th className="text-caption-caption6 text-foreground-tertiary px-8 py-8 text-left">
+              user_id
+            </th>
+            <th className="text-caption-caption6 text-foreground-tertiary px-8 py-8 text-left">
+              last_active
+            </th>
+            <th className="text-caption-caption6 text-foreground-tertiary px-8 py-8 text-right">
+              inactive
+            </th>
+            <th className="text-caption-caption6 text-foreground-tertiary px-8 py-8 text-left">
+              status
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {users.slice(0, 50).map((item) => (
+            <tr key={`${item.user_id}-${item.last_active_at}`} className="border-border-normal border-t">
+              <td className="text-caption-caption6 text-foreground-normal px-8 py-8">
+                {item.user_id}
+              </td>
+              <td className="text-caption-caption6 text-foreground-normal px-8 py-8">
+                {formatDateTime(item.last_active_at)}
+              </td>
+              <td className="text-caption-caption6 text-foreground-normal px-8 py-8 text-right">
+                {formatNumber(item.days_inactive)}d
+              </td>
+              <td className="text-caption-caption6 text-foreground-normal px-8 py-8">
+                {item.status_bucket}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+const NoticeSampleTable = ({ rows }: { rows: NoticeSampleRowResponse[] }) => {
+  if (rows.length === 0) return <EmptyState>sample rows 데이터 없음</EmptyState>;
+
+  return (
+    <div className="dashboard-wide-table border-border-normal overflow-x-auto rounded-6 border">
+      <table className="min-w-[46rem] table-fixed border-collapse">
+        <thead className="bg-background-quaternary">
+          <tr>
+            {['user_id', 'time', 'event_type', 'page_path', 'dwell', 'open'].map((header) => (
+              <th
+                key={header}
+                className="text-caption-caption6 text-foreground-tertiary px-8 py-8 text-left"
+              >
+                {header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.slice(0, 50).map((item, index) => (
+            <tr key={`${item.user_id}-${item.event_time_kst}-${index}`} className="border-border-normal border-t">
+              <td className="text-caption-caption6 text-foreground-normal px-8 py-8">
+                {item.user_id}
+              </td>
+              <td className="text-caption-caption6 text-foreground-normal px-8 py-8">
+                {formatDateTime(item.event_time_kst)}
+              </td>
+              <td className="text-caption-caption6 text-foreground-normal px-8 py-8">
+                {item.event_type}
+              </td>
+              <td className="text-caption-caption6 text-foreground-normal truncate px-8 py-8">
+                {item.page_path}
+              </td>
+              <td className="text-caption-caption6 text-foreground-normal px-8 py-8 text-right">
+                {formatMs(item.dwell_time_ms)}
+              </td>
+              <td className="text-caption-caption6 text-foreground-normal px-8 py-8">
+                {item.is_open ? 'true' : 'false'}
               </td>
             </tr>
           ))}
@@ -313,20 +507,33 @@ const FunnelTable = ({ items }: { items: FunnelItem[] }) => {
 };
 
 const TrafficPanel = ({ data }: { data: DashboardResponse }) => {
-  const latestActivity = data.daily_activity.at(-1);
+  const latestDau = data.traffic.dau.at(-1);
+  const latestWau = data.traffic.wau.at(-1);
+  const latestMau = data.traffic.mau.at(-1);
 
   return (
     <div className="flex flex-col gap-22">
       <div className="grid grid-cols-2 gap-10">
-        <MetricCard label="DAU latest" value={formatNumber(latestActivity?.active_users)} />
-        <MetricCard label="Observed Users" value={formatNumber(data.summary.unique_users)} />
+        <MetricCard label="DAU latest" value={formatNumber(latestDau?.users)} />
+        <MetricCard label="WAU latest" value={formatNumber(latestWau?.users)} />
+        <MetricCard label="MAU latest" value={formatNumber(latestMau?.users)} />
+        <MetricCard label="Active Rate" value={formatPercent(data.traffic.active_rate)} />
+        <MetricCard label="DAU/MAU" value={formatPercent(data.traffic.stickiness.dau_mau)} />
+        <MetricCard label="WAU/MAU" value={formatPercent(data.traffic.stickiness.wau_mau)} />
       </div>
       <Section title="DAU">
-        <SimpleLineChart
-          items={data.daily_activity.map((item) => ({
-            label: item.date,
-            count: item.active_users,
-          }))}
+        <SingleLineChart
+          items={data.traffic.dau.map((item) => ({ label: item.date, count: item.users }))}
+        />
+      </Section>
+      <Section title="WAU">
+        <SingleLineChart
+          items={data.traffic.wau.map((item) => ({ label: item.week, count: item.users }))}
+        />
+      </Section>
+      <Section title="MAU">
+        <SingleLineChart
+          items={data.traffic.mau.map((item) => ({ label: item.month, count: item.users }))}
         />
       </Section>
     </div>
@@ -334,26 +541,50 @@ const TrafficPanel = ({ data }: { data: DashboardResponse }) => {
 };
 
 const KpiPanel = ({ data }: { data: DashboardResponse }) => {
-  const metrics = getKpiMetrics(data);
+  const posts = sumKpi(data.kpi_daily, 'posts');
+  const comments = sumKpi(data.kpi_daily, 'comments');
+  const likes = sumKpi(data.kpi_daily, 'likes_add');
+  const scraps = sumKpi(data.kpi_daily, 'scraps_add');
+  const activityIndex = sumKpi(data.kpi_daily, 'activity_index');
 
   return (
     <div className="flex flex-col gap-22">
       <div className="grid grid-cols-2 gap-10">
-        <MetricCard label="Posts" value={formatNumber(metrics.posts)} />
-        <MetricCard label="Comments" value={formatNumber(metrics.comments)} />
-        <MetricCard label="Likes add" value={formatNumber(metrics.likes)} />
-        <MetricCard label="Scraps add" value={formatNumber(metrics.scraps)} />
-        <MetricCard label="Activity Index" value={formatNumber(metrics.activityIndex)} />
+        <MetricCard label="Posts" value={formatNumber(posts)} />
+        <MetricCard label="Comments" value={formatNumber(comments)} />
+        <MetricCard label="Likes add" value={formatNumber(likes)} />
+        <MetricCard label="Scraps add" value={formatNumber(scraps)} />
+        <MetricCard label="Activity Index" value={formatNumber(activityIndex)} />
       </div>
-      <Section title="KPI total">
-        <SimpleBarChart
-          items={[
-            { label: 'Posts', count: metrics.posts },
-            { label: 'Comments', count: metrics.comments },
-            { label: 'Likes add', count: metrics.likes },
-            { label: 'Scraps add', count: metrics.scraps },
-            { label: 'Activity Index', count: metrics.activityIndex },
+      <Section title="Daily KPI">
+        <MultiLineChart
+          series={[
+            {
+              label: 'Posts',
+              color: '#20232d',
+              points: data.kpi_daily.map((item) => ({ label: item.date, count: item.posts })),
+            },
+            {
+              label: 'Comments',
+              color: '#4169e1',
+              points: data.kpi_daily.map((item) => ({ label: item.date, count: item.comments })),
+            },
+            {
+              label: 'Likes',
+              color: '#0f8f5f',
+              points: data.kpi_daily.map((item) => ({ label: item.date, count: item.likes_add })),
+            },
+            {
+              label: 'Scraps',
+              color: '#e1191d',
+              points: data.kpi_daily.map((item) => ({ label: item.date, count: item.scraps_add })),
+            },
           ]}
+        />
+      </Section>
+      <Section title="Activity Index">
+        <SingleLineChart
+          items={data.kpi_daily.map((item) => ({ label: item.date, count: item.activity_index }))}
         />
       </Section>
     </div>
@@ -361,18 +592,34 @@ const KpiPanel = ({ data }: { data: DashboardResponse }) => {
 };
 
 const FunnelPanel = ({ data }: { data: DashboardResponse }) => {
-  const funnels = getFunnelItems(data);
-
   return (
     <div className="flex flex-col gap-22">
-      <FunnelTable items={funnels} />
-      <Section title="Attempt events">
-        <SimpleBarChart
-          items={funnels.map((item) => ({
-            label: item.funnel,
-            count: item.attemptEvents,
+      <FunnelTable items={data.funnel} />
+      <Section title="Attempt to Matched">
+        <HorizontalBarChart
+          items={data.funnel.flatMap((item) => [
+            { label: `${item.funnel} Attempt`, count: item.attempt_events },
+            { label: `${item.funnel} Matched`, count: item.matched },
+          ])}
+        />
+      </Section>
+    </div>
+  );
+};
+
+const ChurnPanel = ({ data }: { data: DashboardResponse }) => {
+  return (
+    <div className="flex flex-col gap-22">
+      <Section title="Status Bucket">
+        <VerticalBarChart
+          items={data.churn.buckets.map((item) => ({
+            label: item.status_bucket,
+            count: item.users,
           }))}
         />
+      </Section>
+      <Section title="Inactive Users">
+        <ChurnUserTable users={data.churn.users} />
       </Section>
     </div>
   );
@@ -381,31 +628,90 @@ const FunnelPanel = ({ data }: { data: DashboardResponse }) => {
 const ContentPanel = ({ data }: { data: DashboardResponse }) => {
   return (
     <div className="flex flex-col gap-22">
+      <Section title="page_url Top">
+        <DistributionTable
+          items={data.content.page_url_top.map((item) => ({
+            label: item.page_url,
+            count: item.count,
+          }))}
+          labelHeader="page_url"
+        />
+      </Section>
       <Section title="page_path Top">
-        <DistributionTable items={toCountItems(data.path_distribution)} />
+        <DistributionTable
+          items={data.content.page_path_top.map((item) => ({
+            label: item.page_path,
+            count: item.count,
+          }))}
+          labelHeader="page_path"
+        />
+      </Section>
+    </div>
+  );
+};
+
+const NoticePanel = ({ data }: { data: DashboardResponse }) => {
+  return (
+    <div className="flex flex-col gap-22">
+      <div className="grid grid-cols-2 gap-10">
+        <MetricCard label="Notice Open Rate" value={formatPercent(data.notice.open_rate)} />
+        <MetricCard label="Notice Reach" value={formatNumber(data.notice.reach)} />
+        <MetricCard label="Avg dwell" value={formatMs(data.notice.avg_dwell_ms)} />
+        <MetricCard label="Dwell rows" value={formatNumber(data.notice.dwell_rows)} />
+      </div>
+      <Section title="Open Rate">
+        {data.notice.available ? (
+          <DonutChart percent={data.notice.open_rate} />
+        ) : (
+          <EmptyState>Notice 데이터가 아직 제공되지 않습니다.</EmptyState>
+        )}
+      </Section>
+      <Section title="Sample rows">
+        <NoticeSampleTable rows={data.notice.sample_rows} />
       </Section>
     </div>
   );
 };
 
 const DebugPanel = ({ data }: { data: DashboardResponse }) => {
-  const pageViewRows = sumMatchingEvents(data.event_distribution, PAGE_VIEW_KEYWORDS);
-  const homeMatchedRows = getHomeMatchRows(data);
-
   return (
     <div className="flex flex-col gap-24">
+      <div className="grid grid-cols-2 gap-10">
+        <MetricCard label="page_view rows" value={formatNumber(data.debug.page_view_rows)} />
+        <MetricCard
+          label="active(home)"
+          value={formatNumber(data.debug.active_home_matched_rows)}
+        />
+        <MetricCard label="request_id_col" value={data.debug.request_id_col ?? '-'} />
+        <MetricCard
+          label="request_id fill"
+          value={formatPercent(data.debug.request_id_fill_rate ?? null)}
+        />
+      </div>
       <Section title="event_type Top">
-        <DistributionTable items={toCountItems(data.event_distribution)} />
+        <DistributionTable
+          items={data.debug.event_type_top.map((item) => ({
+            label: item.event_type,
+            count: item.count,
+          }))}
+          labelHeader="event_type"
+        />
       </Section>
-      <Section title="page_view rows">
-        <div className="text-body-body9 text-foreground-normal">
-          page_view rows = {formatNumber(pageViewRows)}
-        </div>
-      </Section>
-      <Section title="Active match check">
-        <div className="text-body-body9 text-foreground-normal">
-          active(home) matched rows = {formatNumber(homeMatchedRows)}
-        </div>
+      <Section title="Warnings">
+        {data.debug.warnings.length > 0 ? (
+          <div className="flex flex-col gap-8">
+            {data.debug.warnings.map((warning) => (
+              <div
+                key={warning}
+                className="border-border-normal rounded-6 border px-12 py-10 text-body-body9 text-foreground-normal"
+              >
+                {warning}
+              </div>
+            ))}
+          </div>
+        ) : (
+          <EmptyState>경고 없음</EmptyState>
+        )}
       </Section>
     </div>
   );
@@ -421,7 +727,9 @@ const DashboardContent = ({
   if (activeTab === 'traffic') return <TrafficPanel data={data} />;
   if (activeTab === 'kpi') return <KpiPanel data={data} />;
   if (activeTab === 'funnel') return <FunnelPanel data={data} />;
+  if (activeTab === 'churn') return <ChurnPanel data={data} />;
   if (activeTab === 'content') return <ContentPanel data={data} />;
+  if (activeTab === 'notice') return <NoticePanel data={data} />;
 
   return <DebugPanel data={data} />;
 };

--- a/apps/admin/src/app-pages/dashboard/ui/DashboardPage.tsx
+++ b/apps/admin/src/app-pages/dashboard/ui/DashboardPage.tsx
@@ -92,7 +92,7 @@ const MetricCard = ({
 
 const Section = ({ title, children }: { title: string; children: ReactNode }) => {
   return (
-    <section className="flex flex-col gap-12">
+    <section className="flex min-w-0 flex-col gap-12">
       <h2 className="text-title-title3 text-foreground-normal">{title}</h2>
       {children}
     </section>
@@ -109,17 +109,22 @@ const DistributionTable = ({
   countHeader?: string;
 }) => {
   return (
-    <div className="border-border-normal overflow-hidden rounded-6 border">
+    <div className="border-border-normal min-w-0 overflow-hidden rounded-6 border">
       <table className="w-full table-fixed border-collapse">
+        <colgroup>
+          <col className="w-44" />
+          <col />
+          <col className="w-92" />
+        </colgroup>
         <thead className="bg-background-quaternary">
           <tr>
-            <th className="text-caption-caption6 text-foreground-tertiary w-36 px-8 py-8 text-left">
+            <th className="text-caption-caption6 text-foreground-tertiary px-8 py-8 text-left">
               #
             </th>
-            <th className="text-caption-caption6 text-foreground-tertiary px-8 py-8 text-left">
+            <th className="text-caption-caption6 text-foreground-tertiary min-w-0 truncate px-8 py-8 text-left">
               {labelHeader}
             </th>
-            <th className="text-caption-caption6 text-foreground-tertiary w-70 px-8 py-8 text-right">
+            <th className="text-caption-caption6 text-foreground-tertiary px-10 py-8 text-right">
               {countHeader}
             </th>
           </tr>
@@ -140,10 +145,10 @@ const DistributionTable = ({
                 <td className="text-caption-caption6 text-foreground-tertiary px-8 py-8">
                   {index}
                 </td>
-                <td className="text-caption-caption6 text-foreground-normal truncate px-8 py-8">
+                <td className="text-caption-caption6 text-foreground-normal min-w-0 truncate px-8 py-8">
                   {item.label}
                 </td>
-                <td className="text-caption-caption6 text-foreground-normal px-8 py-8 text-right">
+                <td className="text-caption-caption6 text-foreground-normal truncate px-10 py-8 text-right">
                   {formatNumber(item.count)}
                 </td>
               </tr>

--- a/apps/admin/src/app-pages/dashboard/ui/DashboardPage.tsx
+++ b/apps/admin/src/app-pages/dashboard/ui/DashboardPage.tsx
@@ -1,0 +1,540 @@
+'use client';
+
+import { Input } from '@surf/ui/input';
+import { useMemo, useState, type ReactNode } from 'react';
+import type {
+  DashboardResponse,
+  EventDistributionResponse,
+  PathDistributionResponse,
+} from '@/features/dashboard/api/types';
+import { useDashboardDateRange } from '@/features/dashboard/model/useDashboardDateRange';
+import { useDashboardQuery } from '@/features/dashboard/model/useDashboardQuery';
+
+type DashboardTab = 'traffic' | 'kpi' | 'funnel' | 'content' | 'debug';
+
+type CountItem = {
+  label: string;
+  count: number;
+};
+
+type FunnelItem = {
+  funnel: string;
+  attemptEvents: number;
+  successEvents: number;
+};
+
+const DASHBOARD_TABS: { value: DashboardTab; label: string }[] = [
+  { value: 'traffic', label: '1.1 Traffic' },
+  { value: 'kpi', label: '1.2 KPI' },
+  { value: 'funnel', label: '1.3 Funnel' },
+  { value: 'content', label: '1.5 Content' },
+  { value: 'debug', label: 'Debug' },
+];
+
+const PRESETS = [
+  { value: '7d', label: '최근 7일' },
+  { value: '30d', label: '최근 30일' },
+  { value: 'month', label: '이번 달' },
+] as const;
+
+const POST_KEYWORDS = ['post.create', 'post.created', 'post.submit', 'post.add'];
+const COMMENT_KEYWORDS = ['comment.create', 'comment.submit', 'comment.add'];
+const LIKE_KEYWORDS = ['like.add', 'like.create', 'like'];
+const SCRAP_KEYWORDS = ['scrap.add', 'scrap.create', 'scrap'];
+const PAGE_VIEW_KEYWORDS = ['page.view', 'page_view'];
+
+function formatNumber(value?: number) {
+  if (value === undefined || Number.isNaN(value)) return '-';
+  return value.toLocaleString('ko-KR');
+}
+
+function normalizeEventLabel(event: string) {
+  return event.toLowerCase().replaceAll('_', '.');
+}
+
+function sumMatchingEvents(events: EventDistributionResponse[], keywords: string[]) {
+  return events.reduce((sum, item) => {
+    const label = normalizeEventLabel(item.event);
+    const isMatched = keywords.some((keyword) =>
+      label.includes(keyword.toLowerCase().replaceAll('_', '.')),
+    );
+
+    return isMatched ? sum + item.count : sum;
+  }, 0);
+}
+
+function toCountItems(items: EventDistributionResponse[] | PathDistributionResponse[]) {
+  return items.map((item) => ({
+    label: 'event' in item ? item.event : item.path,
+    count: item.count,
+  }));
+}
+
+function getKpiMetrics(data: DashboardResponse) {
+  const posts = sumMatchingEvents(data.event_distribution, POST_KEYWORDS);
+  const comments = sumMatchingEvents(data.event_distribution, COMMENT_KEYWORDS);
+  const likes = sumMatchingEvents(data.event_distribution, LIKE_KEYWORDS);
+  const scraps = sumMatchingEvents(data.event_distribution, SCRAP_KEYWORDS);
+
+  return {
+    posts,
+    comments,
+    likes,
+    scraps,
+    activityIndex: posts * 3 + comments * 2 + (likes + scraps),
+  };
+}
+
+function getFunnelItems(data: DashboardResponse): FunnelItem[] {
+  const definitions = [
+    {
+      funnel: 'Post Create',
+      attemptKeywords: POST_KEYWORDS,
+      successKeywords: ['post.succeeded', 'post.success', 'post.created'],
+    },
+    {
+      funnel: 'Comment Create',
+      attemptKeywords: COMMENT_KEYWORDS,
+      successKeywords: ['comment.succeeded', 'comment.success', 'comment.created'],
+    },
+    {
+      funnel: 'Like',
+      attemptKeywords: LIKE_KEYWORDS,
+      successKeywords: ['like.succeeded', 'like.success'],
+    },
+    {
+      funnel: 'Scrap',
+      attemptKeywords: SCRAP_KEYWORDS,
+      successKeywords: ['scrap.succeeded', 'scrap.success'],
+    },
+  ];
+
+  return definitions.map((item) => ({
+    funnel: item.funnel,
+    attemptEvents: sumMatchingEvents(data.event_distribution, item.attemptKeywords),
+    successEvents: sumMatchingEvents(data.event_distribution, item.successKeywords),
+  }));
+}
+
+function getHomeMatchRows(data: DashboardResponse) {
+  return (
+    sumMatchingEvents(data.event_distribution, ['home.view']) +
+    data.path_distribution
+      .filter((item) => item.path.includes('/home'))
+      .reduce((sum, item) => sum + item.count, 0)
+  );
+}
+
+const MetricCard = ({ label, value }: { label: string; value: string }) => {
+  return (
+    <div className="border-border-normal bg-background-normal-lighter rounded-6 border p-12">
+      <div className="text-caption-caption6 text-foreground-tertiary">{label}</div>
+      <div className="text-title-title2 text-foreground-normal mt-8">{value}</div>
+    </div>
+  );
+};
+
+const Section = ({ title, children }: { title: string; children: ReactNode }) => {
+  return (
+    <section className="flex flex-col gap-12">
+      <h2 className="text-title-title3 text-foreground-normal">{title}</h2>
+      {children}
+    </section>
+  );
+};
+
+const SimpleLineChart = ({ items }: { items: CountItem[] }) => {
+  const width = 320;
+  const height = 156;
+  const padding = 18;
+  const max = Math.max(...items.map((item) => item.count), 1);
+  const points = items.map((item, index) => {
+    const x =
+      items.length <= 1
+        ? width / 2
+        : padding + (index / (items.length - 1)) * (width - padding * 2);
+    const y = height - padding - (item.count / max) * (height - padding * 2);
+
+    return { x, y, item };
+  });
+  const path = points
+    .map((point, index) => `${index === 0 ? 'M' : 'L'} ${point.x} ${point.y}`)
+    .join(' ');
+
+  return (
+    <div className="border-border-normal rounded-6 border p-12">
+      <svg viewBox={`0 0 ${width} ${height}`} className="h-156 w-full" role="img">
+        <line
+          x1={padding}
+          y1={height - padding}
+          x2={width - padding}
+          y2={height - padding}
+          className="stroke-border-normal"
+        />
+        <line
+          x1={padding}
+          y1={padding}
+          x2={padding}
+          y2={height - padding}
+          className="stroke-border-normal"
+        />
+        <path d={path} fill="none" className="stroke-foreground-normal" strokeWidth="2" />
+        {points.map((point) => (
+          <circle
+            key={point.item.label}
+            cx={point.x}
+            cy={point.y}
+            r="3"
+            className="fill-foreground-normal"
+          />
+        ))}
+      </svg>
+      <div className="mt-8 flex justify-between gap-8">
+        {items.slice(0, 4).map((item) => (
+          <div key={item.label} className="text-caption-caption6 text-foreground-tertiary">
+            {item.label.slice(5)}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const SimpleBarChart = ({ items }: { items: CountItem[] }) => {
+  const max = Math.max(...items.map((item) => item.count), 1);
+
+  return (
+    <div className="flex flex-col gap-9">
+      {items.map((item) => (
+        <div key={item.label} className="grid grid-cols-[minmax(0,1fr)_3rem] items-center gap-8">
+          <div className="min-w-0">
+            <div className="mb-5 truncate text-caption-caption6 text-foreground-tertiary">
+              {item.label}
+            </div>
+            <div className="bg-background-quaternary h-8 overflow-hidden rounded-max">
+              <div
+                className="bg-foreground-normal h-full rounded-max"
+                style={{ width: `${Math.max((item.count / max) * 100, 2)}%` }}
+              />
+            </div>
+          </div>
+          <div className="text-body-body9 text-foreground-normal text-right">
+            {formatNumber(item.count)}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+const DistributionTable = ({ items }: { items: CountItem[] }) => {
+  return (
+    <div className="border-border-normal overflow-hidden rounded-6 border">
+      <table className="w-full table-fixed border-collapse">
+        <thead className="bg-background-quaternary">
+          <tr>
+            <th className="text-caption-caption6 text-foreground-tertiary w-44 px-8 py-8 text-left">
+              #
+            </th>
+            <th className="text-caption-caption6 text-foreground-tertiary px-8 py-8 text-left">
+              name
+            </th>
+            <th className="text-caption-caption6 text-foreground-tertiary w-70 px-8 py-8 text-right">
+              cnt
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.length === 0 ? (
+            <tr>
+              <td
+                colSpan={3}
+                className="text-body-body9 text-foreground-tertiary px-8 py-16 text-center"
+              >
+                데이터 없음
+              </td>
+            </tr>
+          ) : (
+            items.slice(0, 10).map((item, index) => (
+              <tr key={`${item.label}-${index}`} className="border-border-normal border-t">
+                <td className="text-caption-caption6 text-foreground-tertiary px-8 py-8">
+                  {index}
+                </td>
+                <td className="text-caption-caption6 text-foreground-normal truncate px-8 py-8">
+                  {item.label}
+                </td>
+                <td className="text-caption-caption6 text-foreground-normal px-8 py-8 text-right">
+                  {formatNumber(item.count)}
+                </td>
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+const FunnelTable = ({ items }: { items: FunnelItem[] }) => {
+  return (
+    <div className="border-border-normal overflow-hidden rounded-6 border">
+      <table className="w-full table-fixed border-collapse">
+        <thead className="bg-background-quaternary">
+          <tr>
+            <th className="text-caption-caption6 text-foreground-tertiary px-8 py-8 text-left">
+              funnel
+            </th>
+            <th className="text-caption-caption6 text-foreground-tertiary w-92 px-8 py-8 text-right">
+              attempt
+            </th>
+            <th className="text-caption-caption6 text-foreground-tertiary w-92 px-8 py-8 text-right">
+              success
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((item) => (
+            <tr key={item.funnel} className="border-border-normal border-t">
+              <td className="text-caption-caption6 text-foreground-normal px-8 py-8">
+                {item.funnel}
+              </td>
+              <td className="text-caption-caption6 text-foreground-normal px-8 py-8 text-right">
+                {formatNumber(item.attemptEvents)}
+              </td>
+              <td className="text-caption-caption6 text-foreground-normal px-8 py-8 text-right">
+                {formatNumber(item.successEvents)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+const TrafficPanel = ({ data }: { data: DashboardResponse }) => {
+  const latestActivity = data.daily_activity.at(-1);
+
+  return (
+    <div className="flex flex-col gap-22">
+      <div className="grid grid-cols-2 gap-10">
+        <MetricCard label="DAU latest" value={formatNumber(latestActivity?.active_users)} />
+        <MetricCard label="Observed Users" value={formatNumber(data.summary.unique_users)} />
+      </div>
+      <Section title="DAU">
+        <SimpleLineChart
+          items={data.daily_activity.map((item) => ({
+            label: item.date,
+            count: item.active_users,
+          }))}
+        />
+      </Section>
+    </div>
+  );
+};
+
+const KpiPanel = ({ data }: { data: DashboardResponse }) => {
+  const metrics = getKpiMetrics(data);
+
+  return (
+    <div className="flex flex-col gap-22">
+      <div className="grid grid-cols-2 gap-10">
+        <MetricCard label="Posts" value={formatNumber(metrics.posts)} />
+        <MetricCard label="Comments" value={formatNumber(metrics.comments)} />
+        <MetricCard label="Likes add" value={formatNumber(metrics.likes)} />
+        <MetricCard label="Scraps add" value={formatNumber(metrics.scraps)} />
+        <MetricCard label="Activity Index" value={formatNumber(metrics.activityIndex)} />
+      </div>
+      <Section title="KPI total">
+        <SimpleBarChart
+          items={[
+            { label: 'Posts', count: metrics.posts },
+            { label: 'Comments', count: metrics.comments },
+            { label: 'Likes add', count: metrics.likes },
+            { label: 'Scraps add', count: metrics.scraps },
+            { label: 'Activity Index', count: metrics.activityIndex },
+          ]}
+        />
+      </Section>
+    </div>
+  );
+};
+
+const FunnelPanel = ({ data }: { data: DashboardResponse }) => {
+  const funnels = getFunnelItems(data);
+
+  return (
+    <div className="flex flex-col gap-22">
+      <FunnelTable items={funnels} />
+      <Section title="Attempt events">
+        <SimpleBarChart
+          items={funnels.map((item) => ({
+            label: item.funnel,
+            count: item.attemptEvents,
+          }))}
+        />
+      </Section>
+    </div>
+  );
+};
+
+const ContentPanel = ({ data }: { data: DashboardResponse }) => {
+  return (
+    <div className="flex flex-col gap-22">
+      <Section title="page_path Top">
+        <DistributionTable items={toCountItems(data.path_distribution)} />
+      </Section>
+    </div>
+  );
+};
+
+const DebugPanel = ({ data }: { data: DashboardResponse }) => {
+  const pageViewRows = sumMatchingEvents(data.event_distribution, PAGE_VIEW_KEYWORDS);
+  const homeMatchedRows = getHomeMatchRows(data);
+
+  return (
+    <div className="flex flex-col gap-24">
+      <Section title="event_type Top">
+        <DistributionTable items={toCountItems(data.event_distribution)} />
+      </Section>
+      <Section title="page_view rows">
+        <div className="text-body-body9 text-foreground-normal">
+          page_view rows = {formatNumber(pageViewRows)}
+        </div>
+      </Section>
+      <Section title="Active match check">
+        <div className="text-body-body9 text-foreground-normal">
+          active(home) matched rows = {formatNumber(homeMatchedRows)}
+        </div>
+      </Section>
+    </div>
+  );
+};
+
+const DashboardContent = ({
+  activeTab,
+  data,
+}: {
+  activeTab: DashboardTab;
+  data: DashboardResponse;
+}) => {
+  if (activeTab === 'traffic') return <TrafficPanel data={data} />;
+  if (activeTab === 'kpi') return <KpiPanel data={data} />;
+  if (activeTab === 'funnel') return <FunnelPanel data={data} />;
+  if (activeTab === 'content') return <ContentPanel data={data} />;
+
+  return <DebugPanel data={data} />;
+};
+
+export const DashboardPage = () => {
+  const [activeTab, setActiveTab] = useState<DashboardTab>('traffic');
+  const { preset, range, setPreset, setCustomRange } = useDashboardDateRange();
+  const { data, isPending, isError, error, refetch } = useDashboardQuery(range);
+
+  const periodText = useMemo(() => {
+    if (!data) return `${range.startDate} ~ ${range.endDate}`;
+
+    return `${data.period.start_date} ~ ${data.period.end_date}`;
+  }, [data, range.endDate, range.startDate]);
+
+  return (
+    <main className="scroll-touch flex h-full min-h-0 w-full flex-col overflow-y-auto">
+      <div className="bg-background-normal sticky top-0 z-10">
+        <div className="relative">
+          <div className="dashboard-tab-scrollbar border-border-normal flex gap-14 overflow-x-auto border-b px-13 pb-4">
+            {DASHBOARD_TABS.map((tab) => {
+              const isActive = tab.value === activeTab;
+
+              return (
+                <button
+                  key={tab.value}
+                  type="button"
+                  onClick={() => setActiveTab(tab.value)}
+                  className={[
+                    'relative shrink-0 py-12 text-body-body8 transition-colors',
+                    isActive ? 'text-foreground-normal' : 'text-foreground-tertiary',
+                  ].join(' ')}
+                >
+                  {tab.label}
+                  {isActive ? (
+                    <span className="bg-foreground-normal absolute inset-x-0 bottom-0 h-2" />
+                  ) : null}
+                </button>
+              );
+            })}
+          </div>
+          <div className="from-background-normal pointer-events-none absolute bottom-4 right-0 top-0 w-24 bg-gradient-to-l to-transparent" />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-18 px-13 py-16">
+        <div className="flex flex-wrap gap-8">
+          {PRESETS.map((item) => (
+            <button
+              key={item.value}
+              type="button"
+              onClick={() => setPreset(item.value)}
+              className={[
+                'rounded-max border px-12 py-8 text-body-body9',
+                preset === item.value
+                  ? 'border-foreground-normal bg-background-secondary-darker text-foreground-normal'
+                  : 'border-border-normal text-foreground-tertiary',
+              ].join(' ')}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+
+        <div className="grid grid-cols-2 gap-8">
+          <Input
+            type="date"
+            value={range.startDate}
+            onChange={(value) => {
+              setPreset('custom');
+              setCustomRange((prev) => ({ ...prev, startDate: value }));
+            }}
+            aria-label="시작일"
+          />
+          <Input
+            type="date"
+            value={range.endDate}
+            onChange={(value) => {
+              setPreset('custom');
+              setCustomRange((prev) => ({ ...prev, endDate: value }));
+            }}
+            aria-label="종료일"
+          />
+        </div>
+
+        <div className="text-caption-caption6 text-foreground-tertiary">조회 기간: {periodText}</div>
+
+        {isPending ? (
+          <div className="text-body-body9 text-foreground-tertiary py-40 text-center">
+            대시보드 데이터를 불러오는 중입니다.
+          </div>
+        ) : null}
+
+        {isError ? (
+          <div className="border-border-normal rounded-6 border p-14">
+            <div className="text-body-body8 text-foreground-normal">데이터 조회에 실패했습니다.</div>
+            <div className="text-caption-caption6 text-foreground-tertiary mt-6">
+              {error.message}
+            </div>
+            <button
+              type="button"
+              onClick={() => {
+                void refetch();
+              }}
+              className="text-body-body8 text-foreground-normal mt-12 underline"
+            >
+              다시 시도
+            </button>
+          </div>
+        ) : null}
+
+        {data ? <DashboardContent activeTab={activeTab} data={data} /> : null}
+      </div>
+    </main>
+  );
+};

--- a/apps/admin/src/app-pages/dashboard/ui/DashboardPage.tsx
+++ b/apps/admin/src/app-pages/dashboard/ui/DashboardPage.tsx
@@ -112,9 +112,9 @@ const DistributionTable = ({
     <div className="border-border-normal min-w-0 overflow-hidden rounded-6 border">
       <table className="w-full table-fixed border-collapse">
         <colgroup>
-          <col className="w-44" />
+          <col className="w-[2.5rem]" />
           <col />
-          <col className="w-92" />
+          <col className="w-[5rem]" />
         </colgroup>
         <thead className="bg-background-quaternary">
           <tr>
@@ -303,7 +303,7 @@ const TrafficPanel = ({ data }: { data: DashboardResponse }) => {
   const latestMau = data.traffic.mau.at(-1);
 
   return (
-    <div className="flex flex-col gap-22">
+    <div className="flex flex-col gap-16">
       <div className="grid grid-cols-2 gap-10">
         <MetricCard label="DAU latest" value={formatNumber(latestDau?.users)} />
         <MetricCard label="WAU latest" value={formatNumber(latestWau?.users)} />
@@ -339,7 +339,7 @@ const KpiPanel = ({ data }: { data: DashboardResponse }) => {
   const activityIndex = sumKpi(data.kpi_daily, 'activity_index');
 
   return (
-    <div className="flex flex-col gap-22">
+    <div className="flex flex-col gap-16">
       <div className="grid grid-cols-2 gap-10">
         <MetricCard label="Posts" value={formatNumber(posts)} />
         <MetricCard label="Comments" value={formatNumber(comments)} />
@@ -384,7 +384,7 @@ const KpiPanel = ({ data }: { data: DashboardResponse }) => {
 
 const FunnelPanel = ({ data }: { data: DashboardResponse }) => {
   return (
-    <div className="flex flex-col gap-22">
+    <div className="flex flex-col gap-16">
       <FunnelTable items={data.funnel} />
       <Section title="Attempt to Matched">
         <HorizontalBarChart
@@ -400,7 +400,7 @@ const FunnelPanel = ({ data }: { data: DashboardResponse }) => {
 
 const ChurnPanel = ({ data }: { data: DashboardResponse }) => {
   return (
-    <div className="flex flex-col gap-22">
+    <div className="flex flex-col gap-16">
       <Section title="Status Bucket">
         <VerticalBarChart
           items={data.churn.buckets.map((item) => ({
@@ -418,7 +418,7 @@ const ChurnPanel = ({ data }: { data: DashboardResponse }) => {
 
 const ContentPanel = ({ data }: { data: DashboardResponse }) => {
   return (
-    <div className="flex flex-col gap-22">
+    <div className="flex flex-col gap-16">
       <Section title="page_url Top">
         <DistributionTable
           items={data.content.page_url_top.map((item) => ({
@@ -443,7 +443,7 @@ const ContentPanel = ({ data }: { data: DashboardResponse }) => {
 
 const NoticePanel = ({ data }: { data: DashboardResponse }) => {
   return (
-    <div className="flex flex-col gap-22">
+    <div className="flex flex-col gap-16">
       <div className="grid grid-cols-2 gap-10">
         <MetricCard label="Notice Open Rate" value={formatPercent(data.notice.open_rate)} />
         <MetricCard label="Notice Reach" value={formatNumber(data.notice.reach)} />
@@ -466,7 +466,7 @@ const NoticePanel = ({ data }: { data: DashboardResponse }) => {
 
 const DebugPanel = ({ data }: { data: DashboardResponse }) => {
   return (
-    <div className="flex flex-col gap-24">
+    <div className="flex flex-col gap-16">
       <div className="grid grid-cols-2 gap-10">
         <MetricCard label="page_view rows" value={formatNumber(data.debug.page_view_rows)} />
         <MetricCard
@@ -671,7 +671,7 @@ export const DashboardPage = () => {
         <div className="text-caption-caption6 text-foreground-tertiary">조회 기간: {periodText}</div>
 
         {isPending ? (
-          <div className="text-body-body9 text-foreground-tertiary py-40 text-center">
+          <div className="text-body-body9 text-foreground-tertiary py-19 text-center">
             대시보드 데이터를 불러오는 중입니다.
           </div>
         ) : null}

--- a/apps/admin/src/app-pages/dashboard/ui/DashboardPage.tsx
+++ b/apps/admin/src/app-pages/dashboard/ui/DashboardPage.tsx
@@ -1,7 +1,16 @@
 'use client';
 
+import {
+  DonutChart,
+  EmptyState,
+  HorizontalBarChart,
+  MultiLineChart,
+  SingleLineChart,
+  VerticalBarChart,
+  type CountItem,
+} from '@surf/ui/charts';
 import { Input } from '@surf/ui/input';
-import { useMemo, useState, type ReactNode } from 'react';
+import { useId, useMemo, useRef, useState, type KeyboardEvent, type ReactNode } from 'react';
 import type {
   ChurnUserResponse,
   DashboardResponse,
@@ -13,17 +22,6 @@ import { useDashboardDateRange } from '@/features/dashboard/model/useDashboardDa
 import { useDashboardQuery } from '@/features/dashboard/model/useDashboardQuery';
 
 type DashboardTab = 'traffic' | 'kpi' | 'funnel' | 'churn' | 'content' | 'notice' | 'debug';
-
-type CountItem = {
-  label: string;
-  count: number;
-};
-
-type LineSeries = {
-  label: string;
-  color: string;
-  points: CountItem[];
-};
 
 const DASHBOARD_TABS: { value: DashboardTab; label: string }[] = [
   { value: 'traffic', label: '1.1 Traffic' },
@@ -72,20 +70,6 @@ function sumKpi(data: KpiDailyResponse[], key: keyof Omit<KpiDailyResponse, 'dat
   return data.reduce((sum, item) => sum + item[key], 0);
 }
 
-function buildLinePath(points: CountItem[], width: number, height: number, padding: number, max: number) {
-  return points
-    .map((item, index) => {
-      const x =
-        points.length <= 1
-          ? width / 2
-          : padding + (index / (points.length - 1)) * (width - padding * 2);
-      const y = height - padding - (item.count / max) * (height - padding * 2);
-
-      return `${index === 0 ? 'M' : 'L'} ${x} ${y}`;
-    })
-    .join(' ');
-}
-
 const MetricCard = ({
   label,
   value,
@@ -99,7 +83,9 @@ const MetricCard = ({
     <div className="border-border-normal bg-background-normal-lighter rounded-6 border p-12">
       <div className="text-caption-caption6 text-foreground-tertiary">{label}</div>
       <div className="text-title-title2 text-foreground-normal mt-8">{value}</div>
-      {helper ? <div className="text-caption-caption6 text-foreground-tertiary mt-6">{helper}</div> : null}
+      {helper ? (
+        <div className="text-caption-caption6 text-foreground-tertiary mt-6">{helper}</div>
+      ) : null}
     </div>
   );
 };
@@ -110,206 +96,6 @@ const Section = ({ title, children }: { title: string; children: ReactNode }) =>
       <h2 className="text-title-title3 text-foreground-normal">{title}</h2>
       {children}
     </section>
-  );
-};
-
-const EmptyState = ({ children = '데이터 없음' }: { children?: ReactNode }) => {
-  return (
-    <div className="border-border-normal rounded-6 border p-16 text-center text-body-body9 text-foreground-tertiary">
-      {children}
-    </div>
-  );
-};
-
-const SingleLineChart = ({ items }: { items: CountItem[] }) => {
-  if (items.length === 0) return <EmptyState />;
-
-  const width = 320;
-  const height = 156;
-  const padding = 18;
-  const max = Math.max(...items.map((item) => item.count), 1);
-  const path = buildLinePath(items, width, height, padding, max);
-
-  return (
-    <div className="border-border-normal rounded-6 border p-12">
-      <svg viewBox={`0 0 ${width} ${height}`} className="h-156 w-full" role="img">
-        <line
-          x1={padding}
-          y1={height - padding}
-          x2={width - padding}
-          y2={height - padding}
-          className="stroke-border-normal"
-        />
-        <line
-          x1={padding}
-          y1={padding}
-          x2={padding}
-          y2={height - padding}
-          className="stroke-border-normal"
-        />
-        <path d={path} fill="none" className="stroke-foreground-normal" strokeWidth="2" />
-      </svg>
-      <div className="mt-8 flex justify-between gap-8">
-        {items.slice(0, 4).map((item) => (
-          <div key={item.label} className="text-caption-caption6 text-foreground-tertiary">
-            {item.label.slice(5)}
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-};
-
-const MultiLineChart = ({ series }: { series: LineSeries[] }) => {
-  const visibleSeries = series.filter((item) => item.points.length > 0);
-  if (visibleSeries.length === 0) return <EmptyState />;
-
-  const width = 320;
-  const height = 168;
-  const padding = 18;
-  const max = Math.max(
-    ...visibleSeries.flatMap((item) => item.points.map((point) => point.count)),
-    1,
-  );
-  const labels = visibleSeries[0]?.points ?? [];
-
-  return (
-    <div className="border-border-normal rounded-6 border p-12">
-      <svg viewBox={`0 0 ${width} ${height}`} className="h-168 w-full" role="img">
-        <line
-          x1={padding}
-          y1={height - padding}
-          x2={width - padding}
-          y2={height - padding}
-          className="stroke-border-normal"
-        />
-        <line
-          x1={padding}
-          y1={padding}
-          x2={padding}
-          y2={height - padding}
-          className="stroke-border-normal"
-        />
-        {visibleSeries.map((item) => (
-          <path
-            key={item.label}
-            d={buildLinePath(item.points, width, height, padding, max)}
-            fill="none"
-            stroke={item.color}
-            strokeWidth="2"
-          />
-        ))}
-      </svg>
-      <div className="mt-8 flex flex-wrap gap-x-10 gap-y-4">
-        {visibleSeries.map((item) => (
-          <div key={item.label} className="flex items-center gap-4 text-caption-caption6 text-foreground-tertiary">
-            <span className="h-6 w-6 rounded-full" style={{ backgroundColor: item.color }} />
-            {item.label}
-          </div>
-        ))}
-      </div>
-      <div className="mt-8 flex justify-between gap-8">
-        {labels.slice(0, 4).map((item) => (
-          <div key={item.label} className="text-caption-caption6 text-foreground-tertiary">
-            {item.label.slice(5)}
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-};
-
-const HorizontalBarChart = ({ items, maxItems = 10 }: { items: CountItem[]; maxItems?: number }) => {
-  const slicedItems = items.slice(0, maxItems);
-  if (slicedItems.length === 0) return <EmptyState />;
-
-  const max = Math.max(...slicedItems.map((item) => item.count), 1);
-
-  return (
-    <div className="flex flex-col gap-9">
-      {slicedItems.map((item) => (
-        <div key={item.label} className="grid grid-cols-[minmax(0,1fr)_3rem] items-center gap-8">
-          <div className="min-w-0">
-            <div className="mb-5 truncate text-caption-caption6 text-foreground-tertiary">
-              {item.label}
-            </div>
-            <div className="bg-background-quaternary h-8 overflow-hidden rounded-max">
-              <div
-                className="bg-foreground-normal h-full rounded-max"
-                style={{ width: `${Math.max((item.count / max) * 100, 2)}%` }}
-              />
-            </div>
-          </div>
-          <div className="text-body-body9 text-foreground-normal text-right">
-            {formatNumber(item.count)}
-          </div>
-        </div>
-      ))}
-    </div>
-  );
-};
-
-const VerticalBarChart = ({ items }: { items: CountItem[] }) => {
-  if (items.length === 0) return <EmptyState />;
-
-  const max = Math.max(...items.map((item) => item.count), 1);
-
-  return (
-    <div className="border-border-normal rounded-6 border p-12">
-      <div className="flex h-156 items-end gap-8">
-        {items.map((item) => (
-          <div key={item.label} className="flex min-w-0 flex-1 flex-col items-center gap-6">
-            <div className="text-caption-caption6 text-foreground-tertiary">
-              {formatNumber(item.count)}
-            </div>
-            <div
-              className="bg-foreground-normal w-full rounded-t-3"
-              style={{ height: `${Math.max((item.count / max) * 112, 4)}px` }}
-            />
-            <div className="text-caption-caption6 text-foreground-tertiary w-full truncate text-center">
-              {item.label}
-            </div>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-};
-
-const DonutChart = ({ percent }: { percent: number | null }) => {
-  if (percent === null) return <EmptyState>Open Rate 데이터 없음</EmptyState>;
-
-  const radius = 46;
-  const circumference = 2 * Math.PI * radius;
-  const dash = (percent / 100) * circumference;
-
-  return (
-    <div className="border-border-normal flex items-center justify-center rounded-6 border p-18">
-      <svg viewBox="0 0 120 120" className="h-140 w-140" role="img">
-        <circle
-          cx="60"
-          cy="60"
-          r={radius}
-          fill="none"
-          className="stroke-background-quaternary"
-          strokeWidth="14"
-        />
-        <circle
-          cx="60"
-          cy="60"
-          r={radius}
-          fill="none"
-          className="stroke-foreground-normal"
-          strokeDasharray={`${dash} ${circumference - dash}`}
-          strokeLinecap="round"
-          strokeWidth="14"
-          transform="rotate(-90 60 60)"
-        />
-        <text x="60" y="65" textAnchor="middle" className="fill-foreground-normal text-body-body8">
-          {formatPercent(percent)}
-        </text>
-      </svg>
-    </div>
   );
 };
 
@@ -736,6 +522,17 @@ const DashboardContent = ({
 
 export const DashboardPage = () => {
   const [activeTab, setActiveTab] = useState<DashboardTab>('traffic');
+  const tabIdPrefix = useId();
+  const panelIdPrefix = useId();
+  const tabRefs = useRef<Record<DashboardTab, HTMLButtonElement | null>>({
+    traffic: null,
+    kpi: null,
+    funnel: null,
+    churn: null,
+    content: null,
+    notice: null,
+    debug: null,
+  });
   const { preset, range, setPreset, setCustomRange } = useDashboardDateRange();
   const { data, isPending, isError, error, refetch } = useDashboardQuery(range);
 
@@ -745,19 +542,68 @@ export const DashboardPage = () => {
     return `${data.period.start_date} ~ ${data.period.end_date}`;
   }, [data, range.endDate, range.startDate]);
 
+  const getTabId = (tab: DashboardTab) => `${tabIdPrefix}-${tab}`;
+  const getPanelId = (tab: DashboardTab) => `${panelIdPrefix}-${tab}-panel`;
+
+  const focusTab = (tab: DashboardTab) => {
+    setActiveTab(tab);
+    tabRefs.current[tab]?.focus();
+  };
+
+  const handleTabKeyDown = (event: KeyboardEvent<HTMLButtonElement>, tab: DashboardTab) => {
+    const currentIndex = DASHBOARD_TABS.findIndex((item) => item.value === tab);
+    const lastIndex = DASHBOARD_TABS.length - 1;
+    let nextIndex: number | null = null;
+
+    if (event.key === 'ArrowRight') {
+      nextIndex = currentIndex === lastIndex ? 0 : currentIndex + 1;
+    }
+
+    if (event.key === 'ArrowLeft') {
+      nextIndex = currentIndex === 0 ? lastIndex : currentIndex - 1;
+    }
+
+    if (event.key === 'Home') {
+      nextIndex = 0;
+    }
+
+    if (event.key === 'End') {
+      nextIndex = lastIndex;
+    }
+
+    if (nextIndex === null) return;
+
+    event.preventDefault();
+    focusTab(DASHBOARD_TABS[nextIndex].value);
+  };
+
   return (
     <main className="scroll-touch flex h-full min-h-0 w-full flex-col overflow-y-auto">
       <div className="bg-background-normal sticky top-0 z-10">
         <div className="relative">
-          <div className="dashboard-tab-scrollbar border-border-normal flex gap-14 overflow-x-auto border-b px-13 pb-4">
+          <div
+            className="dashboard-tab-scrollbar border-border-normal flex gap-14 overflow-x-auto border-b px-13 pb-4"
+            role="tablist"
+            aria-label="대시보드 섹션"
+            aria-orientation="horizontal"
+          >
             {DASHBOARD_TABS.map((tab) => {
               const isActive = tab.value === activeTab;
 
               return (
                 <button
                   key={tab.value}
+                  ref={(node) => {
+                    tabRefs.current[tab.value] = node;
+                  }}
                   type="button"
-                  onClick={() => setActiveTab(tab.value)}
+                  id={getTabId(tab.value)}
+                  role="tab"
+                  aria-selected={isActive}
+                  aria-controls={getPanelId(tab.value)}
+                  tabIndex={isActive ? 0 : -1}
+                  onClick={() => focusTab(tab.value)}
+                  onKeyDown={(event) => handleTabKeyDown(event, tab.value)}
                   className={[
                     'relative shrink-0 py-12 text-body-body8 transition-colors',
                     isActive ? 'text-foreground-normal' : 'text-foreground-tertiary',
@@ -765,7 +611,10 @@ export const DashboardPage = () => {
                 >
                   {tab.label}
                   {isActive ? (
-                    <span className="bg-foreground-normal absolute inset-x-0 bottom-0 h-2" />
+                    <span
+                      className="bg-foreground-normal absolute inset-x-0 bottom-0 h-2"
+                      aria-hidden="true"
+                    />
                   ) : null}
                 </button>
               );
@@ -841,7 +690,21 @@ export const DashboardPage = () => {
           </div>
         ) : null}
 
-        {data ? <DashboardContent activeTab={activeTab} data={data} /> : null}
+        {DASHBOARD_TABS.map((tab) => {
+          const isActive = tab.value === activeTab;
+
+          return (
+            <div
+              key={tab.value}
+              id={getPanelId(tab.value)}
+              role="tabpanel"
+              aria-labelledby={getTabId(tab.value)}
+              hidden={!isActive}
+            >
+              {isActive && data ? <DashboardContent activeTab={tab.value} data={data} /> : null}
+            </div>
+          );
+        })}
       </div>
     </main>
   );

--- a/apps/admin/src/app/(protected)/(main)/dashboard/page.tsx
+++ b/apps/admin/src/app/(protected)/(main)/dashboard/page.tsx
@@ -1,5 +1,5 @@
-const Page = () => {
-  return <div className="p-6 text-title-title2 text-foreground-normal">SURF 대시보드</div>;
-};
+import { DashboardPage } from '@/app-pages/dashboard/ui/DashboardPage';
+
+const Page = () => <DashboardPage />;
 
 export default Page;

--- a/apps/admin/src/app/api/dashboard/route.ts
+++ b/apps/admin/src/app/api/dashboard/route.ts
@@ -2,27 +2,170 @@ import { NextRequest, NextResponse } from 'next/server';
 
 export const runtime = 'nodejs';
 
-const DASHBOARD_API_BASE_URL = process.env.DASHBOARD_API_BASE_URL ?? 'http://52.65.89.250:8000';
+const AUTH_VALID_PATH = '/v1/user/members/valid-status';
+const DASHBOARD_PATH = '/api/dashboard/v2';
+const DASHBOARD_TIMEOUT_MS = 10_000;
+const ADMIN_ROLES = new Set(['ADMIN', 'PRESIDENT', 'MANAGER', 'admin', 'president', 'manager']);
 
-export async function GET(req: NextRequest) {
-  const targetUrl = new URL('/api/dashboard/v2', DASHBOARD_API_BASE_URL);
+type AuthResult =
+  | { ok: true }
+  | { ok: false; status: 401 | 403 | 500; message: string };
+
+function jsonError(message: string, status: number) {
+  return NextResponse.json({ message }, { status });
+}
+
+function getRequiredEnv(name: string) {
+  const value = process.env[name];
+
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+
+  return value;
+}
+
+function buildRequiredBaseUrl(name: string, options: { requireHttpsInProduction?: boolean } = {}) {
+  const raw = getRequiredEnv(name);
+  const url = new URL(raw);
+
+  if (options.requireHttpsInProduction && process.env.NODE_ENV === 'production' && url.protocol !== 'https:') {
+    throw new Error(`${name} must use https in production`);
+  }
+
+  return raw;
+}
+
+function buildDashboardUrl(req: NextRequest) {
+  const targetUrl = new URL(
+    DASHBOARD_PATH,
+    buildRequiredBaseUrl('DASHBOARD_API_BASE_URL', { requireHttpsInProduction: true }),
+  );
   const startDate = req.nextUrl.searchParams.get('start_date');
   const endDate = req.nextUrl.searchParams.get('end_date');
 
   if (startDate) targetUrl.searchParams.set('start_date', startDate);
   if (endDate) targetUrl.searchParams.set('end_date', endDate);
 
-  const response = await fetch(targetUrl, {
-    method: 'GET',
-    cache: 'no-store',
-  });
+  return targetUrl;
+}
 
-  const text = await response.text();
+function buildAuthUrl() {
+  return new URL(AUTH_VALID_PATH, buildRequiredBaseUrl('API_BASE_URL'));
+}
 
-  return new NextResponse(text, {
-    status: response.status,
-    headers: {
-      'content-type': response.headers.get('content-type') ?? 'application/json',
-    },
-  });
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function extractRole(value: unknown): unknown {
+  if (!isRecord(value)) return null;
+
+  const data = value['data'];
+  if (isRecord(data)) {
+    return data['memberRole'] ?? data['role'] ?? data['userRole'];
+  }
+
+  return value['memberRole'] ?? value['role'] ?? value['userRole'];
+}
+
+function isAdminRole(role: unknown) {
+  return typeof role === 'string' && ADMIN_ROLES.has(role);
+}
+
+function isAbortError(error: unknown) {
+  return error instanceof DOMException && error.name === 'TimeoutError';
+}
+
+function errorMessage(error: unknown) {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  return 'Unknown error';
+}
+
+async function verifyDashboardAccess(req: NextRequest): Promise<AuthResult> {
+  const accessToken = req.cookies.get('accessToken')?.value;
+
+  if (!accessToken) {
+    return { ok: false, status: 401, message: '인증이 필요합니다.' };
+  }
+
+  let response: Response;
+
+  try {
+    response = await fetch(buildAuthUrl(), {
+      method: 'GET',
+      cache: 'no-store',
+      headers: {
+        authorization: `Bearer ${accessToken}`,
+        'X-Client-Type': 'WEB',
+      },
+      signal: AbortSignal.timeout(DASHBOARD_TIMEOUT_MS),
+    });
+  } catch (error) {
+    console.error('[dashboard] auth validation failed:', errorMessage(error));
+    return { ok: false, status: 500, message: '인증 상태를 확인하지 못했습니다.' };
+  }
+
+  if (response.status === 401) {
+    return { ok: false, status: 401, message: '인증이 필요합니다.' };
+  }
+
+  if (!response.ok) {
+    console.error('[dashboard] auth validation returned non-ok status:', response.status);
+    return { ok: false, status: 500, message: '인증 상태를 확인하지 못했습니다.' };
+  }
+
+  const body: unknown = await response.json().catch(() => null);
+  const role = extractRole(body);
+
+  if (!isAdminRole(role)) {
+    console.warn('[dashboard] forbidden dashboard access:', { role });
+    return { ok: false, status: 403, message: '대시보드 접근 권한이 없습니다.' };
+  }
+
+  return { ok: true };
+}
+
+export async function GET(req: NextRequest) {
+  let targetUrl: URL;
+
+  try {
+    targetUrl = buildDashboardUrl(req);
+  } catch (error) {
+    console.error('[dashboard] invalid environment configuration:', errorMessage(error));
+    return jsonError('서버 설정이 올바르지 않습니다.', 500);
+  }
+
+  const auth = await verifyDashboardAccess(req);
+  if (!auth.ok) {
+    return jsonError(auth.message, auth.status);
+  }
+
+  try {
+    const response = await fetch(targetUrl, {
+      method: 'GET',
+      cache: 'no-store',
+      signal: AbortSignal.timeout(DASHBOARD_TIMEOUT_MS),
+    });
+
+    const text = await response.text();
+
+    return new NextResponse(text, {
+      status: response.status,
+      headers: {
+        'content-type': response.headers.get('content-type') ?? 'application/json',
+      },
+    });
+  } catch (error) {
+    const status = isAbortError(error) ? 504 : 502;
+    const message = status === 504 ? '대시보드 요청 시간이 초과되었습니다.' : '대시보드 데이터를 불러오지 못했습니다.';
+
+    console.error('[dashboard] upstream request failed:', {
+      status,
+      message: errorMessage(error),
+    });
+
+    return jsonError(message, status);
+  }
 }

--- a/apps/admin/src/app/api/dashboard/route.ts
+++ b/apps/admin/src/app/api/dashboard/route.ts
@@ -130,16 +130,16 @@ async function verifyDashboardAccess(req: NextRequest): Promise<AuthResult> {
 export async function GET(req: NextRequest) {
   let targetUrl: URL;
 
+  const auth = await verifyDashboardAccess(req);
+  if (!auth.ok) {
+    return jsonError(auth.message, auth.status);
+  }
+
   try {
     targetUrl = buildDashboardUrl(req);
   } catch (error) {
     console.error('[dashboard] invalid environment configuration:', errorMessage(error));
     return jsonError('서버 설정이 올바르지 않습니다.', 500);
-  }
-
-  const auth = await verifyDashboardAccess(req);
-  if (!auth.ok) {
-    return jsonError(auth.message, auth.status);
   }
 
   try {

--- a/apps/admin/src/app/api/dashboard/route.ts
+++ b/apps/admin/src/app/api/dashboard/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+
+const DASHBOARD_API_BASE_URL = process.env.DASHBOARD_API_BASE_URL ?? 'http://52.65.89.250:8000';
+
+export async function GET(req: NextRequest) {
+  const targetUrl = new URL('/api/dashboard', DASHBOARD_API_BASE_URL);
+  const startDate = req.nextUrl.searchParams.get('start_date');
+  const endDate = req.nextUrl.searchParams.get('end_date');
+
+  if (startDate) targetUrl.searchParams.set('start_date', startDate);
+  if (endDate) targetUrl.searchParams.set('end_date', endDate);
+
+  const response = await fetch(targetUrl, {
+    method: 'GET',
+    cache: 'no-store',
+  });
+
+  const text = await response.text();
+
+  return new NextResponse(text, {
+    status: response.status,
+    headers: {
+      'content-type': response.headers.get('content-type') ?? 'application/json',
+    },
+  });
+}

--- a/apps/admin/src/app/api/dashboard/route.ts
+++ b/apps/admin/src/app/api/dashboard/route.ts
@@ -5,7 +5,7 @@ export const runtime = 'nodejs';
 const DASHBOARD_API_BASE_URL = process.env.DASHBOARD_API_BASE_URL ?? 'http://52.65.89.250:8000';
 
 export async function GET(req: NextRequest) {
-  const targetUrl = new URL('/api/dashboard', DASHBOARD_API_BASE_URL);
+  const targetUrl = new URL('/api/dashboard/v2', DASHBOARD_API_BASE_URL);
   const startDate = req.nextUrl.searchParams.get('start_date');
   const endDate = req.nextUrl.searchParams.get('end_date');
 

--- a/apps/admin/src/app/api/proxy/[...path]/route.ts
+++ b/apps/admin/src/app/api/proxy/[...path]/route.ts
@@ -3,7 +3,6 @@ export const runtime = 'nodejs';
 
 const BACKEND = process.env.API_BASE_URL!;
 const IS_DEV = process.env.NODE_ENV !== 'production';
-console.log('[proxy] API_BASE_URL =', process.env.API_BASE_URL);
 
 const HOP_BY_HOP = new Set([
   'connection',

--- a/apps/admin/src/features/dashboard/api/getDashboard.ts
+++ b/apps/admin/src/features/dashboard/api/getDashboard.ts
@@ -1,0 +1,14 @@
+import { axiosInstance } from '@/shared/lib/axiosInstance';
+import type { DashboardDateRangeParams, DashboardResponse } from './types';
+
+export async function getDashboard(params: DashboardDateRangeParams) {
+  const response = await axiosInstance.get<DashboardResponse>('/dashboard', {
+    baseURL: '/api',
+    params: {
+      start_date: params.startDate || undefined,
+      end_date: params.endDate || undefined,
+    },
+  });
+
+  return response.data;
+}

--- a/apps/admin/src/features/dashboard/api/types.ts
+++ b/apps/admin/src/features/dashboard/api/types.ts
@@ -1,0 +1,56 @@
+export type DashboardDateRangeParams = {
+  startDate?: string;
+  endDate?: string;
+};
+
+export type DashboardPeriodResponse = {
+  start_date: string;
+  end_date: string;
+};
+
+export type DashboardSummaryResponse = {
+  total_events: number;
+  unique_users: number;
+  success_events: number;
+  error_events: number;
+  success_rate: number;
+  error_rate: number;
+  average_duration_ms: number;
+};
+
+export type DailyActivityResponse = {
+  date: string;
+  event_count: number;
+  active_users: number;
+  error_count: number;
+};
+
+export type EventDistributionResponse = {
+  event: string;
+  count: number;
+};
+
+export type StatusDistributionResponse = {
+  status: number;
+  count: number;
+};
+
+export type ActorRoleDistributionResponse = {
+  actor_role: string;
+  count: number;
+};
+
+export type PathDistributionResponse = {
+  path: string;
+  count: number;
+};
+
+export type DashboardResponse = {
+  period: DashboardPeriodResponse;
+  summary: DashboardSummaryResponse;
+  daily_activity: DailyActivityResponse[];
+  event_distribution: EventDistributionResponse[];
+  status_distribution: StatusDistributionResponse[];
+  actor_role_distribution: ActorRoleDistributionResponse[];
+  path_distribution: PathDistributionResponse[];
+};

--- a/apps/admin/src/features/dashboard/api/types.ts
+++ b/apps/admin/src/features/dashboard/api/types.ts
@@ -8,49 +8,123 @@ export type DashboardPeriodResponse = {
   end_date: string;
 };
 
-export type DashboardSummaryResponse = {
-  total_events: number;
-  unique_users: number;
-  success_events: number;
-  error_events: number;
-  success_rate: number;
-  error_rate: number;
-  average_duration_ms: number;
+export type TrafficPointResponse = {
+  users: number;
 };
 
-export type DailyActivityResponse = {
+export type DauPointResponse = TrafficPointResponse & {
   date: string;
-  event_count: number;
-  active_users: number;
-  error_count: number;
 };
 
-export type EventDistributionResponse = {
-  event: string;
+export type WauPointResponse = TrafficPointResponse & {
+  week: string;
+};
+
+export type MauPointResponse = TrafficPointResponse & {
+  month: string;
+};
+
+export type TrafficResponse = {
+  dau: DauPointResponse[];
+  wau: WauPointResponse[];
+  mau: MauPointResponse[];
+  active_rate: number | null;
+  stickiness: {
+    dau_mau: number | null;
+    wau_mau: number | null;
+  };
+};
+
+export type KpiDailyResponse = {
+  date: string;
+  posts: number;
+  comments: number;
+  likes_add: number;
+  scraps_add: number;
+  activity_index: number;
+};
+
+export type FunnelResponse = {
+  funnel: string;
+  attempt_event: string;
+  success_event: string;
+  attempt_events: number;
+  attempt_users: number;
+  success_events: number;
+  matched: number;
+  conversion: number;
+};
+
+export type ChurnBucketResponse = {
+  status_bucket: string;
+  users: number;
+};
+
+export type ChurnUserResponse = {
+  user_id: string;
+  last_active_at: string;
+  days_inactive: number;
+  status_bucket: string;
+};
+
+export type ChurnResponse = {
+  buckets: ChurnBucketResponse[];
+  users: ChurnUserResponse[];
+};
+
+export type PageUrlTopResponse = {
+  page_url: string;
   count: number;
 };
 
-export type StatusDistributionResponse = {
-  status: number;
+export type PagePathTopResponse = {
+  page_path: string;
   count: number;
 };
 
-export type ActorRoleDistributionResponse = {
-  actor_role: string;
-  count: number;
+export type ContentResponse = {
+  page_url_top: PageUrlTopResponse[];
+  page_path_top: PagePathTopResponse[];
 };
 
-export type PathDistributionResponse = {
-  path: string;
-  count: number;
+export type NoticeSampleRowResponse = {
+  user_id: string;
+  event_time_kst: string;
+  event_type: string;
+  page_path: string;
+  page_name?: string;
+  dwell_time_ms?: number;
+  is_open: boolean;
+};
+
+export type NoticeResponse = {
+  available: boolean;
+  open_rate: number | null;
+  reach: number | null;
+  avg_dwell_ms: number | null;
+  dwell_rows: number;
+  sample_rows: NoticeSampleRowResponse[];
+};
+
+export type DebugResponse = {
+  event_type_top: {
+    event_type: string;
+    count: number;
+  }[];
+  page_view_rows: number;
+  active_home_matched_rows: number;
+  request_id_col: string | null;
+  request_id_fill_rate?: number | null;
+  warnings: string[];
 };
 
 export type DashboardResponse = {
   period: DashboardPeriodResponse;
-  summary: DashboardSummaryResponse;
-  daily_activity: DailyActivityResponse[];
-  event_distribution: EventDistributionResponse[];
-  status_distribution: StatusDistributionResponse[];
-  actor_role_distribution: ActorRoleDistributionResponse[];
-  path_distribution: PathDistributionResponse[];
+  traffic: TrafficResponse;
+  kpi_daily: KpiDailyResponse[];
+  funnel: FunnelResponse[];
+  churn: ChurnResponse;
+  content: ContentResponse;
+  notice: NoticeResponse;
+  debug: DebugResponse;
 };

--- a/apps/admin/src/features/dashboard/model/queryKeys.ts
+++ b/apps/admin/src/features/dashboard/model/queryKeys.ts
@@ -1,0 +1,7 @@
+import type { DashboardDateRangeParams } from '../api/types';
+
+export const dashboardQueryKeys = {
+  all: ['dashboard'] as const,
+  detail: (params: DashboardDateRangeParams) =>
+    [...dashboardQueryKeys.all, params.startDate ?? '', params.endDate ?? ''] as const,
+};

--- a/apps/admin/src/features/dashboard/model/useDashboardDateRange.ts
+++ b/apps/admin/src/features/dashboard/model/useDashboardDateRange.ts
@@ -1,0 +1,51 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+type Preset = '7d' | '30d' | 'month' | 'custom';
+
+function formatDate(date: Date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+
+  return `${year}-${month}-${day}`;
+}
+
+function getPresetRange(preset: Exclude<Preset, 'custom'>) {
+  const today = new Date();
+
+  if (preset === 'month') {
+    return {
+      startDate: formatDate(new Date(today.getFullYear(), today.getMonth(), 1)),
+      endDate: formatDate(today),
+    };
+  }
+
+  const days = preset === '7d' ? 6 : 29;
+
+  return {
+    startDate: formatDate(new Date(today.getTime() - days * DAY_MS)),
+    endDate: formatDate(today),
+  };
+}
+
+export function useDashboardDateRange() {
+  const [preset, setPreset] = useState<Preset>('30d');
+  const [customRange, setCustomRange] = useState(getPresetRange('30d'));
+
+  const range = useMemo(
+    () => (preset === 'custom' ? customRange : getPresetRange(preset)),
+    [customRange, preset],
+  );
+
+  return {
+    preset,
+    range,
+    customRange,
+    setPreset,
+    setCustomRange,
+  };
+}

--- a/apps/admin/src/features/dashboard/model/useDashboardQuery.ts
+++ b/apps/admin/src/features/dashboard/model/useDashboardQuery.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { getDashboard } from '../api/getDashboard';
+import type { DashboardDateRangeParams } from '../api/types';
+import { dashboardQueryKeys } from './queryKeys';
+
+export function useDashboardQuery(params: DashboardDateRangeParams) {
+  return useQuery({
+    queryKey: dashboardQueryKeys.detail(params),
+    queryFn: () => getDashboard(params),
+  });
+}

--- a/apps/admin/src/shared/styles/globals.css
+++ b/apps/admin/src/shared/styles/globals.css
@@ -33,6 +33,14 @@ body {
   -webkit-overflow-scrolling: touch;
 }
 
+.dashboard-tab-scrollbar {
+  scrollbar-width: none;
+}
+
+.dashboard-tab-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+
 /* placeholder */
 .placeholder-body-14-600--1-24::placeholder {
   font-family:

--- a/packages/ui/components/charts/Charts.tsx
+++ b/packages/ui/components/charts/Charts.tsx
@@ -1,0 +1,251 @@
+import type { ReactNode } from 'react';
+
+export type CountItem = {
+  label: string;
+  count: number;
+};
+
+export type LineSeries = {
+  label: string;
+  color: string;
+  points: CountItem[];
+};
+
+const formatNumber = (value?: number | null) => {
+  if (value === undefined || value === null || Number.isNaN(value)) return '-';
+  return value.toLocaleString('ko-KR');
+};
+
+const formatPercent = (value?: number | null) => {
+  if (value === undefined || value === null || Number.isNaN(value)) return '-';
+  return `${value.toFixed(1)}%`;
+};
+
+const buildLinePath = (
+  points: CountItem[],
+  width: number,
+  height: number,
+  padding: number,
+  max: number,
+) => {
+  return points
+    .map((item, index) => {
+      const x =
+        points.length <= 1
+          ? width / 2
+          : padding + (index / (points.length - 1)) * (width - padding * 2);
+      const y = height - padding - (item.count / max) * (height - padding * 2);
+
+      return `${index === 0 ? 'M' : 'L'} ${x} ${y}`;
+    })
+    .join(' ');
+};
+
+export const EmptyState = ({ children = '데이터 없음' }: { children?: ReactNode }) => {
+  return (
+    <div className="border-border-normal rounded-6 text-body-body9 text-foreground-tertiary border p-16 text-center">
+      {children}
+    </div>
+  );
+};
+
+export const SingleLineChart = ({ items }: { items: CountItem[] }) => {
+  if (items.length === 0) return <EmptyState />;
+
+  const width = 320;
+  const height = 156;
+  const padding = 18;
+  const max = Math.max(...items.map((item) => item.count), 1);
+  const path = buildLinePath(items, width, height, padding, max);
+
+  return (
+    <div className="border-border-normal rounded-6 border p-12">
+      <svg viewBox={`0 0 ${width} ${height}`} className="h-156 w-full" role="img">
+        <line
+          x1={padding}
+          y1={height - padding}
+          x2={width - padding}
+          y2={height - padding}
+          className="stroke-border-normal"
+        />
+        <line
+          x1={padding}
+          y1={padding}
+          x2={padding}
+          y2={height - padding}
+          className="stroke-border-normal"
+        />
+        <path d={path} fill="none" className="stroke-foreground-normal" strokeWidth="2" />
+      </svg>
+      <div className="mt-8 flex justify-between gap-8">
+        {items.slice(0, 4).map((item) => (
+          <div key={item.label} className="text-caption-caption6 text-foreground-tertiary">
+            {item.label.slice(5)}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export const MultiLineChart = ({ series }: { series: LineSeries[] }) => {
+  const visibleSeries = series.filter((item) => item.points.length > 0);
+  if (visibleSeries.length === 0) return <EmptyState />;
+
+  const width = 320;
+  const height = 168;
+  const padding = 18;
+  const max = Math.max(
+    ...visibleSeries.flatMap((item) => item.points.map((point) => point.count)),
+    1,
+  );
+  const labels = visibleSeries[0]?.points ?? [];
+
+  return (
+    <div className="border-border-normal rounded-6 border p-12">
+      <svg viewBox={`0 0 ${width} ${height}`} className="h-168 w-full" role="img">
+        <line
+          x1={padding}
+          y1={height - padding}
+          x2={width - padding}
+          y2={height - padding}
+          className="stroke-border-normal"
+        />
+        <line
+          x1={padding}
+          y1={padding}
+          x2={padding}
+          y2={height - padding}
+          className="stroke-border-normal"
+        />
+        {visibleSeries.map((item) => (
+          <path
+            key={item.label}
+            d={buildLinePath(item.points, width, height, padding, max)}
+            fill="none"
+            stroke={item.color}
+            strokeWidth="2"
+          />
+        ))}
+      </svg>
+      <div className="mt-8 flex flex-wrap gap-x-10 gap-y-4">
+        {visibleSeries.map((item) => (
+          <div
+            key={item.label}
+            className="text-caption-caption6 text-foreground-tertiary flex items-center gap-4"
+          >
+            <span className="h-6 w-6 rounded-full" style={{ backgroundColor: item.color }} />
+            {item.label}
+          </div>
+        ))}
+      </div>
+      <div className="mt-8 flex justify-between gap-8">
+        {labels.slice(0, 4).map((item) => (
+          <div key={item.label} className="text-caption-caption6 text-foreground-tertiary">
+            {item.label.slice(5)}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export const HorizontalBarChart = ({
+  items,
+  maxItems = 10,
+}: {
+  items: CountItem[];
+  maxItems?: number;
+}) => {
+  const slicedItems = items.slice(0, maxItems);
+  if (slicedItems.length === 0) return <EmptyState />;
+
+  const max = Math.max(...slicedItems.map((item) => item.count), 1);
+
+  return (
+    <div className="flex flex-col gap-9">
+      {slicedItems.map((item) => (
+        <div key={item.label} className="grid grid-cols-[minmax(0,1fr)_3rem] items-center gap-8">
+          <div className="min-w-0">
+            <div className="text-caption-caption6 text-foreground-tertiary mb-5 truncate">
+              {item.label}
+            </div>
+            <div className="bg-background-quaternary rounded-max h-8 overflow-hidden">
+              <div
+                className="bg-foreground-normal rounded-max h-full"
+                style={{ width: `${Math.max((item.count / max) * 100, 2)}%` }}
+              />
+            </div>
+          </div>
+          <div className="text-body-body9 text-foreground-normal text-right">
+            {formatNumber(item.count)}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export const VerticalBarChart = ({ items }: { items: CountItem[] }) => {
+  if (items.length === 0) return <EmptyState />;
+
+  const max = Math.max(...items.map((item) => item.count), 1);
+
+  return (
+    <div className="border-border-normal rounded-6 border p-12">
+      <div className="h-156 flex items-end gap-8">
+        {items.map((item) => (
+          <div key={item.label} className="flex min-w-0 flex-1 flex-col items-center gap-6">
+            <div className="text-caption-caption6 text-foreground-tertiary">
+              {formatNumber(item.count)}
+            </div>
+            <div
+              className="bg-foreground-normal rounded-t-3 w-full"
+              style={{ height: `${Math.max((item.count / max) * 112, 4)}px` }}
+            />
+            <div className="text-caption-caption6 text-foreground-tertiary w-full truncate text-center">
+              {item.label}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export const DonutChart = ({ percent }: { percent: number | null }) => {
+  if (percent === null) return <EmptyState>Open Rate 데이터 없음</EmptyState>;
+
+  const radius = 46;
+  const circumference = 2 * Math.PI * radius;
+  const dash = (percent / 100) * circumference;
+
+  return (
+    <div className="border-border-normal rounded-6 p-18 flex items-center justify-center border">
+      <svg viewBox="0 0 120 120" className="h-140 w-140" role="img">
+        <circle
+          cx="60"
+          cy="60"
+          r={radius}
+          fill="none"
+          className="stroke-background-quaternary"
+          strokeWidth="14"
+        />
+        <circle
+          cx="60"
+          cy="60"
+          r={radius}
+          fill="none"
+          className="stroke-foreground-normal"
+          strokeDasharray={`${dash} ${circumference - dash}`}
+          strokeLinecap="round"
+          strokeWidth="14"
+          transform="rotate(-90 60 60)"
+        />
+        <text x="60" y="65" textAnchor="middle" className="fill-foreground-normal text-body-body8">
+          {formatPercent(percent)}
+        </text>
+      </svg>
+    </div>
+  );
+};

--- a/packages/ui/components/charts/Charts.tsx
+++ b/packages/ui/components/charts/Charts.tsx
@@ -1,4 +1,6 @@
-import type { ReactNode } from 'react';
+'use client';
+
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 
 export type CountItem = {
   label: string;
@@ -11,6 +13,26 @@ export type LineSeries = {
   points: CountItem[];
 };
 
+type TooltipRow = {
+  label?: string;
+  color?: string;
+  value: number;
+};
+
+type Plot = {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+  innerWidth: number;
+  innerHeight: number;
+};
+
+const CHART_HEIGHT = 132;
+const DEFAULT_WIDTH = 320;
+const TICK_COUNT = 4;
+const PADDING = { top: 10, right: 12, bottom: 22, left: 40 };
+
 const formatNumber = (value?: number | null) => {
   if (value === undefined || value === null || Number.isNaN(value)) return '-';
   return value.toLocaleString('ko-KR');
@@ -21,127 +43,299 @@ const formatPercent = (value?: number | null) => {
   return `${value.toFixed(1)}%`;
 };
 
+const formatAxisNumber = (value: number) => {
+  if (value === 0) return '0';
+  if (Math.abs(value) >= 1_000_000) return `${Number((value / 1_000_000).toFixed(1))}M`;
+  if (Math.abs(value) >= 1_000) return `${Number((value / 1_000).toFixed(1))}k`;
+  return `${Number(value.toFixed(1))}`;
+};
+
 const formatShortLabel = (label: string) => {
   if (/^\d{4}[-/.]\d{2}[-/.]\d{2}/.test(label)) return label.slice(5);
   return label;
 };
 
-const buildLinePath = (
-  points: CountItem[],
-  width: number,
-  height: number,
-  padding: number,
-  max: number,
-) => {
+const truncateLabel = (label: string, maxChars: number) => {
+  if (maxChars <= 1 || label.length <= maxChars) return label;
+  return `${label.slice(0, Math.max(maxChars - 1, 1))}…`;
+};
+
+const buildScale = (rawMax: number, tickCount = TICK_COUNT) => {
+  const safeMax = Math.max(rawMax, 1);
+  const rawStep = safeMax / tickCount;
+  const exponent = Math.floor(Math.log10(rawStep));
+  const base = 10 ** exponent;
+  const fraction = rawStep / base;
+  const niceFraction = fraction <= 1 ? 1 : fraction <= 2 ? 2 : fraction <= 5 ? 5 : 10;
+
+  let step = niceFraction * base;
+  if (Number.isInteger(safeMax) && step < 1) step = 1;
+
+  const max = step * tickCount;
+  const ticks = Array.from({ length: tickCount + 1 }, (_, index) => step * index);
+
+  return { max, ticks };
+};
+
+const getPlot = (width: number): Plot => {
+  const innerWidth = Math.max(width - PADDING.left - PADDING.right, 1);
+
+  return {
+    left: PADDING.left,
+    right: PADDING.left + innerWidth,
+    top: PADDING.top,
+    bottom: CHART_HEIGHT - PADDING.bottom,
+    innerWidth,
+    innerHeight: CHART_HEIGHT - PADDING.top - PADDING.bottom,
+  };
+};
+
+const getPointX = (index: number, length: number, plot: Plot) => {
+  if (length <= 1) return plot.left + plot.innerWidth / 2;
+  return plot.left + (index / (length - 1)) * plot.innerWidth;
+};
+
+const getPointY = (value: number, max: number, plot: Plot) => {
+  return plot.bottom - (value / max) * plot.innerHeight;
+};
+
+const getHoverBand = (index: number, length: number, plot: Plot) => {
+  if (length <= 1) return { x: plot.left, width: plot.innerWidth };
+
+  const step = plot.innerWidth / (length - 1);
+  const start = index === 0 ? plot.left : plot.left + (index - 0.5) * step;
+  const end = index === length - 1 ? plot.right : plot.left + (index + 0.5) * step;
+
+  return { x: start, width: Math.max(end - start, 1) };
+};
+
+const buildLinePath = (points: CountItem[], max: number, plot: Plot) => {
   return points
     .map((item, index) => {
-      const x =
-        points.length <= 1
-          ? width / 2
-          : padding + (index / (points.length - 1)) * (width - padding * 2);
-      const y = height - padding - (item.count / max) * (height - padding * 2);
+      const x = getPointX(index, points.length, plot);
+      const y = getPointY(item.count, max, plot);
 
       return `${index === 0 ? 'M' : 'L'} ${x} ${y}`;
     })
     .join(' ');
 };
 
-const buildLineAreaPath = (
-  points: CountItem[],
-  width: number,
-  height: number,
-  padding: number,
-  max: number,
-) => {
+const buildLineAreaPath = (points: CountItem[], max: number, plot: Plot) => {
   if (points.length === 0) return '';
 
-  const linePath = buildLinePath(points, width, height, padding, max);
-  const firstX = points.length <= 1 ? width / 2 : padding;
-  const lastX = points.length <= 1 ? width / 2 : width - padding;
-  const baseY = height - padding;
+  const linePath = buildLinePath(points, max, plot);
+  const firstX = getPointX(0, points.length, plot);
+  const lastX = getPointX(points.length - 1, points.length, plot);
 
-  return `${linePath} L ${lastX} ${baseY} L ${firstX} ${baseY} Z`;
+  return `${linePath} L ${lastX} ${plot.bottom} L ${firstX} ${plot.bottom} Z`;
 };
 
-const getLinePointPosition = (
-  point: CountItem,
-  index: number,
-  pointsLength: number,
-  width: number,
-  height: number,
-  padding: number,
-  max: number,
-) => {
-  const x =
-    pointsLength <= 1 ? width / 2 : padding + (index / (pointsLength - 1)) * (width - padding * 2);
-  const y = height - padding - (point.count / max) * (height - padding * 2);
+const useChartWidth = () => {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [width, setWidth] = useState(DEFAULT_WIDTH);
 
-  return { x, y };
+  useEffect(() => {
+    const element = ref.current;
+    if (!element || typeof ResizeObserver === 'undefined') return;
+
+    const observer = new ResizeObserver((entries) => {
+      const nextWidth = entries[0]?.contentRect.width;
+      if (nextWidth && nextWidth > 0) setWidth(nextWidth);
+    });
+
+    observer.observe(element);
+
+    return () => observer.disconnect();
+  }, []);
+
+  return { ref, width };
 };
 
-const LinePointTooltip = ({
-  label,
-  value,
+const ChartGrid = ({ ticks, max, plot }: { ticks: number[]; max: number; plot: Plot }) => {
+  return (
+    <g aria-hidden="true">
+      {ticks.map((tick) => {
+        const y = getPointY(tick, max, plot);
+        const isBaseline = tick === 0;
+
+        return (
+          <g key={tick}>
+            <line
+              x1={plot.left}
+              y1={y}
+              x2={plot.right}
+              y2={y}
+              className="stroke-border-normal"
+              strokeWidth="1"
+              strokeDasharray={isBaseline ? undefined : '3 3'}
+              opacity={isBaseline ? 1 : 0.6}
+            />
+            <text
+              x={plot.left - 6}
+              y={y + 3}
+              textAnchor="end"
+              className="fill-foreground-tertiary text-caption-caption6"
+            >
+              {formatAxisNumber(tick)}
+            </text>
+          </g>
+        );
+      })}
+    </g>
+  );
+};
+
+const XAxisLabels = ({ labels, plot }: { labels: string[]; plot: Plot }) => {
+  if (labels.length === 0) return null;
+
+  const maxLabels = Math.max(2, Math.min(5, Math.floor(plot.innerWidth / 58)));
+  const indices =
+    labels.length <= maxLabels
+      ? labels.map((_, index) => index)
+      : Array.from({ length: maxLabels }, (_, index) =>
+          Math.round((index / (maxLabels - 1)) * (labels.length - 1)),
+        );
+
+  return (
+    <g aria-hidden="true">
+      {Array.from(new Set(indices)).map((index) => {
+        const x = getPointX(index, labels.length, plot);
+        const anchor =
+          labels.length === 1
+            ? 'middle'
+            : index === 0
+              ? 'start'
+              : index === labels.length - 1
+                ? 'end'
+                : 'middle';
+
+        return (
+          <text
+            key={index}
+            x={x}
+            y={CHART_HEIGHT - 6}
+            textAnchor={anchor}
+            className="fill-foreground-tertiary text-caption-caption6"
+          >
+            {formatShortLabel(labels[index])}
+          </text>
+        );
+      })}
+    </g>
+  );
+};
+
+const HoverBands = ({
+  length,
+  plot,
+  onHover,
+  getBand = getHoverBand,
+}: {
+  length: number;
+  plot: Plot;
+  onHover: (index: number | null) => void;
+  getBand?: (index: number, length: number, plot: Plot) => { x: number; width: number };
+}) => {
+  return (
+    <g onMouseLeave={() => onHover(null)}>
+      {Array.from({ length }, (_, index) => {
+        const band = getBand(index, length, plot);
+
+        return (
+          <rect
+            key={index}
+            x={band.x}
+            y={plot.top}
+            width={band.width}
+            height={plot.innerHeight}
+            fill="transparent"
+            className="cursor-pointer"
+            onMouseEnter={() => onHover(index)}
+          />
+        );
+      })}
+    </g>
+  );
+};
+
+const ChartTooltip = ({
   x,
   y,
-  color = 'var(--color-foreground-normal)',
+  title,
+  rows,
+  width,
+  showGuide = true,
+  plot,
 }: {
-  label: string;
-  value: number;
   x: number;
   y: number;
-  color?: string;
+  title: string;
+  rows: TooltipRow[];
+  width: number;
+  showGuide?: boolean;
+  plot: Plot;
 }) => {
-  const tooltipWidth = 140;
-  const tooltipHeight = 42;
-  const tooltipX = Math.min(Math.max(x - tooltipWidth / 2, 4), 320 - tooltipWidth - 4);
+  const rowHeight = 14;
+  const tooltipWidth = 148;
+  const tooltipHeight = 22 + rows.length * rowHeight;
+  const maxX = Math.max(width - tooltipWidth - 4, 4);
+  const tooltipX = Math.min(Math.max(x - tooltipWidth / 2, 4), maxX);
   const tooltipY = Math.max(y - tooltipHeight - 10, 4);
 
   return (
-    <g className="group">
-      <circle
-        cx={x}
-        cy={y}
-        r="3"
-        className="fill-background-normal"
-        stroke={color}
-        strokeWidth="2"
-      />
-      <circle cx={x} cy={y} r="12" fill="transparent" className="cursor-pointer" />
-      <circle
-        cx={x}
-        cy={y}
-        r="6"
-        fill="transparent"
-        stroke={color}
-        className="opacity-0 transition-opacity group-hover:opacity-25"
-        strokeWidth="3"
-      />
-      <g className="pointer-events-none opacity-0 transition-opacity group-hover:opacity-100">
-        <rect
-          x={tooltipX}
-          y={tooltipY}
-          width={tooltipWidth}
-          height={tooltipHeight}
-          rx="6"
-          className="fill-background-normal stroke-border-normal"
-          style={{ filter: 'drop-shadow(0 2px 6px rgba(0, 0, 0, 0.12))' }}
+    <g className="pointer-events-none">
+      {showGuide ? (
+        <line
+          x1={x}
+          y1={plot.top}
+          x2={x}
+          y2={plot.bottom}
+          className="stroke-border-normal"
+          strokeWidth="1"
         />
-        <text
-          x={tooltipX + 10}
-          y={tooltipY + 16}
-          className="fill-foreground-tertiary text-caption-caption6"
-        >
-          {formatShortLabel(label)}
-        </text>
-        <text
-          x={tooltipX + 10}
-          y={tooltipY + 32}
-          className="fill-foreground-normal text-caption-caption6"
-        >
-          {formatNumber(value)}
-        </text>
-      </g>
+      ) : null}
+      <rect
+        x={tooltipX}
+        y={tooltipY}
+        width={tooltipWidth}
+        height={tooltipHeight}
+        rx="6"
+        className="fill-background-normal stroke-border-normal"
+        style={{ filter: 'drop-shadow(0 2px 6px rgba(0, 0, 0, 0.12))' }}
+      />
+      <text
+        x={tooltipX + 10}
+        y={tooltipY + 15}
+        className="fill-foreground-tertiary text-caption-caption6"
+      >
+        {title}
+      </text>
+      {rows.map((row, index) => {
+        const rowY = tooltipY + 15 + rowHeight * (index + 1);
+
+        return (
+          <g key={`${row.label ?? 'value'}-${index}`}>
+            {row.color ? <circle cx={tooltipX + 13} cy={rowY - 3} r="3" fill={row.color} /> : null}
+            {row.label ? (
+              <text
+                x={tooltipX + (row.color ? 21 : 10)}
+                y={rowY}
+                className="fill-foreground-tertiary text-caption-caption6"
+              >
+                {row.label}
+              </text>
+            ) : null}
+            <text
+              x={tooltipX + tooltipWidth - 10}
+              y={rowY}
+              textAnchor="end"
+              className="fill-foreground-normal text-caption-caption6"
+            >
+              {formatNumber(row.value)}
+            </text>
+          </g>
+        );
+      })}
     </g>
   );
 };
@@ -155,103 +349,116 @@ export const EmptyState = ({ children = '데이터 없음' }: { children?: React
 };
 
 export const SingleLineChart = ({ items }: { items: CountItem[] }) => {
+  const { ref, width } = useChartWidth();
+  const [hoverIndex, setHoverIndex] = useState<number | null>(null);
+
+  const plot = getPlot(width);
+  const { max, ticks } = buildScale(Math.max(...items.map((item) => item.count), 0));
+  const activeIndex = hoverIndex !== null && hoverIndex < items.length ? hoverIndex : null;
+  const activeItem = activeIndex !== null ? items[activeIndex] : null;
+
   if (items.length === 0) return <EmptyState />;
 
-  const width = 320;
-  const height = 156;
-  const padding = 18;
-  const max = Math.max(...items.map((item) => item.count), 1);
-  const path = buildLinePath(items, width, height, padding, max);
-
   return (
-    <div className="border-border-normal rounded-6 border p-12">
-      <svg viewBox={`0 0 ${width} ${height}`} className="h-156 w-full" role="img">
-        <line
-          x1={padding}
-          y1={height - padding}
-          x2={width - padding}
-          y2={height - padding}
-          className="stroke-border-normal"
-        />
-        <line
-          x1={padding}
-          y1={padding}
-          x2={padding}
-          y2={height - padding}
-          className="stroke-border-normal"
-        />
+    <div ref={ref} className="border-border-normal rounded-6 border p-12">
+      <svg
+        viewBox={`0 0 ${width} ${CHART_HEIGHT}`}
+        width={width}
+        height={CHART_HEIGHT}
+        className="block w-full"
+        role="img"
+      >
+        <ChartGrid ticks={ticks} max={max} plot={plot} />
         <path
-          d={buildLineAreaPath(items, width, height, padding, max)}
+          d={buildLineAreaPath(items, max, plot)}
           className="fill-foreground-normal opacity-[0.08]"
         />
-        <path d={path} fill="none" className="stroke-foreground-normal" strokeWidth="2" />
-        {items.map((item, index) => {
-          const { x, y } = getLinePointPosition(
-            item,
-            index,
-            items.length,
-            width,
-            height,
-            padding,
-            max,
-          );
-
-          return (
-            <LinePointTooltip
-              key={`${item.label}-${index}`}
-              label={item.label}
-              value={item.count}
-              x={x}
-              y={y}
-            />
-          );
-        })}
-      </svg>
-      <div className="mt-8 flex justify-between gap-8">
-        {items.slice(0, 4).map((item) => (
-          <div key={item.label} className="text-caption-caption6 text-foreground-tertiary">
-            {item.label.slice(5)}
-          </div>
+        <path
+          d={buildLinePath(items, max, plot)}
+          fill="none"
+          className="stroke-foreground-normal"
+          strokeWidth="2"
+        />
+        {items.map((item, index) => (
+          <circle
+            key={`${item.label}-${index}`}
+            cx={getPointX(index, items.length, plot)}
+            cy={getPointY(item.count, max, plot)}
+            r="2.5"
+            className="fill-foreground-normal"
+          />
         ))}
-      </div>
+        <XAxisLabels labels={items.map((item) => item.label)} plot={plot} />
+        <HoverBands length={items.length} plot={plot} onHover={setHoverIndex} />
+        {activeItem && activeIndex !== null ? (
+          <>
+            <circle
+              cx={getPointX(activeIndex, items.length, plot)}
+              cy={getPointY(activeItem.count, max, plot)}
+              r="5"
+              fill="transparent"
+              className="stroke-foreground-normal pointer-events-none opacity-30"
+              strokeWidth="3"
+            />
+            <ChartTooltip
+              x={getPointX(activeIndex, items.length, plot)}
+              y={getPointY(activeItem.count, max, plot)}
+              title={formatShortLabel(activeItem.label)}
+              rows={[{ value: activeItem.count }]}
+              width={width}
+              plot={plot}
+            />
+          </>
+        ) : null}
+      </svg>
     </div>
   );
 };
 
 export const MultiLineChart = ({ series }: { series: LineSeries[] }) => {
+  const { ref, width } = useChartWidth();
+  const [hoverIndex, setHoverIndex] = useState<number | null>(null);
+
   const visibleSeries = series.filter((item) => item.points.length > 0);
+  const plot = getPlot(width);
+  const { max, ticks } = buildScale(
+    Math.max(...visibleSeries.flatMap((item) => item.points.map((point) => point.count)), 0),
+  );
+  const labelSource = visibleSeries.reduce<CountItem[]>(
+    (longest, item) => (item.points.length > longest.length ? item.points : longest),
+    [],
+  );
+  const activeIndex = hoverIndex !== null && hoverIndex < labelSource.length ? hoverIndex : null;
+  const activeRows =
+    activeIndex === null
+      ? []
+      : visibleSeries
+          .map((item) => ({
+            label: item.label,
+            color: item.color,
+            value: item.points[activeIndex]?.count,
+          }))
+          .filter(
+            (row): row is { label: string; color: string; value: number } =>
+              row.value !== undefined,
+          );
+
   if (visibleSeries.length === 0) return <EmptyState />;
 
-  const width = 320;
-  const height = 168;
-  const padding = 18;
-  const max = Math.max(
-    ...visibleSeries.flatMap((item) => item.points.map((point) => point.count)),
-    1,
-  );
-  const labels = visibleSeries[0]?.points ?? [];
-
   return (
-    <div className="border-border-normal rounded-6 border p-12">
-      <svg viewBox={`0 0 ${width} ${height}`} className="h-168 w-full" role="img">
-        <line
-          x1={padding}
-          y1={height - padding}
-          x2={width - padding}
-          y2={height - padding}
-          className="stroke-border-normal"
-        />
-        <line
-          x1={padding}
-          y1={padding}
-          x2={padding}
-          y2={height - padding}
-          className="stroke-border-normal"
-        />
+    <div ref={ref} className="border-border-normal rounded-6 border p-12">
+      <svg
+        viewBox={`0 0 ${width} ${CHART_HEIGHT}`}
+        width={width}
+        height={CHART_HEIGHT}
+        className="block w-full"
+        role="img"
+      >
+        <ChartGrid ticks={ticks} max={max} plot={plot} />
         {visibleSeries.map((item) => (
           <path
             key={`${item.label}-area`}
-            d={buildLineAreaPath(item.points, width, height, padding, max)}
+            d={buildLineAreaPath(item.points, max, plot)}
             fill={item.color}
             opacity="0.08"
           />
@@ -259,36 +466,41 @@ export const MultiLineChart = ({ series }: { series: LineSeries[] }) => {
         {visibleSeries.map((item) => (
           <path
             key={`${item.label}-line`}
-            d={buildLinePath(item.points, width, height, padding, max)}
+            d={buildLinePath(item.points, max, plot)}
             fill="none"
             stroke={item.color}
             strokeWidth="2"
           />
         ))}
-        {visibleSeries.map((item) =>
-          item.points.map((point, index) => {
-            const { x, y } = getLinePointPosition(
-              point,
-              index,
-              item.points.length,
-              width,
-              height,
-              padding,
-              max,
-            );
+        <XAxisLabels labels={labelSource.map((item) => item.label)} plot={plot} />
+        <HoverBands length={labelSource.length} plot={plot} onHover={setHoverIndex} />
+        {activeIndex !== null && activeRows.length > 0 ? (
+          <>
+            {visibleSeries.map((item) => {
+              const point = item.points[activeIndex];
+              if (!point) return null;
 
-            return (
-              <LinePointTooltip
-                key={`${item.label}-${point.label}-${index}`}
-                label={`${item.label} · ${formatShortLabel(point.label)}`}
-                value={point.count}
-                x={x}
-                y={y}
-                color={item.color}
-              />
-            );
-          }),
-        )}
+              return (
+                <circle
+                  key={`${item.label}-active`}
+                  cx={getPointX(activeIndex, item.points.length, plot)}
+                  cy={getPointY(point.count, max, plot)}
+                  r="3.5"
+                  className="pointer-events-none"
+                  fill={item.color}
+                />
+              );
+            })}
+            <ChartTooltip
+              x={getPointX(activeIndex, labelSource.length, plot)}
+              y={plot.top}
+              title={formatShortLabel(labelSource[activeIndex]?.label ?? '')}
+              rows={activeRows}
+              width={width}
+              plot={plot}
+            />
+          </>
+        ) : null}
       </svg>
       <div className="mt-8 flex flex-wrap gap-x-10 gap-y-4">
         {visibleSeries.map((item) => (
@@ -298,13 +510,6 @@ export const MultiLineChart = ({ series }: { series: LineSeries[] }) => {
           >
             <span className="h-6 w-6 rounded-full" style={{ backgroundColor: item.color }} />
             {item.label}
-          </div>
-        ))}
-      </div>
-      <div className="mt-8 flex justify-between gap-8">
-        {labels.slice(0, 4).map((item) => (
-          <div key={item.label} className="text-caption-caption6 text-foreground-tertiary">
-            {item.label.slice(5)}
           </div>
         ))}
       </div>
@@ -353,32 +558,79 @@ export const HorizontalBarChart = ({
 };
 
 export const VerticalBarChart = ({ items }: { items: CountItem[] }) => {
+  const { ref, width } = useChartWidth();
+  const [hoverIndex, setHoverIndex] = useState<number | null>(null);
+
+  const plot = getPlot(width);
+  const { max, ticks } = buildScale(Math.max(...items.map((item) => item.count), 0));
+  const slotWidth = plot.innerWidth / Math.max(items.length, 1);
+  const barWidth = Math.min(Math.max(slotWidth - 14, 6), 44);
+  const maxLabelChars = Math.max(Math.floor(slotWidth / 6), 2);
+  const activeIndex = hoverIndex !== null && hoverIndex < items.length ? hoverIndex : null;
+  const activeItem = activeIndex !== null ? items[activeIndex] : null;
+
+  const getBarBand = (index: number) => ({
+    x: plot.left + slotWidth * index,
+    width: slotWidth,
+  });
+
   if (items.length === 0) return <EmptyState />;
 
-  const max = Math.max(...items.map((item) => item.count), 1);
-
   return (
-    <div className="border-border-normal rounded-6 border p-12">
-      <div className="h-156 flex items-end gap-8">
-        {items.map((item) => (
-          <div
-            key={item.label}
-            className="flex min-w-0 flex-1 flex-col items-center gap-6"
-            title={`${item.label}: ${formatNumber(item.count)}`}
-          >
-            <div className="text-caption-caption6 text-foreground-tertiary">
-              {formatNumber(item.count)}
-            </div>
-            <div
-              className="bg-foreground-normal rounded-t-3 w-full"
-              style={{ height: `${Math.max((item.count / max) * 112, 4)}px` }}
-            />
-            <div className="text-caption-caption6 text-foreground-tertiary w-full truncate text-center">
-              {item.label}
-            </div>
-          </div>
-        ))}
-      </div>
+    <div ref={ref} className="border-border-normal rounded-6 border p-12">
+      <svg
+        viewBox={`0 0 ${width} ${CHART_HEIGHT}`}
+        width={width}
+        height={CHART_HEIGHT}
+        className="block w-full"
+        role="img"
+      >
+        <ChartGrid ticks={ticks} max={max} plot={plot} />
+        {items.map((item, index) => {
+          const band = getBarBand(index);
+          const centerX = band.x + slotWidth / 2;
+          const y = getPointY(item.count, max, plot);
+
+          return (
+            <g key={`${item.label}-${index}`}>
+              <rect
+                x={centerX - barWidth / 2}
+                y={y}
+                width={barWidth}
+                height={Math.max(plot.bottom - y, 2)}
+                rx="3"
+                className="fill-foreground-normal"
+                opacity={activeIndex === null || activeIndex === index ? 1 : 0.45}
+              />
+              <text
+                x={centerX}
+                y={CHART_HEIGHT - 6}
+                textAnchor="middle"
+                className="fill-foreground-tertiary text-caption-caption6"
+              >
+                {truncateLabel(item.label, maxLabelChars)}
+              </text>
+            </g>
+          );
+        })}
+        <HoverBands
+          length={items.length}
+          plot={plot}
+          onHover={setHoverIndex}
+          getBand={(index) => getBarBand(index)}
+        />
+        {activeItem && activeIndex !== null ? (
+          <ChartTooltip
+            x={plot.left + slotWidth * activeIndex + slotWidth / 2}
+            y={getPointY(activeItem.count, max, plot)}
+            title={activeItem.label}
+            rows={[{ value: activeItem.count }]}
+            width={width}
+            showGuide={false}
+            plot={plot}
+          />
+        ) : null}
+      </svg>
     </div>
   );
 };
@@ -392,10 +644,10 @@ export const DonutChart = ({ percent }: { percent: number | null }) => {
 
   return (
     <div
-      className="border-border-normal rounded-6 p-18 flex items-center justify-center border"
+      className="border-border-normal rounded-6 flex items-center justify-center border p-16"
       title={`Open Rate: ${formatPercent(percent)}`}
     >
-      <svg viewBox="0 0 120 120" className="h-140 w-140" role="img">
+      <svg viewBox="0 0 120 120" className="h-[140px] w-[140px]" role="img">
         <circle
           cx="60"
           cy="60"

--- a/packages/ui/components/charts/Charts.tsx
+++ b/packages/ui/components/charts/Charts.tsx
@@ -21,6 +21,11 @@ const formatPercent = (value?: number | null) => {
   return `${value.toFixed(1)}%`;
 };
 
+const formatShortLabel = (label: string) => {
+  if (/^\d{4}[-/.]\d{2}[-/.]\d{2}/.test(label)) return label.slice(5);
+  return label;
+};
+
 const buildLinePath = (
   points: CountItem[],
   width: number,
@@ -39,6 +44,106 @@ const buildLinePath = (
       return `${index === 0 ? 'M' : 'L'} ${x} ${y}`;
     })
     .join(' ');
+};
+
+const buildLineAreaPath = (
+  points: CountItem[],
+  width: number,
+  height: number,
+  padding: number,
+  max: number,
+) => {
+  if (points.length === 0) return '';
+
+  const linePath = buildLinePath(points, width, height, padding, max);
+  const firstX = points.length <= 1 ? width / 2 : padding;
+  const lastX = points.length <= 1 ? width / 2 : width - padding;
+  const baseY = height - padding;
+
+  return `${linePath} L ${lastX} ${baseY} L ${firstX} ${baseY} Z`;
+};
+
+const getLinePointPosition = (
+  point: CountItem,
+  index: number,
+  pointsLength: number,
+  width: number,
+  height: number,
+  padding: number,
+  max: number,
+) => {
+  const x =
+    pointsLength <= 1 ? width / 2 : padding + (index / (pointsLength - 1)) * (width - padding * 2);
+  const y = height - padding - (point.count / max) * (height - padding * 2);
+
+  return { x, y };
+};
+
+const LinePointTooltip = ({
+  label,
+  value,
+  x,
+  y,
+  color = 'var(--color-foreground-normal)',
+}: {
+  label: string;
+  value: number;
+  x: number;
+  y: number;
+  color?: string;
+}) => {
+  const tooltipWidth = 140;
+  const tooltipHeight = 42;
+  const tooltipX = Math.min(Math.max(x - tooltipWidth / 2, 4), 320 - tooltipWidth - 4);
+  const tooltipY = Math.max(y - tooltipHeight - 10, 4);
+
+  return (
+    <g className="group">
+      <circle
+        cx={x}
+        cy={y}
+        r="3"
+        className="fill-background-normal"
+        stroke={color}
+        strokeWidth="2"
+      />
+      <circle cx={x} cy={y} r="12" fill="transparent" className="cursor-pointer" />
+      <circle
+        cx={x}
+        cy={y}
+        r="6"
+        fill="transparent"
+        stroke={color}
+        className="opacity-0 transition-opacity group-hover:opacity-25"
+        strokeWidth="3"
+      />
+      <g className="pointer-events-none opacity-0 transition-opacity group-hover:opacity-100">
+        <rect
+          x={tooltipX}
+          y={tooltipY}
+          width={tooltipWidth}
+          height={tooltipHeight}
+          rx="6"
+          className="fill-background-normal stroke-border-normal"
+          style={{ filter: 'drop-shadow(0 2px 6px rgba(0, 0, 0, 0.12))' }}
+        />
+        <text
+          x={tooltipX + 10}
+          y={tooltipY + 16}
+          className="fill-foreground-tertiary text-caption-caption6"
+        >
+          {formatShortLabel(label)}
+        </text>
+        <text
+          x={tooltipX + 10}
+          y={tooltipY + 32}
+          className="fill-foreground-normal text-caption-caption6"
+        >
+          {formatNumber(value)}
+        </text>
+      </g>
+    </g>
+  );
 };
 
 export const EmptyState = ({ children = '데이터 없음' }: { children?: ReactNode }) => {
@@ -75,7 +180,32 @@ export const SingleLineChart = ({ items }: { items: CountItem[] }) => {
           y2={height - padding}
           className="stroke-border-normal"
         />
+        <path
+          d={buildLineAreaPath(items, width, height, padding, max)}
+          className="fill-foreground-normal opacity-[0.08]"
+        />
         <path d={path} fill="none" className="stroke-foreground-normal" strokeWidth="2" />
+        {items.map((item, index) => {
+          const { x, y } = getLinePointPosition(
+            item,
+            index,
+            items.length,
+            width,
+            height,
+            padding,
+            max,
+          );
+
+          return (
+            <LinePointTooltip
+              key={`${item.label}-${index}`}
+              label={item.label}
+              value={item.count}
+              x={x}
+              y={y}
+            />
+          );
+        })}
       </svg>
       <div className="mt-8 flex justify-between gap-8">
         {items.slice(0, 4).map((item) => (
@@ -120,13 +250,45 @@ export const MultiLineChart = ({ series }: { series: LineSeries[] }) => {
         />
         {visibleSeries.map((item) => (
           <path
-            key={item.label}
+            key={`${item.label}-area`}
+            d={buildLineAreaPath(item.points, width, height, padding, max)}
+            fill={item.color}
+            opacity="0.08"
+          />
+        ))}
+        {visibleSeries.map((item) => (
+          <path
+            key={`${item.label}-line`}
             d={buildLinePath(item.points, width, height, padding, max)}
             fill="none"
             stroke={item.color}
             strokeWidth="2"
           />
         ))}
+        {visibleSeries.map((item) =>
+          item.points.map((point, index) => {
+            const { x, y } = getLinePointPosition(
+              point,
+              index,
+              item.points.length,
+              width,
+              height,
+              padding,
+              max,
+            );
+
+            return (
+              <LinePointTooltip
+                key={`${item.label}-${point.label}-${index}`}
+                label={`${item.label} · ${formatShortLabel(point.label)}`}
+                value={point.count}
+                x={x}
+                y={y}
+                color={item.color}
+              />
+            );
+          }),
+        )}
       </svg>
       <div className="mt-8 flex flex-wrap gap-x-10 gap-y-4">
         {visibleSeries.map((item) => (
@@ -165,7 +327,11 @@ export const HorizontalBarChart = ({
   return (
     <div className="flex flex-col gap-9">
       {slicedItems.map((item) => (
-        <div key={item.label} className="grid grid-cols-[minmax(0,1fr)_3rem] items-center gap-8">
+        <div
+          key={item.label}
+          className="grid grid-cols-[minmax(0,1fr)_3rem] items-center gap-8"
+          title={`${item.label}: ${formatNumber(item.count)}`}
+        >
           <div className="min-w-0">
             <div className="text-caption-caption6 text-foreground-tertiary mb-5 truncate">
               {item.label}
@@ -195,7 +361,11 @@ export const VerticalBarChart = ({ items }: { items: CountItem[] }) => {
     <div className="border-border-normal rounded-6 border p-12">
       <div className="h-156 flex items-end gap-8">
         {items.map((item) => (
-          <div key={item.label} className="flex min-w-0 flex-1 flex-col items-center gap-6">
+          <div
+            key={item.label}
+            className="flex min-w-0 flex-1 flex-col items-center gap-6"
+            title={`${item.label}: ${formatNumber(item.count)}`}
+          >
             <div className="text-caption-caption6 text-foreground-tertiary">
               {formatNumber(item.count)}
             </div>
@@ -221,7 +391,10 @@ export const DonutChart = ({ percent }: { percent: number | null }) => {
   const dash = (percent / 100) * circumference;
 
   return (
-    <div className="border-border-normal rounded-6 p-18 flex items-center justify-center border">
+    <div
+      className="border-border-normal rounded-6 p-18 flex items-center justify-center border"
+      title={`Open Rate: ${formatPercent(percent)}`}
+    >
       <svg viewBox="0 0 120 120" className="h-140 w-140" role="img">
         <circle
           cx="60"

--- a/packages/ui/components/charts/index.ts
+++ b/packages/ui/components/charts/index.ts
@@ -1,0 +1,1 @@
+export * from './Charts';


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 코드에 any가 사용되지 않았습니다
- [ ] 스토리북에 추가했습니다 (해당 시)
- [ ] 이슈와 커밋이 명확히 연결되어 있습니다


## 📌 작업 목적

- 어드민 대시보드 기능 구현

## 🔨 주요 작업 내용

- 관리자 대시보드 페이지를 신규 구현하고 `/dashboard` 라우트에 연결했습니다.
- 대시보드 조회 API 클라이언트, React Query 훅, 날짜 범위 프리셋 훅을 추가했습니다.
- 관리자 프록시 API를 통해 대시보드 서버 응답을 가져오도록 연동했습니다.
- 대시보드 API를 `/api/dashboard/v2`로 전환하고, v2 응답 스키마에 맞춰 타입을 확장했습니다.
- Traffic, KPI, Funnel, Churn, Content, Notice, Debug 탭을 구성했습니다.
- DAU/WAU/MAU, stickiness, daily KPI, funnel conversion, 이탈 유저, 페이지 상위 분포, 공지 open rate/sample rows, debug warnings 등을 시각화했습니다.
- 라인 차트, 멀티 라인 차트, 가로/세로 바 차트, 도넛 차트, 테이블, 빈 상태 UI를 추가했습니다.
- 대시보드 탭 스크롤 UI를 위해 전역 스타일 유틸을 추가했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 대시보드 분석 화면을 제공합니다.
  * 7일·30일·이번 달·사용자 지정 기간을 선택할 수 있습니다.
  * 트래픽, KPI, 퍼널, 이탈, 콘텐츠, 공지, 디버그 탭을 지원합니다.
  * 지표 카드, 반응형 차트, 분포 및 상세 테이블을 확인할 수 있습니다.
  * 키보드 탐색과 접근성 기능을 제공합니다.
  * 로딩, 오류, 재시도 및 데이터 없음 상태를 표시합니다.
  * 관리자 권한이 있는 사용자만 접근할 수 있습니다.

* **스타일**
  * 대시보드 탭 영역의 스크롤 경험을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->