### PR TITLE
[FIX] 웹뷰에서 화면 위아래 여백 제거

### DIFF
--- a/apps/web/src/app-pages/home/ui/HomePageClient.tsx
+++ b/apps/web/src/app-pages/home/ui/HomePageClient.tsx
@@ -93,7 +93,7 @@ export const HomePageClient = ({ heroProps }: { heroProps: HeroCardProps }) => {
         />
       </div>
 
-      <div className="relative -mt-[3rem]">
+      <div className="app-hero-offset relative -mt-[3rem]">
         {/* Hero Card */}
         <div className="flex w-full flex-col">
           <HeroCard {...heroProps} />

--- a/apps/web/src/shared/styles/globals.css
+++ b/apps/web/src/shared/styles/globals.css
@@ -1,4 +1,5 @@
 @import '../../../../../packages/ui/styles/globals.css';
+@import './safe-area-native.css';
 
 /* 뷰포트 높이 전파 */
 html,

--- a/apps/web/src/shared/styles/safe-area-native.css
+++ b/apps/web/src/shared/styles/safe-area-native.css
@@ -1,0 +1,13 @@
+/*
+ * 네이티브 앱 WebView 전용 세이프에어리어 대응.
+ * .is-native-app / --sat,--sar,--sab,--sal 은 WebView 로드 시 앱에서 <html>에 주입한다.
+ * 이 클래스가 없는 일반 브라우저에서는 아래 규칙이 매칭되지 않아 기존 화면과 동일하다.
+ */
+
+.is-native-app .app-header {
+  padding-top: calc(var(--spacing-11) + var(--sat, 0px)); /* py-11의 top 값 + 세이프에어리어 */
+}
+
+.is-native-app .app-bottom-nav {
+  padding-bottom: calc(var(--spacing-13) + var(--sab, 0px)); /* pb-13 값 + 세이프에어리어 */
+}

--- a/apps/web/src/shared/styles/safe-area-native.css
+++ b/apps/web/src/shared/styles/safe-area-native.css
@@ -4,8 +4,20 @@
  * 이 클래스가 없는 일반 브라우저에서는 아래 규칙이 매칭되지 않아 기존 화면과 동일하다.
  */
 
+/* 헤더는 높이를 정확히 (3rem + sat) 으로 고정한다.
+ * padding-top 만 늘리면 Tailwind 의 min-h-[3rem] 이 그대로 48px 이라
+ * 실제 높이가 max(48px, 12px + sat + 콘텐츠 + 12px) 로 커지고,
+ * 아래 .app-hero-offset 이 가정하는 (48px + sat) 과 어긋나 헤더/히어로가 함께 밀린다.
+ * box-sizing: border-box 기준이라 콘텐츠 영역은 웹과 동일하게 24px 로 유지된다. */
 .is-native-app .app-header {
+  height: calc(3rem + var(--sat, 0px));
   padding-top: calc(var(--spacing-11) + var(--sat, 0px)); /* py-11의 top 값 + 세이프에어리어 */
+}
+
+/* 홈 히어로는 헤더(3rem) 밑으로 겹치도록 -mt-[3rem]로 끌어올려져 있다.
+ * 위에서 헤더 높이를 3rem + sat 로 고정했으므로 오프셋도 정확히 같은 값으로 늘린다. */
+.is-native-app .app-hero-offset {
+  margin-top: calc(-3rem - var(--sat, 0px));
 }
 
 .is-native-app .app-bottom-nav {

--- a/apps/web/src/shared/styles/safe-area-native.css
+++ b/apps/web/src/shared/styles/safe-area-native.css
@@ -8,14 +8,22 @@
  * padding-top 만 늘리면 Tailwind 의 min-h-[3rem] 이 그대로 48px 이라
  * 실제 높이가 max(48px, 12px + sat + 콘텐츠 + 12px) 로 커지고,
  * 아래 .app-hero-offset 이 가정하는 (48px + sat) 과 어긋나 헤더/히어로가 함께 밀린다.
- * box-sizing: border-box 기준이라 콘텐츠 영역은 웹과 동일하게 24px 로 유지된다. */
+ *
+ * --app-header-lift: 헤더 콘텐츠(로고·아이콘)를 위로 끌어올리는 값.
+ * 헤더가 flex items-center 라 콘텐츠는 패딩 박스의 중앙에 놓인다.
+ * 위 패딩에서 빼고 아래 패딩에 그대로 더하면 패딩 총합(=높이)은 그대로인 채
+ * 콘텐츠만 정확히 이 값만큼 올라간다. 더 올리려면 숫자만 키우면 된다. */
 .is-native-app .app-header {
+  --app-header-lift: 6px;
+
   height: calc(3rem + var(--sat, 0px));
-  padding-top: calc(var(--spacing-11) + var(--sat, 0px)); /* py-11의 top 값 + 세이프에어리어 */
+  padding-top: calc(var(--spacing-11) + var(--sat, 0px) - var(--app-header-lift));
+  padding-bottom: calc(var(--spacing-11) + var(--app-header-lift));
 }
 
 /* 홈 히어로는 헤더(3rem) 밑으로 겹치도록 -mt-[3rem]로 끌어올려져 있다.
- * 위에서 헤더 높이를 3rem + sat 로 고정했으므로 오프셋도 정확히 같은 값으로 늘린다. */
+ * 위에서 헤더 높이를 3rem + sat 로 고정했으므로 오프셋도 정확히 같은 값으로 늘린다.
+ * (헤더 높이는 lift 와 무관하게 유지되므로 히어로는 화면 y=0 에 그대로 붙는다.) */
 .is-native-app .app-hero-offset {
   margin-top: calc(-3rem - var(--sat, 0px));
 }

--- a/apps/web/src/shared/styles/safe-area-native.css
+++ b/apps/web/src/shared/styles/safe-area-native.css
@@ -14,7 +14,7 @@
  * 위 패딩에서 빼고 아래 패딩에 그대로 더하면 패딩 총합(=높이)은 그대로인 채
  * 콘텐츠만 정확히 이 값만큼 올라간다. 더 올리려면 숫자만 키우면 된다. */
 .is-native-app .app-header {
-  --app-header-lift: 6px;
+  --app-header-lift: 12px;
 
   height: calc(3rem + var(--sat, 0px));
   padding-top: calc(var(--spacing-11) + var(--sat, 0px) - var(--app-header-lift));

--- a/apps/web/src/widgets/bottom-navigation/ui/AppNavigation.tsx
+++ b/apps/web/src/widgets/bottom-navigation/ui/AppNavigation.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { BOTTOM_NAV_ITEMS, type TabId } from '../model/config';
 
 const navStyle =
-  'bottom-0 left-0 bg-background-normal-lighter rounded-t-5 shadow-embossed-inverse flex w-full justify-around pb-13';
+  'app-bottom-nav bottom-0 left-0 bg-background-normal-lighter rounded-t-5 shadow-embossed-inverse flex w-full justify-around pb-13';
 const linkStyle = 'flex flex-1 flex-col items-center gap-6 pt-13';
 
 export const AppNavigation = () => {

--- a/packages/ui/components/header/Header.tsx
+++ b/packages/ui/components/header/Header.tsx
@@ -187,7 +187,7 @@ export const Header = ({ className, ...props }: HeaderProps) => {
 
   return (
     <header
-      className={`app-header px-13 top-0 flex h-[3rem] w-full items-center justify-between py-11 ${className ?? 'bg-background-normal'} border-border-normal border-b-[var(--stroke-weight-0)]`}
+      className={`app-header px-13 top-0 flex min-h-[3rem] w-full items-center justify-between py-11 ${className ?? 'bg-background-normal'} border-border-normal border-b-[var(--stroke-weight-0)]`}
     >
       {content}
     </header>

--- a/packages/ui/components/header/Header.tsx
+++ b/packages/ui/components/header/Header.tsx
@@ -187,7 +187,7 @@ export const Header = ({ className, ...props }: HeaderProps) => {
 
   return (
     <header
-      className={`px-13 top-0 flex h-[3rem] w-full items-center justify-between py-11 ${className ?? 'bg-background-normal'} border-border-normal border-b-[var(--stroke-weight-0)]`}
+      className={`app-header px-13 top-0 flex h-[3rem] w-full items-center justify-between py-11 ${className ?? 'bg-background-normal'} border-border-normal border-b-[var(--stroke-weight-0)]`}
     >
       {content}
     </header>


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 코드에 any가 사용되지 않았습니다
- [ ] 스토리북에 추가했습니다 (해당 없음)
- [ ] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈

- close #

## 📌 작업 목적

웹뷰 상·하단에 남던 흰 여백을 없애고, 앱 화면이 세이프에어리어까지 꽉 차도록 edge-to-edge로 전환합니다.

## 🔨 주요 작업 내용

**`src/app/index.tsx`**
- `SafeAreaView` → `View`로 교체해 WebView가 화면 전체를 차지하도록 변경
- iOS 자동 inset 보정 비활성화 (`contentInsetAdjustmentBehavior="never"`, `automaticallyAdjustContentInsets={false}`)
- `injectedJavaScriptBeforeContentLoaded`로 `<html>`에 `.is-native-app` 클래스와 세이프에어리어 CSS 변수(`--sat` / `--sar` / `--sab` / `--sal`) 주입
- SPA 라우팅으로 document가 교체되는 경우를 대비해 `onLoadEnd`에서 재주입
- 개발 빌드에서만 WebView 원격 디버깅 허용 (`webviewDebuggingEnabled={__DEV__}`) — iOS 16.4+에서 Safari 웹 속성 연결에 필요
- 배경색 `#ffffff` → `#0A0A0A` (로딩 중·바운스 시 흰 줄 노출 방지)

**`src/app/_layout.tsx`**
- `Stack`의 `contentStyle` 배경색을 동일하게 정리
- Expo SDK 55 Android는 edge-to-edge가 기본이므로 `StatusBar`의 `translucent` / `backgroundColor`는 지정하지 않음 (deprecated 경고 방지)

## ⚠️ 기존 문제

- `SafeAreaView`가 상·하단 inset만큼 padding을 넣고, 그 자리에 `backgroundColor: '#ffffff'`가 그대로 노출돼 위아래에 흰 띠가 생김
- iOS는 여기에 더해 `WKWebView`의 contentInset 자동 보정이 겹쳐 여백이 한 번 더 발생

## ☑️ 해결 방법

- 네이티브는 여백을 만들지 않고 화면 전체를 WebView에 넘김
- 세이프에어리어 확보는 웹에서 padding으로만 처리하도록 역할을 분리 — 그래야 상단(하늘색 일러스트)과 하단(다크)처럼 서로 다른 배경색이 화면 끝까지 자연스럽게 이어짐
- 웹이 그 값을 알 수 있도록 네이티브가 실제 inset을 CSS 변수로 주입
- `env(safe-area-inset-*)` 대신 `.is-native-app` 마커 클래스 + CSS 변수 방식을 사용해, 일반 웹 브라우저에서는 규칙 자체가 매칭되지 않도록 함 (웹 레이아웃 영향 0)

## 🧪 테스트 방법
1. `pnpm ios` / `pnpm android`로 네이티브 재빌드 (Fast Refresh로는 WebView prop 일부가 반영되지 않음)
2. 홈 진입 → 히어로 일러스트가 상태바 뒤까지, 하단 네비게이션이 홈 인디케이터까지 채워지는지 확인
3. 헤더 로고·알림 아이콘이 상태바에 가리지 않는지 확인
4. Safari 웹 속성(또는 `chrome://inspect`) 콘솔에서 주입 확인
   ```js
   document.documentElement.className; // "is-native-app" 포함
   getComputedStyle(document.documentElement).getPropertyValue('--sat'); // "59px" 등
   document.querySelector('.app-hero-offset').getBoundingClientRect().top; // 0
   ```
5. 일반 브라우저에서 https://www.tavesurf.site/ 접속 → 기존과 레이아웃이 동일한지 확인 (회귀 없음)

## ✔️ 설치 라이브러리

- 없음

## 📷 실행 영상 또는 스크린샷

- 

## 💬 논의할 점
- 

## 🙋🏻 참고 자료

- 