### PR TITLE
[FIX(admin)] 배지 관리 복귀 라우팅 히스토리 대체 처리

### DIFF
--- a/apps/admin/src/app-pages/badge/BadgeDetailPage.tsx
+++ b/apps/admin/src/app-pages/badge/BadgeDetailPage.tsx
@@ -16,7 +16,7 @@ export const BadgeDetailPage = ({ badgeId }: BadgeDetailPageProps) => {
   return (
     <>
       <AppHeader
-        customBack={() => router.push(PAGE_ROUTES.BADGE_MNG.LIST)}
+        customBack={() => router.replace(PAGE_ROUTES.BADGE_MNG.LIST)}
         overrideHeader={{
           mode: HeaderMode.TextBtn,
           title: '활동 배지 관리',

--- a/apps/admin/src/app-pages/badge/BadgeEditPage.tsx
+++ b/apps/admin/src/app-pages/badge/BadgeEditPage.tsx
@@ -16,7 +16,7 @@ export const BadgeEditPage = ({ badgeId }: BadgeEditPageProps) => {
   return (
     <>
       <AppHeader
-        customBack={() => router.push(PAGE_ROUTES.BADGE_MNG.DETAIL(badgeId))}
+        customBack={() => router.replace(PAGE_ROUTES.BADGE_MNG.DETAIL(badgeId))}
         overrideHeader={{
           mode: HeaderMode.Default,
           title: '활동 배지 관리',

--- a/apps/admin/src/app-pages/badge/model/useBadgeAssignPage.ts
+++ b/apps/admin/src/app-pages/badge/model/useBadgeAssignPage.ts
@@ -34,7 +34,7 @@ export const useBadgeAssignPage = (badgeId: number) => {
 
   /** 배지 수정 화면으로 돌아간다. */
   const handleBack = () => {
-    router.push(PAGE_ROUTES.BADGE_MNG.EDIT(badgeId));
+    router.replace(PAGE_ROUTES.BADGE_MNG.EDIT(badgeId));
   };
 
   /** 선택된 멤버들에게 배지를 부여하고 수정 화면으로 이동한다. */


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 any가 사용되지 않았습니다
- [ ] 스토리북에 추가했습니다 (해당 시)
- [x] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈

- close #639 

## 📌 작업 목적

- 배지 관리 화면의 헤더 뒤로가기 동작이 이전 상세 화면으로 되돌아가는 문제를 해결합니다.

## 🔨 주요 작업 내용

- 배지 상세 화면에서 목록 복귀 시 `router.push` 대신 `router.replace`를 사용하도록 변경
- 배지 수정 화면에서 상세 복귀 시 `router.push` 대신 `router.replace`를 사용하도록 변경
- 배지 부여 화면에서 수정 화면 복귀 시 `router.push` 대신 `router.replace`를 사용하도록 변경

## ⚠️ 기존 문제 (선택)

- 배지 상세 화면에서 헤더 뒤로가기로 목록에 복귀할 때 `push`로 목록 페이지가 히스토리에 새로 쌓였습니다.
- 이후 배지 목록 화면의 헤더 뒤로가기를 누르면 admin 전체 메뉴가 아니라 직전 히스토리인 배지 상세 화면으로 이동했습니다.

## ☑️ 해결 방법 (선택)

- 배지 관리 플로우에서 “진입”이 아닌 “복귀” 성격의 라우팅을 `replace`로 변경했습니다.
- 상세/수정/부여 화면이 복귀 경로에 불필요하게 남지 않도록 히스토리 스택을 정리했습니다.

## 🧪 테스트 방법

- [x] `pnpm lint:admin`
- [ ] `/` → 배지 목록 → 배지 상세 → 헤더 뒤로가기 → 배지 목록 → 헤더 뒤로가기 시 admin 전체 메뉴로 이동하는지 확인
- [ ] 배지 상세 → 수정 → 헤더 뒤로가기 시 배지 상세로 복귀하는지 확인
- [ ] 배지 수정 → 부여 → 헤더 뒤로가기 시 배지 수정으로 복귀하는지 확인

## ✔️ 설치 라이브러리

-

## 📷 실행 영상 또는 스크린샷

-

## 💬 논의할 점

- admin 라우팅에서 진입성 이동은 `push`, 복귀성 이동은 `replace`로 사용하는 컨벤션을 유지하면 유사 이슈를 줄일 수 있습니다.
