### PR TITLE
[FIX(admin)] 점수 관리 팀 조회 활동 기수 처리 개선

### DIFF
--- a/apps/admin/src/app-pages/score-management/ui/ScoreManagementPage.tsx
+++ b/apps/admin/src/app-pages/score-management/ui/ScoreManagementPage.tsx
@@ -16,19 +16,19 @@ import {
 import { useTeamsQuery } from '@/entities/team/model/queries/useTeamsQuery';
 import { PAGE_ROUTES } from '@/shared/config/path';
 
-const FILTER_LABELS: Record<ScoreListFilter, string> = {
-  individual: '개인',
-  study: '스터디',
-  project: '프로젝트',
-};
-
-const FILTER_ORDER: ScoreListFilter[] = ['individual', 'study', 'project'];
+const FILTER_OPTIONS = [
+  { value: 'individual', label: '개인' },
+  { value: 'study', label: '스터디' },
+  { value: 'project', label: '프로젝트' },
+] as const satisfies ReadonlyArray<{ value: ScoreListFilter; label: string }>;
 
 const GROUP_EMPTY_MESSAGES: Record<ScoreGroupKind, string> = {
   study: '진행중인 스터디가 없습니다.',
   project: '진행중인 프로젝트가 없습니다.',
 };
 
+const ACTIVE_GENERATION_ERROR_MESSAGE = '활동 기수 정보를 불러오지 못했습니다.';
+const SCORE_STATUS_ERROR_MESSAGE = '점수 현황을 불러오지 못했습니다.';
 const SCORE_RANKING_PAGE_SIZE = 50;
 
 export const ScoreManagementPage = () => {
@@ -45,6 +45,8 @@ export const ScoreManagementPage = () => {
     isError: isActiveCohortError,
   } = useActiveGenerationQuery();
   const activeGeneration = activeCohort?.generation;
+  const isGroupFilter = !isIndividual;
+  const canFetchTeams = isGroupFilter && activeGeneration != null;
 
   const {
     data: members = [],
@@ -66,7 +68,7 @@ export const ScoreManagementPage = () => {
   } = useTeamsQuery({
     kind: isIndividual ? 'study' : filter,
     generation: activeGeneration,
-    enabled: !isIndividual && activeGeneration != null,
+    enabled: canFetchTeams,
   });
 
   const sortedMembers = useMemo(
@@ -78,10 +80,14 @@ export const ScoreManagementPage = () => {
     router.push(PAGE_ROUTES.SCORE_MNG_MEMBER(memberId));
   };
 
-  const isError = isIndividual ? isMemberRankingLoadingError : isActiveCohortError || isTeamsError;
-  const isLoading = isIndividual
-    ? isMemberRankingLoading
-    : !isError && (isActiveCohortLoading || activeGeneration == null || isTeamsLoading);
+  const isGroupLoading = isActiveCohortLoading || activeGeneration == null || isTeamsLoading;
+  const isGroupError = isActiveCohortError || isTeamsError;
+  const isError = isIndividual ? isMemberRankingLoadingError : isGroupError;
+  const isLoading = isIndividual ? isMemberRankingLoading : !isGroupError && isGroupLoading;
+  const errorMessage =
+    isGroupFilter && isActiveCohortError
+      ? ACTIVE_GENERATION_ERROR_MESSAGE
+      : SCORE_STATUS_ERROR_MESSAGE;
 
   const memberRankingTriggerRef = useInfiniteScroll({
     enabled: isIndividual && !isLoading && !isError && !isMemberRankingFetchNextPageError,
@@ -96,13 +102,13 @@ export const ScoreManagementPage = () => {
     <div className="relative flex h-full flex-col overflow-hidden">
       <div className="border-border-normal flex items-center border-b px-13 pb-10">
         <div className="flex gap-10">
-          {FILTER_ORDER.map((value) => (
+          {FILTER_OPTIONS.map(({ value, label }) => (
             <ScoreFilterChip
               key={value}
               isSelected={filter === value}
               onClick={() => setFilter(value)}
             >
-              {FILTER_LABELS[value]}
+              {label}
             </ScoreFilterChip>
           ))}
         </div>
@@ -114,9 +120,7 @@ export const ScoreManagementPage = () => {
           <div className="text-body-body9 text-foreground-tertiary px-13 py-12">Loading...</div>
         )}
         {isError && (
-          <div className="text-body-body9 text-foreground-tertiary px-13 py-12">
-            점수 현황을 불러오지 못했습니다.
-          </div>
+          <div className="text-body-body9 text-foreground-tertiary px-13 py-12">{errorMessage}</div>
         )}
         {!isLoading && !isError && isIndividual ? (
           <>

--- a/apps/admin/src/app-pages/score-management/ui/ScoreTargetSelectPage.tsx
+++ b/apps/admin/src/app-pages/score-management/ui/ScoreTargetSelectPage.tsx
@@ -72,9 +72,7 @@ export const ScoreTargetSelectPage = ({ criterionId }: ScoreTargetSelectPageProp
         )}
         {!state.isLoading && state.isError && (
           <div className="flex flex-col items-start gap-8 px-13 py-12">
-            <p className="text-body-body9 text-foreground-tertiary">
-              회원 목록을 불러오지 못했습니다.
-            </p>
+            <p className="text-body-body9 text-foreground-tertiary">{state.errorMessage}</p>
             <button
               type="button"
               className="rounded-2 border-border-quaternary text-body-body9 text-foreground-normal border px-11 py-7"

--- a/apps/admin/src/features/score-assign/model/useScoreTargetSelect.ts
+++ b/apps/admin/src/features/score-assign/model/useScoreTargetSelect.ts
@@ -30,6 +30,9 @@ const getTodayDateString = () => {
   return `${year}-${month}-${day}`;
 };
 
+const ACTIVE_GENERATION_ERROR_MESSAGE = '활동 기수 정보를 불러오지 못했습니다.';
+const TARGET_LIST_ERROR_MESSAGE = '회원 목록을 불러오지 못했습니다.';
+
 const toPartLabel = (part: string) => PART_LABELS[part as TrackPart] ?? part;
 
 /** 팀 상세 / 파트 그룹 응답 모두 `tracks` 구조가 같아 동일하게 변환한다. */
@@ -59,7 +62,15 @@ export const useScoreTargetSelect = (criterionId: string) => {
   const [openGroupIds, setOpenGroupIds] = useState<Set<string>>(new Set());
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
 
-  const { data: activeCohort } = useActiveGenerationQuery();
+  const {
+    data: activeCohort,
+    isLoading: isActiveCohortLoading,
+    isError: isActiveCohortError,
+    refetch: refetchActiveCohort,
+  } = useActiveGenerationQuery();
+  const activeGeneration = activeCohort?.generation;
+  const hasActiveGeneration = activeGeneration != null;
+  const isPartTarget = targetKind === 'part';
 
   const {
     data: categories = [],
@@ -74,8 +85,8 @@ export const useScoreTargetSelect = (criterionId: string) => {
     isError: isPartGroupsError,
     refetch: refetchPartGroups,
   } = useGroupedMembersByPartQuery({
-    generation: activeCohort?.generation,
-    enabled: targetKind === 'part',
+    generation: activeGeneration,
+    enabled: isPartTarget,
   });
 
   const {
@@ -84,9 +95,9 @@ export const useScoreTargetSelect = (criterionId: string) => {
     isError: isTeamsError,
     refetch: refetchTeams,
   } = useTeamsQuery({
-    kind: targetKind === 'part' ? 'study' : targetKind,
-    generation: activeCohort?.generation,
-    enabled: targetKind !== 'part',
+    kind: isPartTarget ? 'study' : targetKind,
+    generation: activeGeneration,
+    enabled: !isPartTarget && hasActiveGeneration,
   });
 
   const criterion = useMemo(
@@ -197,28 +208,40 @@ export const useScoreTargetSelect = (criterionId: string) => {
     });
   };
 
+  const isTargetListLoading = isPartTarget ? isPartGroupsLoading : isTeamsLoading;
+  const isTargetListError = isPartTarget ? isPartGroupsError : isTeamsError;
+  const isError = isActivityTypesError || isActiveCohortError || isTargetListError;
+  const isWaitingForActiveGeneration = !isActiveCohortError && !hasActiveGeneration;
   const isLoading =
-    isActivityTypesLoading || (targetKind === 'part' ? isPartGroupsLoading : isTeamsLoading);
-  const isError =
-    isActivityTypesError || (targetKind === 'part' ? isPartGroupsError : isTeamsError);
+    !isError &&
+    (isActivityTypesLoading ||
+      isActiveCohortLoading ||
+      isWaitingForActiveGeneration ||
+      isTargetListLoading);
+  const errorMessage = isActiveCohortError
+    ? ACTIVE_GENERATION_ERROR_MESSAGE
+    : TARGET_LIST_ERROR_MESSAGE;
 
   /** 현재 탭에서 실패한 조회만 다시 실행한다. */
   const retry = useCallback(() => {
+    if (isActiveCohortError) void refetchActiveCohort();
     if (isActivityTypesError) void refetchActivityTypes();
-    if (targetKind === 'part') {
+    if (isPartTarget) {
       if (isPartGroupsError) void refetchPartGroups();
 
       return;
     }
     if (isTeamsError) void refetchTeams();
   }, [
+    isActiveCohortError,
     isActivityTypesError,
+    isPartTarget,
     isPartGroupsError,
     isTeamsError,
+    refetchActiveCohort,
     refetchActivityTypes,
     refetchPartGroups,
     refetchTeams,
-    targetKind,
   ]);
 
   return {
@@ -233,6 +256,7 @@ export const useScoreTargetSelect = (criterionId: string) => {
       selectedIds,
       isLoading,
       isError,
+      errorMessage,
       isApplyDisabled: selectedIds.size === 0 || !criterion || isTeamCriterion || isCreatePending,
     },
     actions: {

--- a/apps/admin/src/shared/config/path.ts
+++ b/apps/admin/src/shared/config/path.ts
@@ -23,7 +23,7 @@ export const PAGE_ROUTES = {
   SCORE_MNG: SCORE_ROOT,
   SCORE_MNG_ASSIGN: `${SCORE_ROOT}/assign`,
   SCORE_MNG_ASSIGN_TARGET: (criterionId: string | number) => `${SCORE_ROOT}/assign/${criterionId}`,
-  SCORE_MNG_MEMBER: (memberId: string | number) => `${SCORE_ROOT}/member/${memberId}`,
+  SCORE_MNG_MEMBER: (memberId: string | number): string => `${SCORE_ROOT}/member/${memberId}`,
   WELCOME_MSG: '/welcome-message',
   BADGE_MNG: {
     LIST: '/badge-management',


### PR DESCRIPTION
## ✅ 체크리스트
- [x] 코드에 any가 사용되지 않았습니다
- [ ] 스토리북에 추가했습니다 (해당 시)
- [x] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈

- close #637 

## 📌 작업 목적

- 회원 점수 조회의 스터디/프로젝트 탭에서 활동 기수 팀만 조회하도록 개선합니다.
- 활동 기수 조회 실패 시 일반 점수 현황 오류와 구분되는 메시지를 노출합니다.

## 🔨 주요 작업 내용

- 점수 관리 스터디/프로젝트 탭의 팀 조회 조건을 활동 기수 확정 이후로 제한
- 활동 기수 조회 실패 시 `활동 기수 정보를 불러오지 못했습니다.` 메시지 노출
- 점수 부여 대상 선택 화면에서도 활동 기수 확정 전 팀 조회가 실행되지 않도록 개선
- `PAGE_ROUTES.SCORE_MNG_MEMBER` 반환 타입을 명시해 `router.push` 타입 안전성 개선

## ⚠️ 기존 문제 (선택)

- 스터디/프로젝트 팀 조회 시 활동 기수가 확정되지 않은 상태에서 요청이 나갈 수 있었습니다.
- 활동 기수 조회 실패와 팀/점수 목록 조회 실패가 동일한 오류 메시지로 노출되었습니다.
- `router.push(PAGE_ROUTES.SCORE_MNG_MEMBER(memberId))`에서 반환 타입 추론이 불안정해 unsafe argument 경고가 발생했습니다.

## ☑️ 해결 방법 (선택)

- `activeGeneration != null`일 때만 `/v1/admin/teams` 조회가 실행되도록 `enabled` 조건을 명확히 했습니다.
- 활성 기수 관련 로딩/에러 상태와 팀 목록 로딩/에러 상태를 분리했습니다.
- 동적 라우트 helper 반환 타입을 `string`으로 명시했습니다.

## 🧪 테스트 방법

- [x] `pnpm lint:admin`
- [x] `pnpm check-types:admin`
- [x] 단일 파일 `@typescript-eslint/no-unsafe-argument` 검증
- [ ] 회원 점수 조회 → 스터디/프로젝트 탭 진입 시 `/v1/admin/teams?type=STUDY|PROJECT&generation={활동기수}` 요청 확인
- [ ] 활동 기수 조회 실패 시 `활동 기수 정보를 불러오지 못했습니다.` 메시지 노출 확인

## ✔️ 설치 라이브러리

-

## 📷 실행 영상 또는 스크린샷

-

## 💬 논의할 점

-

## 🙋🏻 참고 자료

-