### PR TITLE
feat: 회원 차단 및 차단 해제 기능 구현

### DIFF
--- a/apps/web/src/app-pages/member/ui/MemberProfilePage.tsx
+++ b/apps/web/src/app-pages/member/ui/MemberProfilePage.tsx
@@ -2,12 +2,15 @@
 
 import { SolidButton } from '@surf/ui/button';
 import { FieldGroup } from '@surf/ui/field-group';
+import { HeaderMode, type HeaderProps } from '@surf/ui/header';
 import { useRouter } from 'next/navigation';
 import type { UserProfile } from '@/entities/user/model/types';
 import { CareerCard } from '@/entities/user/ui/career-card/CareerCard';
 import { useAuthStore } from '@/features/auth/model/useAuthStore';
+import { useBlockMember } from '@/features/block';
 import CareerEmpty from '@/shared/assets/icons/empty-space/career-empty.svg';
 import { PAGE_ROUTES } from '@/shared/config/path';
+import { AppHeader } from '@/widgets/header/ui/AppHeader';
 import { ProfileBadge } from '@/widgets/profile-badge/ui/ProfileBadge';
 import { ProfileHeader } from '@/widgets/profile-header/ui/ProfileHeader';
 
@@ -20,6 +23,22 @@ export const MemberProfilePage = ({ userProfile, memberId }: Props) => {
   const router = useRouter();
   const myId = useAuthStore((s) => s.memberId);
   const isMe = myId != null && myId === memberId;
+  const openBlockSheet = useBlockMember(memberId);
+
+  // 주소록/게시글 등 진입점에서 push되어 들어오므로 back이 기본, 직접 진입 시에만 주소록으로
+  const handleBack = () => {
+    if (window.history.length > 1) {
+      router.back();
+      return;
+    }
+    router.push(PAGE_ROUTES.MEMBER.MEMBER_SEARCH);
+  };
+
+  const overrideHeader: HeaderProps = {
+    mode: HeaderMode.Default,
+    hasLeftIcon: true,
+    icons: isMe ? [] : [{ label: 'Dots', onClickIcon: openBlockSheet }],
+  };
 
   function handleMessage() {
     if (isMe) return;
@@ -34,36 +53,40 @@ export const MemberProfilePage = ({ userProfile, memberId }: Props) => {
   }
 
   return (
-    <div className="flex h-full flex-col overflow-y-auto">
-      <ProfileHeader userProfile={userProfile} />
-      <div className="w-full px-13">
-        <SolidButton size="s" variant="secondary" onClick={handleMessage} isDisabled={isMe}>
-          쪽지 보내기
-        </SolidButton>
-      </div>
-      <section className="flex flex-col gap-16 px-13 pt-16">
-        <div className="flex flex-col gap-10">
-          <FieldGroup title="경력">
-            {userProfile.careers.length > 0 ? (
-              <ul className="flex flex-col gap-10">
-                {userProfile.careers.map((c) => (
-                  <li key={c.careerId ?? `${c.companyName}-${c.startDate}`}>
-                    <CareerCard item={c} />
-                  </li>
-                ))}
-              </ul>
-            ) : (
-              <div className="flex flex-col items-center gap-3 py-16">
-                <CareerEmpty aria-hidden="true" />
-                <span className="text-body-body8 text-foreground-tertiary">
-                  등록된 경력이 없어요
-                </span>
-              </div>
-            )}
-          </FieldGroup>
+    <div className="flex h-full flex-col">
+      <AppHeader customBack={handleBack} overrideHeader={overrideHeader} />
+
+      <div className="flex flex-1 flex-col overflow-y-auto">
+        <ProfileHeader userProfile={userProfile} />
+        <div className="w-full px-13">
+          <SolidButton size="s" variant="secondary" onClick={handleMessage} isDisabled={isMe}>
+            쪽지 보내기
+          </SolidButton>
         </div>
-      </section>
-      <ProfileBadge memberId={memberId} />
+        <section className="flex flex-col gap-16 px-13 pt-16">
+          <div className="flex flex-col gap-10">
+            <FieldGroup title="경력">
+              {userProfile.careers.length > 0 ? (
+                <ul className="flex flex-col gap-10">
+                  {userProfile.careers.map((c) => (
+                    <li key={c.careerId ?? `${c.companyName}-${c.startDate}`}>
+                      <CareerCard item={c} />
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <div className="flex flex-col items-center gap-3 py-16">
+                  <CareerEmpty aria-hidden="true" />
+                  <span className="text-body-body8 text-foreground-tertiary">
+                    등록된 경력이 없어요
+                  </span>
+                </div>
+              )}
+            </FieldGroup>
+          </div>
+        </section>
+        <ProfileBadge memberId={memberId} />
+      </div>
     </div>
   );
 };

--- a/apps/web/src/app-pages/mypage/settings/blocked-members/ui/BlockedMembersPage.tsx
+++ b/apps/web/src/app-pages/mypage/settings/blocked-members/ui/BlockedMembersPage.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { BlockedMemberList, useBlockedMembersQuery, useUnblockMember } from '@/features/block';
+import SearchEmpty from '@/shared/assets/icons/empty-space/search-empty.svg';
+
+const BlockedMembersPage = () => {
+  const { data: members, isLoading, isError } = useBlockedMembersQuery();
+  const confirmUnblock = useUnblockMember();
+
+  if (isLoading) return <div className="flex h-full w-full items-center justify-center" />;
+
+  if (isError) {
+    return (
+      <div className="flex h-full w-full items-center justify-center">
+        <span className="text-body-body8 text-foreground-tertiary">
+          차단한 회원을 불러오지 못했습니다.
+        </span>
+      </div>
+    );
+  }
+
+  if (!members || members.length === 0) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-3 pb-25">
+        <SearchEmpty
+          className="h-[5.59944rem] w-[5.59944rem]"
+          aria-hidden="true"
+          focusable="false"
+        />
+        <span className="text-body-body8 text-foreground-tertiary">차단한 회원이 없어요</span>
+      </div>
+    );
+  }
+
+  return <BlockedMemberList members={members} onSelectMember={confirmUnblock} />;
+};
+
+export default BlockedMembersPage;

--- a/apps/web/src/app/(protected)/(sub)/settings/blocked-members/page.tsx
+++ b/apps/web/src/app/(protected)/(sub)/settings/blocked-members/page.tsx
@@ -1,0 +1,7 @@
+import BlockedMembersPage from '@/app-pages/mypage/settings/blocked-members/ui/BlockedMembersPage';
+
+const Page = () => {
+  return <BlockedMembersPage />;
+};
+
+export default Page;

--- a/apps/web/src/features/block/api/types.ts
+++ b/apps/web/src/features/block/api/types.ts
@@ -11,3 +11,19 @@ export type BlockMemberRequest = {
 };
 
 export type BlockMemberResponse = CommonResponse<null>;
+
+/** 차단 해제 요청 */
+export type UnblockMemberRequest = {
+  targetMemberId: number;
+};
+
+export type UnblockMemberResponse = CommonResponse<null>;
+
+/** 차단한 회원 목록 아이템 */
+export type BlockedMemberResponse = {
+  memberId: number;
+  nickname: string;
+  profileImageUrl?: string;
+};
+
+export type BlockedMemberListResponse = CommonResponse<BlockedMemberResponse[]>;

--- a/apps/web/src/features/block/api/types.ts
+++ b/apps/web/src/features/block/api/types.ts
@@ -1,0 +1,13 @@
+import type { CommonResponse } from '@/shared/api/types';
+
+/**
+ * 회원 차단 요청
+ *
+ * TODO: 백엔드 차단 API 스펙 확정 후 실제 DTO에 맞게 수정
+ * (엔드포인트 / 필드명 미확정 상태)
+ */
+export type BlockMemberRequest = {
+  targetMemberId: number;
+};
+
+export type BlockMemberResponse = CommonResponse<null>;

--- a/apps/web/src/features/block/index.ts
+++ b/apps/web/src/features/block/index.ts
@@ -1,0 +1,2 @@
+export { MemberBlockBottomSheet } from './ui/MemberBlockBottomSheet';
+export { useBlockMember } from './model/useBlockMember';

--- a/apps/web/src/features/block/index.ts
+++ b/apps/web/src/features/block/index.ts
@@ -1,2 +1,5 @@
 export { MemberBlockBottomSheet } from './ui/MemberBlockBottomSheet';
+export { BlockedMemberList } from './ui/BlockedMemberList';
 export { useBlockMember } from './model/useBlockMember';
+export { useUnblockMember } from './model/useUnblockMember';
+export { useBlockedMembersQuery } from './model/useBlockedMembersQuery';

--- a/apps/web/src/features/block/model/constants.ts
+++ b/apps/web/src/features/block/model/constants.ts
@@ -4,3 +4,10 @@ export const BLOCK_CONFIRM_INFO_TEXT =
 
 export const BLOCK_SUCCESS_MESSAGE = '차단이 완료되었습니다.';
 export const BLOCK_ERROR_MESSAGE = '차단에 실패했습니다. 잠시 후 다시 시도해주세요.';
+
+export const UNBLOCK_CONFIRM_TITLE = '해당 회원의 차단을 해제하시겠습니까?';
+export const UNBLOCK_CONFIRM_INFO_TEXT =
+  '차단을 해제할 경우, 해당 회원에 대한 정보 및 작성한 게시글 및 댓글을 확인할 수 있습니다.';
+
+export const UNBLOCK_SUCCESS_MESSAGE = '차단 해제가 완료되었습니다.';
+export const UNBLOCK_ERROR_MESSAGE = '차단 해제에 실패했습니다. 잠시 후 다시 시도해주세요.';

--- a/apps/web/src/features/block/model/constants.ts
+++ b/apps/web/src/features/block/model/constants.ts
@@ -1,0 +1,6 @@
+export const BLOCK_CONFIRM_TITLE = '해당 회원을 차단하시겠습니까?';
+export const BLOCK_CONFIRM_INFO_TEXT =
+  '차단할 경우, 해당 회원이 작성한 게시글과 댓글이 보이지 않습니다.';
+
+export const BLOCK_SUCCESS_MESSAGE = '차단이 완료되었습니다.';
+export const BLOCK_ERROR_MESSAGE = '차단에 실패했습니다. 잠시 후 다시 시도해주세요.';

--- a/apps/web/src/features/block/model/queryKeys.ts
+++ b/apps/web/src/features/block/model/queryKeys.ts
@@ -1,0 +1,6 @@
+export const blockQueryKeys = {
+  all: ['block'] as const,
+
+  // 차단한 회원 목록
+  blockedMembers: () => [...blockQueryKeys.all, 'members'] as const,
+};

--- a/apps/web/src/features/block/model/useBlockMember.ts
+++ b/apps/web/src/features/block/model/useBlockMember.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import { useAlertStore } from '@surf/ui/store/alertStore';
+
+import { useBottomSheetStore } from '@/shared/store/bottomSheetStore';
+import { BLOCK_CONFIRM_INFO_TEXT, BLOCK_CONFIRM_TITLE } from './constants';
+import { useBlockMemberMutation } from './useBlockMemberMutation';
+
+/** 차단 바텀시트 → 확인 다이얼로그 → 차단 접수까지의 흐름을 묶는다. */
+export const useBlockMember = (memberId: number) => {
+  const openBottomSheet = useBottomSheetStore((s) => s.open);
+  const openAlert = useAlertStore((s) => s.open);
+  const closeAlert = useAlertStore((s) => s.close);
+  const { mutate } = useBlockMemberMutation();
+
+  const confirmBlock = () => {
+    openAlert({
+      state: 'default',
+      title: BLOCK_CONFIRM_TITLE,
+      infoText: BLOCK_CONFIRM_INFO_TEXT,
+      actions: [
+        { type: 'solid', variant: 'secondary', label: '취소', onClick: () => closeAlert() },
+        {
+          type: 'solid',
+          variant: 'danger',
+          label: '차단하기',
+          onClick: () => {
+            // 차단 후 진입점 화면으로 이동하므로 포커스 복원을 건너뛴다
+            closeAlert({ restoreFocus: false });
+            mutate({ targetMemberId: memberId });
+          },
+        },
+      ],
+    });
+  };
+
+  const openBlockSheet = () => {
+    openBottomSheet({ type: 'memberBlock', props: { onBlock: confirmBlock } });
+  };
+
+  return openBlockSheet;
+};

--- a/apps/web/src/features/block/model/useBlockMemberMutation.ts
+++ b/apps/web/src/features/block/model/useBlockMemberMutation.ts
@@ -1,0 +1,48 @@
+'use client';
+
+import { useToastStore } from '@surf/ui/store/toastStore';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+
+import type { BlockMemberRequest } from '../api/types';
+import { PAGE_ROUTES } from '@/shared/config/path';
+import { BLOCK_ERROR_MESSAGE, BLOCK_SUCCESS_MESSAGE } from './constants';
+
+/**
+ * 회원 차단 뮤테이션
+ *
+ * TODO: 백엔드 차단 API 미연동 상태. 스펙 확정 후 아래만 교체하면 됩니다.
+ *  1. `features/block/api/blockMember.client.ts` 추가 (예: POST /v1/user/blocks)
+ *  2. 여기 mutationFn을 해당 함수 호출로 교체
+ *  3. `api/types.ts`의 BlockMemberRequest를 실제 DTO에 맞게 수정
+ */
+export const useBlockMemberMutation = () => {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const showToast = useToastStore((s) => s.show);
+
+  return useMutation({
+    mutationFn: (request: BlockMemberRequest) => {
+      console.warn('[차단] API 미연동 상태입니다. 요청 값:', request);
+      return Promise.resolve();
+    },
+    onSuccess: () => {
+      // 차단된 회원의 글/댓글은 게시글·댓글·검색 등 앱 전반에 걸쳐 있어 전체를 무효화한다.
+      void queryClient.invalidateQueries();
+
+      // 토스트는 전역 store라 이동 후 진입점 화면에서 그대로 노출됩니다.
+      showToast(BLOCK_SUCCESS_MESSAGE);
+
+      // 프로필은 게시글/주소록 등 진입점에서 push되어 들어오므로 back이면 원래 화면으로 돌아간다.
+      if (window.history.length > 1) {
+        router.back();
+        return;
+      }
+      router.push(PAGE_ROUTES.MEMBER.MEMBER_SEARCH);
+    },
+    onError: (error) => {
+      console.error('회원 차단 실패:', error);
+      showToast(BLOCK_ERROR_MESSAGE);
+    },
+  });
+};

--- a/apps/web/src/features/block/model/useBlockedMembersQuery.ts
+++ b/apps/web/src/features/block/model/useBlockedMembersQuery.ts
@@ -1,0 +1,18 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import type { BlockedMemberResponse } from '../api/types';
+import { blockQueryKeys } from './queryKeys';
+
+/**
+ * 차단한 회원 목록 조회
+ *
+ * TODO: 백엔드 차단 API 미연동 상태. 스펙 확정 후 queryFn을 실제 조회로 교체
+ *  (예: GET /v1/user/blocks → BlockedMemberListResponse)
+ */
+export const useBlockedMembersQuery = () =>
+  useQuery({
+    queryKey: blockQueryKeys.blockedMembers(),
+    queryFn: (): Promise<BlockedMemberResponse[]> => Promise.resolve([]),
+  });

--- a/apps/web/src/features/block/model/useUnblockMember.ts
+++ b/apps/web/src/features/block/model/useUnblockMember.ts
@@ -1,0 +1,35 @@
+'use client';
+
+import { useAlertStore } from '@surf/ui/store/alertStore';
+
+import { UNBLOCK_CONFIRM_INFO_TEXT, UNBLOCK_CONFIRM_TITLE } from './constants';
+import { useUnblockMemberMutation } from './useUnblockMemberMutation';
+
+/** 목록에서 회원을 눌렀을 때의 확인 다이얼로그 → 차단 해제 흐름 */
+export const useUnblockMember = () => {
+  const openAlert = useAlertStore((s) => s.open);
+  const closeAlert = useAlertStore((s) => s.close);
+  const { mutate } = useUnblockMemberMutation();
+
+  const confirmUnblock = (targetMemberId: number) => {
+    openAlert({
+      state: 'default',
+      title: UNBLOCK_CONFIRM_TITLE,
+      infoText: UNBLOCK_CONFIRM_INFO_TEXT,
+      actions: [
+        { type: 'solid', variant: 'secondary', label: '취소', onClick: () => closeAlert() },
+        {
+          type: 'solid',
+          variant: 'primary',
+          label: '해제하기',
+          onClick: () => {
+            closeAlert();
+            mutate({ targetMemberId });
+          },
+        },
+      ],
+    });
+  };
+
+  return confirmUnblock;
+};

--- a/apps/web/src/features/block/model/useUnblockMemberMutation.ts
+++ b/apps/web/src/features/block/model/useUnblockMemberMutation.ts
@@ -1,0 +1,36 @@
+'use client';
+
+import { useToastStore } from '@surf/ui/store/toastStore';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import type { UnblockMemberRequest } from '../api/types';
+import { UNBLOCK_ERROR_MESSAGE, UNBLOCK_SUCCESS_MESSAGE } from './constants';
+
+/**
+ * 회원 차단 해제 뮤테이션
+ *
+ * TODO: 백엔드 차단 API 미연동 상태. 스펙 확정 후 아래만 교체하면 됩니다.
+ *  1. `features/block/api/unblockMember.client.ts` 추가 (예: DELETE /v1/user/blocks/{targetMemberId})
+ *  2. 여기 mutationFn을 해당 함수 호출로 교체
+ *  3. `api/types.ts`의 UnblockMemberRequest를 실제 DTO에 맞게 수정
+ */
+export const useUnblockMemberMutation = () => {
+  const queryClient = useQueryClient();
+  const showToast = useToastStore((s) => s.show);
+
+  return useMutation({
+    mutationFn: (request: UnblockMemberRequest) => {
+      console.warn('[차단 해제] API 미연동 상태입니다. 요청 값:', request);
+      return Promise.resolve();
+    },
+    onSuccess: () => {
+      // 해제된 회원의 글/댓글이 다시 보여야 하므로 전체를 무효화한다.
+      void queryClient.invalidateQueries();
+      showToast(UNBLOCK_SUCCESS_MESSAGE);
+    },
+    onError: (error) => {
+      console.error('회원 차단 해제 실패:', error);
+      showToast(UNBLOCK_ERROR_MESSAGE);
+    },
+  });
+};

--- a/apps/web/src/features/block/ui/BlockedMemberList.tsx
+++ b/apps/web/src/features/block/ui/BlockedMemberList.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { Avatar } from '@surf/ui/avatar';
+
+import type { BlockedMemberResponse } from '../api/types';
+
+type BlockedMemberListProps = {
+  members: BlockedMemberResponse[];
+  onSelectMember: (memberId: number) => void;
+};
+
+/** 차단한 회원 목록 — 항목을 누르면 차단 해제 확인으로 이어진다 */
+export const BlockedMemberList = ({ members, onSelectMember }: BlockedMemberListProps) => (
+  <ul className="flex w-full flex-col gap-5 px-13 pt-10 pb-13">
+    {members.map((member) => (
+      <li key={member.memberId}>
+        <button
+          type="button"
+          onClick={() => onSelectMember(member.memberId)}
+          className="flex w-full items-center gap-8 px-12 py-10 text-left"
+        >
+          <Avatar size="xs" src={member.profileImageUrl} alt={`${member.nickname} 프로필 이미지`} />
+          <span className="text-body-body6 text-foreground-normal min-w-0 flex-1 truncate">
+            {member.nickname}
+          </span>
+        </button>
+      </li>
+    ))}
+  </ul>
+);

--- a/apps/web/src/features/block/ui/MemberBlockBottomSheet.tsx
+++ b/apps/web/src/features/block/ui/MemberBlockBottomSheet.tsx
@@ -1,0 +1,43 @@
+import { Sheet, SheetItem } from '@surf/ui/sheet';
+import { Sheet as ModalSheet } from 'react-modal-sheet';
+
+declare module '@/shared/store/bottomSheetStore' {
+  interface BottomSheetMap {
+    memberBlock: Omit<MemberBlockBottomSheetProps, 'isOpen' | 'onClose'>;
+  }
+}
+
+export type MemberBlockBottomSheetProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  onBlock: () => void;
+};
+
+export const MemberBlockBottomSheet = ({
+  isOpen,
+  onClose,
+  onBlock,
+}: MemberBlockBottomSheetProps) => {
+  if (!isOpen) return null;
+
+  return (
+    <ModalSheet isOpen={isOpen} onClose={onClose}>
+      <ModalSheet.Container className="!right-0 !left-0 mx-auto w-full sm:max-w-[min(100dvw,calc(100dvh*375/812))]">
+        <ModalSheet.Content>
+          <Sheet>
+            <div className="flex w-full flex-col">
+              <SheetItem
+                title="차단하기"
+                onClick={() => {
+                  onBlock();
+                  onClose();
+                }}
+              />
+            </div>
+          </Sheet>
+        </ModalSheet.Content>
+      </ModalSheet.Container>
+      <ModalSheet.Backdrop onClick={onClose} />
+    </ModalSheet>
+  );
+};

--- a/apps/web/src/shared/config/path.ts
+++ b/apps/web/src/shared/config/path.ts
@@ -49,6 +49,7 @@ export const PAGE_ROUTES = {
     FEEDBACK: '/settings/feedback',
     SCRAPS: '/settings/scraps',
     MY_POSTS: '/settings/my-posts',
+    BLOCKED_MEMBERS: '/settings/blocked-members',
     MODE: '/settings/mode',
     POLICY: {
       MAIN: '/settings/policy',

--- a/apps/web/src/shared/config/routes.tsx
+++ b/apps/web/src/shared/config/routes.tsx
@@ -111,6 +111,16 @@ export const createRouteConfig = (router: RouterInstance): RouteConfig[] => [
     },
   },
   {
+    id: 'mypage-blocked-members',
+    path: PAGE_ROUTES.MYPAGE.BLOCKED_MEMBERS,
+    backPath: PAGE_ROUTES.MYPAGE.SETTINGS,
+    header: {
+      mode: HeaderMode.Default,
+      title: '차단한 회원 리스트',
+      hasLeftIcon: true,
+    },
+  },
+  {
     id: 'mypage-policy',
     path: PAGE_ROUTES.MYPAGE.POLICY.MAIN,
     backPath: PAGE_ROUTES.MYPAGE.SETTINGS,

--- a/apps/web/src/shared/config/routes.tsx
+++ b/apps/web/src/shared/config/routes.tsx
@@ -162,15 +162,6 @@ export const createRouteConfig = (router: RouterInstance): RouteConfig[] => [
       hasLeftIcon: true,
     },
   },
-  {
-    id: 'profile',
-    path: /^\/member\/\d+$/,
-    backPath: PAGE_ROUTES.MEMBER.MEMBER_SEARCH,
-    header: {
-      mode: HeaderMode.Default,
-      hasLeftIcon: true,
-    },
-  },
   // {
   //   id: 'board',
   //   path: PAGE_ROUTES.BOARD.MAIN,

--- a/apps/web/src/widgets/bottom-sheet/model/constants.ts
+++ b/apps/web/src/widgets/bottom-sheet/model/constants.ts
@@ -9,6 +9,7 @@ import { CommentOptionBottomSheet } from '@/features/comment/ui/CommentOptionBot
 import { ScheduleCategoryBottomSheet } from '@/features/schedule/ui/ScheduleCategoryBottomSheet';
 import { ScheduleDateBottomSheet } from '@/features/schedule/ui/ScheduleDateBottomSheet';
 import { AccountIntegrationBottomSheet } from '@/features/account-integration/ui/AccountIntegrationBottomSheet';
+import { MemberBlockBottomSheet } from '@/features/block/ui/MemberBlockBottomSheet';
 import type { BottomSheetMap, BottomSheetType } from '@/shared/store/bottomSheetStore';
 import type { ComponentType } from 'react';
 
@@ -33,4 +34,5 @@ export const SHEET_COMPONENTS = {
   scheduleCategory: ScheduleCategoryBottomSheet,
   scheduleDate: ScheduleDateBottomSheet,
   accountIntegration: AccountIntegrationBottomSheet,
+  memberBlock: MemberBlockBottomSheet,
 } satisfies BottomSheetComponents;

--- a/apps/web/src/widgets/settings-list/model/constants.ts
+++ b/apps/web/src/widgets/settings-list/model/constants.ts
@@ -33,6 +33,12 @@ export const SETTINGS_ITEMS: SettingsItemType[] = [
     action: { type: 'NAVIGATE', payload: PAGE_ROUTES.MYPAGE.MODE },
   },
   {
+    id: 'blocked-members',
+    leftIconName: 'SmileCircle',
+    text: '차단한 회원 리스트',
+    action: { type: 'NAVIGATE', payload: PAGE_ROUTES.MYPAGE.BLOCKED_MEMBERS },
+  },
+  {
     id: 'policy',
     leftIconName: 'InfoCircle',
     text: '이용약관',


### PR DESCRIPTION
## Summary
- 회원 프로필 화면에 차단 옵션 시트를 추가하고, 차단 완료 시 이전 화면으로 돌아가며 관련 쿼리를 무효화
- 마이페이지 > 설정에 "차단한 회원 리스트" 화면을 추가해 차단 회원 목록 조회 및 개별 차단 해제 지원
- 차단/차단 해제 API는 아직 백엔드 스펙이 확정되지 않아 mutation/query는 mock(성공 응답)으로 동작 — 코드 내 TODO에 교체 지점 명시

## Test plan
- [ ] 회원 프로필(`/member/[id]`)에서 우측 상단 옵션 → 차단하기 → 토스트 노출 및 이전 화면 복귀 확인
- [ ] 마이페이지 > 설정 > 차단한 회원 리스트 진입 확인
- [ ] 차단 해제 플로우 확인
- [ ] 백엔드 API 연동 전이므로 실제 차단 상태는 반영되지 않음 (mock) — API 스펙 확정 후 후속 작업 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CMAwKnQfJQ51kUBbuSATdF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 마이페이지 설정에 ‘차단한 회원 리스트’ 메뉴와 화면을 추가했습니다.
  * 차단된 회원 목록에서 프로필 이미지와 닉네임을 확인할 수 있습니다.
  * 회원 차단 및 차단 해제 기능과 확인 절차를 제공합니다.
  * 다른 회원의 프로필에서 더보기 메뉴를 통해 차단할 수 있습니다.
  * 프로필 화면의 뒤로가기 동작과 고정 헤더를 개선했습니다.
* **개선 사항**
  * 차단 회원 목록의 로딩, 오류, 빈 목록 상태를 안내합니다.
  * 차단 및 차단 해제 결과를 알림으로 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->