### PR TITLE
[FIX] 게시글 작성 뒤로가기 버그 해결

### DIFF
--- a/apps/web/src/app-pages/post/write/ui/PostPage.tsx
+++ b/apps/web/src/app-pages/post/write/ui/PostPage.tsx
@@ -18,7 +18,10 @@ import { useAuthStore } from '@/features/auth/model/useAuthStore';
 import { useGetPostScheduleQuery } from '@/features/post/model/useGetPostScheduleQuery';
 import { TOOLBAR_KEY } from '@/features/post/post-editor/ui/PostEditorToolbar';
 import { usePostForm } from '@/features/post/post-form/model/usePostForm';
-import { usePostFormExitGuard } from '@/features/post/post-form/model/usePostFormExitGuard';
+import {
+  leavePostFormHistory,
+  usePostFormExitGuard,
+} from '@/features/post/post-form/model/usePostFormExitGuard';
 import { usePostFormStore } from '@/features/post/post-form/model/usePostFormStore';
 import { usePostInitialization } from '@/features/post/post-form/model/usePostInitialization';
 import { useCreatePostScheduleStore } from '@/features/schedule/create-post-schedule/model/useCreatePostScheduleStore';
@@ -114,25 +117,48 @@ const PostPage = (props: PostPageProps) => {
     [closeAlert, setShowExitAlert],
   );
 
-  const navigateOut = useCallback(() => {
+  // 글쓰기 페이지를 떠날 때의 목적지.
+  const exitDestination =
+    mode === 'edit' && postId
+      ? PAGE_ROUTES.BOARD.POST_DETAIL(boardId, postId)
+      : PAGE_ROUTES.BOARD.SELECT_CATEGORY(boardId);
+
+  // 글쓰기 페이지가 차지한 히스토리 엔트리(원본 + 뒤로가기 가드용 더미)를 먼저 걷어낸다.
+  // 걷어낸 자리가 이미 목적지면(= 게시판에서 들어온 일반적인 경우) 그대로 두고,
+  // 아니라면 그 위에 목적지를 push 한다.
+  // replace로 덮어쓰면 바로 아래에 같은 URL이 한 번 더 쌓여 뒤로가기가 제자리걸음이 된다.
+  const navigateOut = useCallback(async () => {
+    const landedAt = await leavePostFormHistory();
     resetPostState();
 
-    if (mode === 'edit' && postId) {
-      router.replace(PAGE_ROUTES.BOARD.POST_DETAIL(boardId, postId));
+    if (landedAt === null) {
+      // 되돌아갈 엔트리가 없었던 경우(주소 직접 진입/새로고침). 아직 글쓰기 페이지에
+      // 있으므로 이 자리를 목적지로 덮어쓴다.
+      router.replace(exitDestination);
       return;
     }
 
-    router.replace(PAGE_ROUTES.BOARD.SELECT_CATEGORY(boardId));
-  }, [boardId, mode, postId, resetPostState, router]);
+    if (landedAt !== exitDestination) {
+      router.push(exitDestination);
+    }
+  }, [exitDestination, resetPostState, router]);
 
+  // 헤더 뒤로가기(customBack)와 브라우저 뒤로가기(popstate) 양쪽에서 호출된다.
   const requestExit = useCallback(() => {
     if (hasUnsavedChanges()) {
       setShowExitAlert(true);
       return;
     }
 
-    navigateOut();
+    void navigateOut();
   }, [hasUnsavedChanges, navigateOut, setShowExitAlert]);
+
+  usePostFormExitGuard({
+    enabled: isInitialized,
+    hasUnsavedChanges,
+    onRequestExit: requestExit,
+    onSilentExit: resetPostState,
+  });
 
   const handleSaveReservation = (date: Date) => {
     setField('reservedAt', date);
@@ -197,7 +223,7 @@ const PostPage = (props: PostPageProps) => {
           variant: 'danger',
           onClick: () => {
             closeExitAlert({ restoreFocus: false });
-            navigateOut();
+            void navigateOut();
           },
         },
       ],
@@ -205,18 +231,13 @@ const PostPage = (props: PostPageProps) => {
     setShowExitAlert(false);
   }, [closeExitAlert, navigateOut, openAlert, setShowExitAlert, showExitAlert]);
 
