### PR TITLE
[FIX] 게시글 작성 취소 시 뒤로가기 오류 해결

### DIFF
--- a/apps/web/src/app-pages/post/write/ui/PostPage.tsx
+++ b/apps/web/src/app-pages/post/write/ui/PostPage.tsx
@@ -217,7 +217,6 @@ const PostPage = (props: PostPageProps) => {
     <div className="flex h-full w-full flex-1 flex-col">
       {/* 1. 상단 헤더 */}
       <AppHeader
-        customBack={requestExit}
         overrideHeader={{
           mode: HeaderMode.TextBtn,
           title: boardLabel,

--- a/apps/web/src/features/post/post-form/model/usePostFormExitGuard.ts
+++ b/apps/web/src/features/post/post-form/model/usePostFormExitGuard.ts
@@ -31,7 +31,13 @@ export const usePostFormExitGuard = ({
     };
 
     const handlePopState = () => {
-      history.go(1);
+      // 저장 안 한 변경사항이 있을 때만 뒤로가기를 취소하고 확인창을 띄운다.
+      // 없으면 go(1)을 호출하지 않는다 — onRequestExit()이 부르는 router.replace()가
+      // 아직 끝나지 않은 go(1)과 경합하면, replace로 이동한 직후 go(1)이 뒤늦게
+      // 실행되며 가드 엔트리로 다시 스냅해버린다 (뒤로가기 무한루프의 원인).
+      if (hasUnsavedChanges()) {
+        history.go(1);
+      }
       onRequestExit();
     };
 


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 코드에 any가 사용되지 않았습니다
- [ ] 스토리북에 추가했습니다 (해당 시)
- [ ] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈

- close #

## 📌 작업 목적

- 작업 목적을 한 줄로 요약해주세요.

## 🔨 주요 작업 내용

- usePostFormExitGuard가 마운트 시 push하는 가드용 히스토리 엔트리를 navigateOut이 router.push로 나가면서 대체하지 않고 위에 쌓기만 해, 게시판에서 다시 뒤로가기를 누르면 그 엔트리로 되돌아가 PostPage가 재마운트되고 가드가 재무장되는 루프가
발생했다.

- handlePopState: 저장 안 한 변경사항이 있을 때만 history.go(1)을 호출하도록 변경. 무조건 go(1)을 부르면 아직 끝나지 않은 go(1)이 router.replace() 직후 뒤늦게 실행되며 가드 엔트리로 다시 스냅해버리는 경합이 있었음
- 헤더 X버튼(customBack)이 requestExit을 직접 호출해 위 popstate 경로를 우회하던 것도 제거 -> 기본 router.back()을 타도록 해서 하드웨어 뒤로가기와 동일한 경로로 통일 (아이콘 클릭 시엔 가드 엔트리 뒤에 남은 원본 글쓰기 엔트리가 소비되지 않아 한 번 더 뒤로가면 다시 글쓰기 화면으로 돌아가던 문제 해결)

## ⚠️ 기존 문제 (선택)

- 버그나 리팩토링인 경우 작성해주세요.

## ☑️ 해결 방법 (선택)

- 위 문제를 어떻게 해결했는지 요약해주세요.

## 🧪 테스트 방법

- ex. 회원가입 폼 UI 구현 시 올바른 정보 입력 시 회원가입 성공 후 홈으로 이동되는지 확인

## ✔️ 설치 라이브러리

-

## 📷 실행 영상 또는 스크린샷

-

## 💬 논의할 점

-

## 🙋🏻 참고 자료

-
