### PR TITLE
[FIX(admin)] 모바일 하단 화면 잘림 현상 수정

### DIFF
--- a/apps/admin/src/app-pages/badge/BadgeCreatePage.tsx
+++ b/apps/admin/src/app-pages/badge/BadgeCreatePage.tsx
@@ -12,7 +12,7 @@ export const BadgeCreatePage = () => {
   const { state, actions } = useBadgeCreateForm();
 
   return (
-    <div className="border-border-normal bg-background-normal flex min-h-dvh flex-col border-t-[0.4px]">
+    <div className="border-border-normal bg-background-normal flex h-full min-h-0 flex-col border-t-[0.4px]">
       <div className="flex flex-1 flex-col gap-18 px-13 py-11">
         <FieldGroup title="배지 이미지 등록">
           <ImgUploader

--- a/apps/admin/src/app-pages/badge/BadgeCreatePage.tsx
+++ b/apps/admin/src/app-pages/badge/BadgeCreatePage.tsx
@@ -37,8 +37,10 @@ export const BadgeCreatePage = () => {
       </div>
 
       <div
-        className="bg-background-normal shadow-embossed-inverse sticky bottom-0 px-13 pt-13 pb-16"
-        style={{ paddingBottom: keyboardOffset + 16 }}
+        className="bg-background-normal shadow-embossed-inverse sticky bottom-0 px-13 pt-13"
+        style={{
+          paddingBottom: `calc(max(env(safe-area-inset-bottom), ${keyboardOffset}px) + 16px)`,
+        }}
       >
         <SolidButton
           size="l"

--- a/apps/admin/src/app-pages/group-management/ui/GroupManagementDetailPage.tsx
+++ b/apps/admin/src/app-pages/group-management/ui/GroupManagementDetailPage.tsx
@@ -67,7 +67,7 @@ export const GroupManagementDetailPage = ({ mode, id }: Props) => {
         )}
       </div>
 
-      <div className="px-13 py-16 pt-13">
+      <div className="px-13 pt-13 pb-[calc(env(safe-area-inset-bottom)+16px)]">
         {c.sticky && (
           <SolidButton
             size="l"

--- a/apps/admin/src/app-pages/group-management/ui/MemberSearchPage.tsx
+++ b/apps/admin/src/app-pages/group-management/ui/MemberSearchPage.tsx
@@ -65,7 +65,7 @@ export const MemberSearchPage = ({ generation, formKey }: MemberSearchPageProps)
         selectedIds={selectedIds}
         onToggle={toggleSelect}
       />
-      <div className="px-13 pt-13 pb-16">
+      <div className="px-13 pt-13 pb-[calc(env(safe-area-inset-bottom)+16px)]">
         <SolidButton
           size="l"
           variant="primary"

--- a/apps/admin/src/app-pages/login/ui/LoginPage.tsx
+++ b/apps/admin/src/app-pages/login/ui/LoginPage.tsx
@@ -3,7 +3,7 @@ import { LoginForm } from '@/features/auth/ui/LoginForm';
 
 export const LoginPage = () => {
   return (
-    <div className="flex h-dvh w-dvw flex-col px-16">
+    <div className="flex h-full min-h-0 w-full flex-col px-16">
       <div className="relative flex w-full grow flex-col items-center justify-center gap-[2.25rem]">
         <Logo width={224.61} height={115.8} role="img" aria-label="SURF 어드민 로고" />
         <LoginForm />

--- a/apps/admin/src/app-pages/score-management/ui/ScoreTargetSelectPage.tsx
+++ b/apps/admin/src/app-pages/score-management/ui/ScoreTargetSelectPage.tsx
@@ -125,7 +125,7 @@ export const ScoreTargetSelectPage = ({ criterionId }: ScoreTargetSelectPageProp
           )}
       </div>
 
-      <div className="px-13 pt-13 pb-16">
+      <div className="px-13 pt-13 pb-[calc(env(safe-area-inset-bottom)+16px)]">
         <SolidButton
           size="l"
           variant="primary"

--- a/apps/admin/src/app-pages/welcome-message/ui/WelcomeMessageManagePage.tsx
+++ b/apps/admin/src/app-pages/welcome-message/ui/WelcomeMessageManagePage.tsx
@@ -24,7 +24,7 @@ export const WelcomeMessageManagePage = () => {
   const { setMainMessage, setSubMessage, handleEdit, handleBack, handleSubmit } = actions;
 
   return (
-    <div className="flex h-dvh w-full flex-col">
+    <div className="flex h-full min-h-0 w-full flex-col">
       <AppHeader
         customBack={isEditMode ? handleBack : undefined}
         overrideHeader={

--- a/apps/admin/src/app-pages/welcome-message/ui/WelcomeMessageManagePage.tsx
+++ b/apps/admin/src/app-pages/welcome-message/ui/WelcomeMessageManagePage.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useKeyboardOffset } from '@surf/hooks';
 import { SolidButton } from '@surf/ui/button';
 import { FieldGroup } from '@surf/ui/field-group';
 import { HeaderMode } from '@surf/ui/header';
@@ -19,6 +20,7 @@ const SUB_MESSAGE_LIMIT = 10;
  * - `message` → 메인 메시지(최대 40자), `sender` → 서브 메시지(최대 10자)
  */
 export const WelcomeMessageManagePage = () => {
+  const keyboardOffset = useKeyboardOffset();
   const { state, actions } = useWelcomeMessageForm();
   const { isEditMode, mainMessage, subMessage, canSubmit, isPending } = state;
   const { setMainMessage, setSubMessage, handleEdit, handleBack, handleSubmit } = actions;
@@ -70,7 +72,12 @@ export const WelcomeMessageManagePage = () => {
       </div>
 
       {isEditMode && (
-        <div className={`bg-background-normal shadow-embossed-inverse bottom-0 px-13 pt-13 pb-16`}>
+        <div
+          className="bg-background-normal shadow-embossed-inverse bottom-0 px-13 pt-13"
+          style={{
+            paddingBottom: `calc(max(env(safe-area-inset-bottom), ${keyboardOffset}px) + 16px)`,
+          }}
+        >
           <SolidButton
             size="l"
             variant="primary"

--- a/apps/admin/src/app/layout.tsx
+++ b/apps/admin/src/app/layout.tsx
@@ -8,11 +8,11 @@ import { GlobalComponents } from '@/shared/ui/global-components/GlobalComponents
 const RootLayout = ({ children }: { children: ReactNode }) => {
   return (
     <html lang="ko" suppressHydrationWarning>
-      <body className="flex min-h-screen items-center justify-center bg-gray-200">
+      <body className="flex h-dvh min-h-dvh items-center justify-center bg-gray-200">
         <QueryProvider>
           <MockingProvider>
             <ThemeProvider attribute="data-theme" defaultTheme="system" enableSystem>
-              <main className="bg-background-normal box-content flex h-full w-dvw sm:h-[min(100dvh,calc(100dvw*812/375))] sm:w-[min(100dvw,calc(100dvh*375/812))]">
+              <main className="bg-background-normal box-content flex h-full min-h-0 w-dvw sm:h-[min(100dvh,calc(100dvw*812/375))] sm:w-[min(100dvw,calc(100dvh*375/812))]">
                 {children}
               </main>
             </ThemeProvider>

--- a/apps/admin/src/shared/ui/BottomActionBar.tsx
+++ b/apps/admin/src/shared/ui/BottomActionBar.tsx
@@ -23,10 +23,8 @@ export const BottomActionBar = ({ actions }: BottomActionBarProps) => {
 
   return (
     <div className="mx-auto flex w-full sm:w-[min(100dvw,calc(100dvh*375/812))]">
-      <div
-        className={'h-[4.5rem] w-full max-w-screen-sm pb-[calc(env(safe-area-inset-bottom)+12px)]'}
-      >
-        <div className="flex h-full w-full">
+      <div className="w-full max-w-screen-sm pb-[calc(env(safe-area-inset-bottom)+12px)]">
+        <div className="flex h-[4.5rem] w-full">
           {actions.map((a) => (
             <div key={a.key} className="flex-1">
               <SolidButton

--- a/apps/admin/src/widgets/badge/ui/BadgeEditBottomBar.tsx
+++ b/apps/admin/src/widgets/badge/ui/BadgeEditBottomBar.tsx
@@ -20,8 +20,10 @@ export const BadgeEditBottomBar = ({
   return (
     // 키보드가 올라와도 저장 버튼이 가려지지 않도록 하단 여백을 보정한다.
     <div
-      className="bg-background-normal shadow-embossed-inverse sticky bottom-0 px-13 pt-13 pb-16"
-      style={{ paddingBottom: keyboardOffset + 16 }}
+      className="bg-background-normal shadow-embossed-inverse sticky bottom-0 px-13 pt-13"
+      style={{
+        paddingBottom: `calc(max(env(safe-area-inset-bottom), ${keyboardOffset}px) + 16px)`,
+      }}
     >
       <SolidButton
         size="l"

--- a/apps/admin/src/widgets/banner/ui/BannerFormWidget.tsx
+++ b/apps/admin/src/widgets/banner/ui/BannerFormWidget.tsx
@@ -94,8 +94,10 @@ export const BannerFormWidget = ({
 
       {/* 하단 고정 버튼*/}
       <div
-        className="sticky bottom-0 p-13 shadow-[var(--effect-shadow-embossed-inverse-x-normal,0)_var(--effect-shadow-embossed-inverse-y-normal,0)_var(--effect-shadow-embossed-inverse-blur,2px)_var(--effect-shadow-raised-spread,0)_var(--effect-shadow-embossed-inverse-color-normal,rgba(0,0,0,0.02)),_var(--effect-shadow-embossed-inverse-x-normal,0)_var(--effect-shadow-embossed-inverse-y-secondary,-2px)_var(--effect-shadow-embossed-inverse-blur-secondary,4px)_var(--effect-shadow-embossed-inverse-spread,0)_var(--effect-shadow-embossed-inverse-color-secondary,rgba(0,0,0,0.04))]"
-        style={{ paddingBottom: keyboardOffset + 16 }}
+        className="sticky bottom-0 px-13 pt-13 shadow-[var(--effect-shadow-embossed-inverse-x-normal,0)_var(--effect-shadow-embossed-inverse-y-normal,0)_var(--effect-shadow-embossed-inverse-blur,2px)_var(--effect-shadow-raised-spread,0)_var(--effect-shadow-embossed-inverse-color-normal,rgba(0,0,0,0.02)),_var(--effect-shadow-embossed-inverse-x-normal,0)_var(--effect-shadow-embossed-inverse-y-secondary,-2px)_var(--effect-shadow-embossed-inverse-blur-secondary,4px)_var(--effect-shadow-embossed-inverse-spread,0)_var(--effect-shadow-embossed-inverse-color-secondary,rgba(0,0,0,0.04))]"
+        style={{
+          paddingBottom: `calc(max(env(safe-area-inset-bottom), ${keyboardOffset}px) + 16px)`,
+        }}
       >
         <SolidButton
           size="l"

--- a/apps/admin/src/widgets/banner/ui/BannerFormWidget.tsx
+++ b/apps/admin/src/widgets/banner/ui/BannerFormWidget.tsx
@@ -42,7 +42,7 @@ export const BannerFormWidget = ({
   );
 
   return (
-    <div className="border-border-normal flex min-h-screen flex-col border-t-[0.4px] pt-11">
+    <div className="border-border-normal flex min-h-0 flex-1 flex-col border-t-[0.4px] pt-11">
       <div className="flex flex-1 flex-col gap-[1.125rem] px-14 pb-40">
         {/* 수정 모드: 활성화 토글 */}
         {mode === 'edit' && (


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 any가 사용되지 않았습니다
- [ ] 스토리북에 추가했습니다 (해당 시)
- [x] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈

- close #641 

## 📌 작업 목적

- admin 프로젝트에서 모바일 화면 하단이 일부 잘리는 문제를 수정합니다.

## 🔨 주요 작업 내용

- root layout의 모바일 뷰포트 높이 계산을 `dvh` 기준으로 보정
- 페이지 내부 전체 높이 컨테이너를 부모 높이 기반 구조로 정리
- 하단 CTA/액션 영역에 safe-area 패딩 적용

## ⚠️ 기존 문제 (선택)

- 모바일 브라우저에서 `screen/vh` 계열 높이와 실제 visual viewport 높이가 달라 하단 영역이 일부 잘릴 수 있었습니다.
- root에서 화면 높이를 잡은 뒤 하위 페이지가 다시 `h-dvh`, `min-h-dvh`, `min-h-screen`을 사용해 높이가 중복 계산되는 구간이 있었습니다.
- 일부 하단 버튼 영역은 `env(safe-area-inset-bottom)`을 고려하지 않아 홈 인디케이터 영역과 겹칠 수 있었습니다.

## ☑️ 해결 방법 (선택)

- root `body`를 `h-dvh min-h-dvh`로 변경하고 `main`에 `min-h-0`을 추가했습니다.
- 하위 페이지의 전체 높이 컨테이너를 `h-full min-h-0`, `flex-1 min-h-0` 패턴으로 정리했습니다.
- 하단 액션 영역은 safe-area를 포함하도록 패딩을 보정하고, 키보드 대응이 필요한 영역은 `keyboardOffset`과 safe-area 중 큰 값을 사용하도록 수정했습니다.

## 🧪 테스트 방법

- `pnpm --filter surf-admin exec eslint ...`로 변경 파일 lint 확인
- 커밋 훅의 lint-staged 및 커밋 메시지 검사 통과
- 모바일 viewport에서 로그인, 배너 생성/수정, 배지 생성/수정, 웰컴 메시지 편집, 선택 모드 하단 액션 영역 확인 필요

## ✔️ 설치 라이브러리

- 없음

## 📷 실행 영상 또는 스크린샷

-

## 💬 논의할 점

- 실제 iOS Safari/Android Chrome 기기에서 하단 CTA가 홈 인디케이터와 겹치지 않는지 최종 확인이 필요합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 모바일 화면에서 키보드가 표시될 때 하단 고정 버튼과 입력 영역이 가려지지 않도록 개선했습니다.
  * 기기별 하단 안전 영역을 반영해 하단 여백을 동적으로 조정합니다.
  * 배지, 그룹 관리, 로그인, 점수 관리, 환영 메시지 및 배너 화면의 화면 높이와 하단 영역 표시를 개선했습니다.
  * 하단 액션 바의 높이와 정렬을 조정해 다양한 화면 크기에서 안정적으로 표시되도록 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->