-  usePostFormExitGuard({
-    enabled: isInitialized,
-    hasUnsavedChanges,
-    onRequestExit: requestExit,
-  });
-
   if (!isInitialized) return <Loading />;
 
   return (
     <div className="flex h-full w-full flex-1 flex-col">
       {/* 1. 상단 헤더 */}
       <AppHeader
+        customBack={requestExit}
         overrideHeader={{
           mode: HeaderMode.TextBtn,
           title: boardLabel,

--- a/apps/web/src/app-pages/post/write/ui/PostPage.tsx
+++ b/apps/web/src/app-pages/post/write/ui/PostPage.tsx
@@ -217,7 +217,6 @@ const PostPage = (props: PostPageProps) => {
     <div className="flex h-full w-full flex-1 flex-col">
       {/* 1. 상단 헤더 */}
       <AppHeader
-        customBack={requestExit}
         overrideHeader={{
           mode: HeaderMode.TextBtn,
           title: boardLabel,

--- a/apps/web/src/features/post/post-form/model/usePostForm.ts
+++ b/apps/web/src/features/post/post-form/model/usePostForm.ts
@@ -14,6 +14,7 @@ import { useEditSchedule } from '@/features/schedule/edit/model/useEditSchedule'
 import { usePostFormStore } from './usePostFormStore';
 import { useCreatePostScheduleStore } from '@/features/schedule/create-post-schedule/model/useCreatePostScheduleStore';
 import { usePostDirtyCheck } from '@/features/post/post-form/model/useDirtyCheck';
+import { leavePostFormGuardEntry } from '@/features/post/post-form/model/usePostFormExitGuard';
 
 import { PostPageMode } from './types';
 import { useDeletePostSchedule } from '@/features/schedule/delete/model/useDelPostSchedule';
@@ -244,6 +245,10 @@ export const usePostForm = ({ mode, boardId, postId, postDetail, postSchedule }:
 
       // 모든 무효화 작업이 완료될 때까지 대기
       await Promise.all(invalidatePromises);
+
+      // 뒤로가기 가드용 더미 히스토리 엔트리가 쌓여 있으면 먼저 걷어낸다.
+      // 남겨두면 저장 후 뒤로가기 시 비워진 글쓰기 페이지로 되돌아온다.
+      await leavePostFormGuardEntry();
 
       resetPostState();
       if (mode === 'create') {

--- a/apps/web/src/features/post/post-form/model/usePostFormExitGuard.ts
+++ b/apps/web/src/features/post/post-form/model/usePostFormExitGuard.ts
@@ -31,7 +31,13 @@ export const usePostFormExitGuard = ({
     };
 
     const handlePopState = () => {
-      history.go(1);
+      // 저장 안 한 변경사항이 있을 때만 뒤로가기를 취소하고 확인창을 띄운다.
+      // 없으면 go(1)을 호출하지 않는다 — onRequestExit()이 부르는 router.replace()가
+      // 아직 끝나지 않은 go(1)과 경합하면, replace로 이동한 직후 go(1)이 뒤늦게
+      // 실행되며 가드 엔트리로 다시 스냅해버린다 (뒤로가기 무한루프의 원인).
+      if (hasUnsavedChanges()) {
+        history.go(1);
+      }
       onRequestExit();
     };
 

--- a/apps/web/src/features/post/post-form/model/usePostFormExitGuard.ts
+++ b/apps/web/src/features/post/post-form/model/usePostFormExitGuard.ts
@@ -5,23 +5,102 @@ import { useEffect, useRef } from 'react';
 type UsePostFormExitGuardParams = {
   enabled: boolean;
   hasUnsavedChanges: () => boolean;
+  /** 저장 안 한 변경사항이 있는 채로 이탈을 시도한 경우 (확인창 노출) */
   onRequestExit: () => void;
+  /** 변경사항이 없어 확인창 없이 나가는 경우 (폼 정리용) */
+  onSilentExit: () => void;
 };
+
+const GUARD_STATE_KEY = '__postFormExitGuard';
+
+const readHistoryState = () => window.history.state as Record<string, unknown> | null;
+
+/** 지금 서 있는 히스토리 엔트리가 뒤로가기 흡수용 더미 엔트리인지 */
+const isOnGuardEntry = () => readHistoryState()?.[GUARD_STATE_KEY] === true;
+
+/**
+ * 뒤로가기를 흡수할 더미 엔트리를 현재 URL 위에 쌓는다.
+ * 기존 state를 함께 펼쳐 넘기는 이유는, App Router가 popstate 때 읽는 내부
+ * state(__NA, __PRIVATE_NEXTJS_INTERNALS_TREE)가 빠지면 전체 새로고침으로
+ * 빠질 수 있기 때문이다.
+ */
+const pushGuardEntry = () => {
+  window.history.pushState({ ...readHistoryState(), [GUARD_STATE_KEY]: true }, '');
+};
+
+/** 코드가 의도적으로 히스토리를 되감는 중인지 (사용자 뒤로가기와 구분) */
+let isRewindingHistory = false;
+
+const REWIND_TIMEOUT_MS = 400;
+
+/**
+ * 히스토리를 steps만큼 되감고, 되감긴 뒤의 pathname으로 resolve 한다.
+ * 되돌아갈 엔트리가 없어 popstate가 오지 않으면 null로 resolve 한다.
+ */
+const rewindHistory = (steps: number) =>
+  new Promise<string | null>((resolve) => {
+    if (typeof window === 'undefined' || steps <= 0) {
+      resolve(typeof window === 'undefined' ? null : window.location.pathname);
+      return;
+    }
+
+    isRewindingHistory = true;
+
+    // popstate가 오지 않는 경우(되돌아갈 엔트리 없음 등)에도 이동이 막히지 않도록.
+    const fallbackTimer = window.setTimeout(() => settle(null), REWIND_TIMEOUT_MS);
+
+    function settle(pathname: string | null) {
+      window.clearTimeout(fallbackTimer);
+      window.removeEventListener('popstate', handleRewound);
+      isRewindingHistory = false;
+      resolve(pathname);
+    }
+
+    function handleRewound() {
+      settle(window.location.pathname);
+    }
+
+    window.addEventListener('popstate', handleRewound);
+    window.history.go(-steps);
+  });
+
+/**
+ * 더미 엔트리만 걷어낸다. 저장 후 다른 화면으로 replace 할 때 사용한다.
+ * (글쓰기 엔트리는 남겨두고 그 자리를 replace로 덮어써야 스택이 깔끔하다.)
+ */
+export const leavePostFormGuardEntry = () => rewindHistory(isOnGuardEntry() ? 1 : 0);
+
+/**
+ * 글쓰기 페이지가 차지한 엔트리(원본 + 더미)를 통째로 걷어낸다.
+ * 확인창에서 "나가기"를 누르거나 변경사항 없이 나갈 때 사용한다.
+ */
+export const leavePostFormHistory = () => rewindHistory(isOnGuardEntry() ? 2 : 1);
 
 export const usePostFormExitGuard = ({
   enabled,
   hasUnsavedChanges,
   onRequestExit,
+  onSilentExit,
 }: UsePostFormExitGuardParams) => {
-  const hasPushedExitGuardStateRef = useRef(false);
+  const formPathnameRef = useRef('');
 
   useEffect(() => {
-    if (!enabled) return;
+    formPathnameRef.current = window.location.pathname;
+  }, []);
 
-    if (!hasPushedExitGuardStateRef.current) {
-      hasPushedExitGuardStateRef.current = true;
-      history.pushState({ __postFormExitGuard: true }, '', window.location.href);
-    }
+  // 1. 변경사항이 생기면 뒤로가기를 흡수할 더미 엔트리를 쌓아둔다.
+  //    이게 없으면 뒤로가기가 실제로 이전 페이지로 이동해버려서, 확인창을 띄우라는
+  //    setState가 반영되기 전에 글쓰기 페이지가 언마운트된다 (= 모달이 안 뜬다).
+  //    hasUnsavedChanges는 스토어 값이 바뀔 때마다 새로 만들어지므로, 엔트리가
+  //    어떤 이유로 걷혔더라도 다음 입력에서 다시 채워진다.
+  useEffect(() => {
+    if (!enabled || !hasUnsavedChanges() || isOnGuardEntry()) return;
+    pushGuardEntry();
+  }, [enabled, hasUnsavedChanges]);
+
+  // 2. 새로고침 / 탭 닫기
+  useEffect(() => {
+    if (!enabled) return;
 
     const handleBeforeUnload = (event: BeforeUnloadEvent) => {
       if (!hasUnsavedChanges()) return;
@@ -30,23 +109,49 @@ export const usePostFormExitGuard = ({
       event.returnValue = '';
     };
 
-    const handlePopState = () => {
-      // 저장 안 한 변경사항이 있을 때만 뒤로가기를 취소하고 확인창을 띄운다.
-      // 없으면 go(1)을 호출하지 않는다 — onRequestExit()이 부르는 router.replace()가
-      // 아직 끝나지 않은 go(1)과 경합하면, replace로 이동한 직후 go(1)이 뒤늦게
-      // 실행되며 가드 엔트리로 다시 스냅해버린다 (뒤로가기 무한루프의 원인).
-      if (hasUnsavedChanges()) {
-        history.go(1);
-      }
-      onRequestExit();
-    };
-
     window.addEventListener('beforeunload', handleBeforeUnload);
-    window.addEventListener('popstate', handlePopState);
 
     return () => {
       window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, [enabled, hasUnsavedChanges]);
+
+  // 3. 브라우저 뒤로가기 (헤더 뒤로가기는 customBack으로 직접 처리되어 여기 오지 않는다)
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handlePopState = () => {
+      // 코드가 히스토리를 되감는 중이면 사용자의 이탈 시도가 아니다.
+      if (isRewindingHistory) return;
+
+      // 더미 엔트리만 pop된 경우엔 URL이 그대로다 = 아직 이 페이지를 떠나지 않았다.
+      const stillOnFormPage = window.location.pathname === formPathnameRef.current;
+
+      if (!hasUnsavedChanges()) {
+        onSilentExit();
+        // 더미 엔트리만 걷힌 상태라면 사용자가 의도한 만큼 실제로 뒤로 보내준다.
+        if (stillOnFormPage) window.history.back();
+        return;
+      }
+
+      if (!stillOnFormPage) {
+        // 더미 엔트리가 없어 이미 떠나버린 경우의 안전망. 여기선 확인창을 띄울 수
+        // 없으므로 폼 상태만 정리하고 내비게이션은 브라우저에 맡긴다.
+        onSilentExit();
+        return;
+      }
+
+      // 더미 엔트리를 다시 쌓아 이 페이지에 머문 채로 확인창을 띄운다.
+      // history.go(1)은 비동기라 라우터 전환과 경합하지만, pushState는 동기라
+      // 페이지를 떠나는 일 자체가 발생하지 않는다.
+      pushGuardEntry();
+      onRequestExit();
+    };
+
+    window.addEventListener('popstate', handlePopState);
+
+    return () => {
       window.removeEventListener('popstate', handlePopState);
     };
-  }, [enabled, hasUnsavedChanges, onRequestExit]);
+  }, [enabled, hasUnsavedChanges, onRequestExit, onSilentExit]);
 };

--- a/apps/web/src/shared/config/path.ts
+++ b/apps/web/src/shared/config/path.ts
@@ -26,7 +26,7 @@ export const PAGE_ROUTES = {
 
   // 게시판 관련
   BOARD: {
-    MAIN: '/board/announcement',
+    MAIN: '/board/1',
     SELECT_CATEGORY: (boardId: string | number) => `/board/${boardId}`,
     SEARCH: '/board/search',
     POST_DETAIL: (boardId: string | number, postId: string | number) =>


### PR DESCRIPTION
## ✅ 체크리스트
- [ ] 코드에 any가 사용되지 않았습니다
- [ ] 스토리북에 추가했습니다 (해당 시)
- [ ] 이슈와 커밋이 명확히 연결되어 있습니다

## 🔗 관련 이슈

- close #

## 📌 작업 목적

- 작업 목적을 한 줄로 요약해주세요.

## 🔨 주요 작업 내용

- ex. 회원가입 페이지 UI 구현

## ⚠️ 기존 문제 (선택)

- 버그나 리팩토링인 경우 작성해주세요.

## ☑️ 해결 방법 (선택)

- 위 문제를 어떻게 해결했는지 요약해주세요.

## 🧪 테스트 방법

- ex. 회원가입 폼 UI 구현 시 올바른 정보 입력 시 회원가입 성공 후 홈으로 이동되는지 확인

## ✔️ 설치 라이브러리

-

## 📷 실행 영상 또는 스크린샷

-

## 💬 논의할 점

-

## 🙋🏻 참고 자료

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 게시글 작성 중 뒤로가기, 브라우저 뒤로가기, 페이지 종료 시 동작을 안정적으로 개선했습니다.
  * 저장하지 않은 변경사항이 있을 때 작성 내용을 보호하고, 종료 확인 후 자연스럽게 이동할 수 있습니다.
  * 게시글 저장 완료 후 불필요한 뒤로가기 기록이 정리됩니다.
  * 종료 과정에서 작성 페이지 상태가 올바르게 초기화됩니다.

* **변경 사항**
  * 게시판 기본 진입 경로가 `/board/1`로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->