### PR TITLE
[FIX] 게시글 작성 취소 시 뒤로가기 히스토리 대체 처리

### DIFF
--- a/apps/web/src/app-pages/post/write/ui/PostPage.tsx
+++ b/apps/web/src/app-pages/post/write/ui/PostPage.tsx
@@ -118,11 +118,11 @@ const PostPage = (props: PostPageProps) => {
     resetPostState();
 
     if (mode === 'edit' && postId) {
-      router.push(PAGE_ROUTES.BOARD.POST_DETAIL(boardId, postId));
+      router.replace(PAGE_ROUTES.BOARD.POST_DETAIL(boardId, postId));
       return;
     }
 
-    router.push(PAGE_ROUTES.BOARD.SELECT_CATEGORY(boardId));
+    router.replace(PAGE_ROUTES.BOARD.SELECT_CATEGORY(boardId));
   }, [boardId, mode, postId, resetPostState, router]);
 
   const requestExit = useCallback(() => {


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 코드에 any가 사용되지 않았습니다
- [ ] 스토리북에 추가했습니다 (해당 시)
- [ ] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈

- close #

## 📌 작업 목적

- FAB으로 진입한 게시글 작성 페이지에서 뒤로가기 시 무한루프에 빠지는 버그 수정

## 🔨 주요 작업 내용

- PostPage의 `navigateOut`에서 `router.push` → `router.replace`로 변경

## ⚠️ 기존 문제 (선택)

- `usePostFormExitGuard`가 마운트 시 뒤로가기 가로채기용 더미 히스토리 엔트리를 push하는데, 나가기(취소) 경로인 `navigateOut`은 `router.push`로 이탈해서 그 더미 엔트리를 대체하지 않고 위에 새 엔트리를 쌓기만 했음. 그 결과 게시판에서 다시 뒤로가기를 누르면 더미 엔트리로 되돌아가 PostPage가 재마운트되고 가드가 재무장되는 게 반복되어 무한루프처럼 보임

## ☑️ 해결 방법 (선택)

- navigateOut의 router.push를 router.replace로 변경해, 이탈 시 더미 가드 엔트리를 새 목적지로 교체(대체)하도록 수정함 
- usePostForm.ts의 저장 성공 경로가 이미 replace/back()을 쓰고 있던 것과 동일한 패턴으로 통일

## 🧪 테스트 방법

- ex. 회원가입 폼 UI 구현 시 올바른 정보 입력 시 회원가입 성공 후 홈으로 이동되는지 확인

## ✔️ 설치 라이브러리

-

## 📷 실행 영상 또는 스크린샷

-

## 💬 논의할 점

-

## 🙋🏻 참고 자료

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 게시글 작성 또는 수정 후 화면 이동이 기존 페이지를 기록하지 않는 방식으로 개선되었습니다.
  - 수정 완료 시 게시글 상세 페이지로, 새 글 작성 시 카테고리 선택 페이지로 자연스럽게 이동합니다.
  - 이동 후 뒤로 가기 시 작성·수정 화면으로 다시 돌아가는 불편이 줄어듭니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->