### PR TITLE
feat: 게시글/댓글 신고하기 기능 구현

### DIFF
--- a/apps/web/src/app-pages/post/PostDetailPage.tsx
+++ b/apps/web/src/app-pages/post/PostDetailPage.tsx
@@ -16,6 +16,7 @@ import { useDeletePostMutation } from '@/features/post/model/useDeletePostMutati
 import { useGetPostLikesQuery } from '@/features/post/model/useGetPostLikesQuery';
 import { useGetPostScheduleQuery } from '@/features/post/model/useGetPostScheduleQuery';
 import { usePageName } from '@/shared/analytics/lib/getPageName';
+import { PAGE_ROUTES } from '@/shared/config/path';
 import { useBottomSheetStore } from '@/shared/store/bottomSheetStore';
 import { CommentComposer } from '@/widgets/comment-composer/ui/CommentComposer';
 import { CommentSection } from '@/widgets/comment-section/ui/CommentSection';
@@ -149,7 +150,7 @@ const PostDetailPage = ({ postId }: PostDetailPageProps) => {
             ],
           });
         },
-        onReport: () => showToast('신고 기능은 준비 중입니다.'),
+        onReport: () => router.push(PAGE_ROUTES.BOARD.POST_REPORT(post.boardId, numericPostId)),
       },
     });
   };
@@ -160,6 +161,10 @@ const PostDetailPage = ({ postId }: PostDetailPageProps) => {
 
   const handleConsumedReply = () => {
     setPendingReply(null);
+  };
+
+  const handleReportComment = (commentId: number) => {
+    router.push(PAGE_ROUTES.BOARD.POST_REPORT(post.boardId, numericPostId, { commentId }));
   };
   return (
     <div className="flex h-full flex-col">
@@ -217,6 +222,7 @@ const PostDetailPage = ({ postId }: PostDetailPageProps) => {
                     : '첫 댓글을 남겨보세요!'
                 }
                 onStartReply={handleStartReply}
+                onReportComment={handleReportComment}
               />
             </div>
           </div>

--- a/apps/web/src/app-pages/post/PostDetailPage.tsx
+++ b/apps/web/src/app-pages/post/PostDetailPage.tsx
@@ -18,6 +18,7 @@ import { useGetPostScheduleQuery } from '@/features/post/model/useGetPostSchedul
 import { usePageName } from '@/shared/analytics/lib/getPageName';
 import { PAGE_ROUTES } from '@/shared/config/path';
 import { useBottomSheetStore } from '@/shared/store/bottomSheetStore';
+import { PageError, PageLoading } from '@/shared/ui/page-status/PageStatus';
 import { CommentComposer } from '@/widgets/comment-composer/ui/CommentComposer';
 import { CommentSection } from '@/widgets/comment-section/ui/CommentSection';
 import { AppHeader } from '@/widgets/header/ui/AppHeader';
@@ -83,18 +84,9 @@ const PostDetailPage = ({ postId }: PostDetailPageProps) => {
 
   // 로딩/에러 처리
   if (isLoading || (scheduleId && isScheduleLoading))
-    return (
-      <div className="flex h-full w-full items-center justify-center">
-        {/* <span>불러오는 중...</span> */}
-      </div>
-    );
+    return <PageLoading label="게시글을 불러오는 중이에요" />;
 
-  if (isError || !post)
-    return (
-      <div className="flex h-full w-full items-center justify-center">
-        <span>게시글을 불러오지 못했습니다.</span>
-      </div>
-    );
+  if (isError || !post) return <PageError message="게시글을 불러오지 못했습니다." />;
 
   if (scheduleId && isScheduleError) {
     if (process.env.NODE_ENV === 'development') {

--- a/apps/web/src/app-pages/post/report/model/useReportTarget.ts
+++ b/apps/web/src/app-pages/post/report/model/useReportTarget.ts
@@ -1,0 +1,82 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { usePostDetail } from '@/entities/post/api/usePostDetail';
+import { COMMENT_PAGE_SIZE } from '@/features/comment/model/constant';
+import { useInfiniteCommentsQuery } from '@/features/comment/model/useInfiniteCommentsQuery';
+import type { ReportTargetType } from '@/features/report';
+
+type ReportTarget = {
+  targetType: ReportTargetType;
+  targetId: number;
+  writer: string;
+  contentLabel: string;
+  content: string;
+};
+
+/**
+ * 신고 화면에 보여줄 대상(게시글 또는 댓글)의 작성자·제목/내용을 해석한다.
+ * commentId가 있으면 댓글 신고, 없으면 게시글 신고.
+ */
+export const useReportTarget = (postId: number, commentId: number | null) => {
+  const isCommentReport = commentId !== null;
+
+  const {
+    data: post,
+    isLoading: isPostLoading,
+    isError: isPostError,
+  } = usePostDetail(postId, { enabled: !isCommentReport });
+
+  const {
+    data: commentPages,
+    isLoading: isCommentsLoading,
+    isError: isCommentsError,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useInfiniteCommentsQuery(postId, COMMENT_PAGE_SIZE, isCommentReport);
+
+  const targetComment = isCommentReport
+    ? (commentPages?.pages
+        .flatMap((page) => page.comments)
+        .find((comment) => comment.id === commentId) ?? null)
+    : null;
+
+  // 신고 대상 댓글이 아직 불러오지 않은 페이지에 있을 수 있어, 찾을 때까지 다음 페이지를 가져온다
+  useEffect(() => {
+    if (!isCommentReport || targetComment || !hasNextPage || isFetchingNextPage) return;
+    void fetchNextPage();
+  }, [isCommentReport, targetComment, hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  const isCommentSearching =
+    isCommentReport && !targetComment && (isCommentsLoading || isFetchingNextPage || hasNextPage);
+
+  const isLoading = isCommentReport ? isCommentSearching : isPostLoading;
+
+  const target: ReportTarget | null = (() => {
+    if (isCommentReport) {
+      if (!targetComment) return null;
+      return {
+        targetType: 'comment',
+        targetId: targetComment.id,
+        writer: targetComment.nickname,
+        contentLabel: '내용',
+        content: targetComment.content,
+      };
+    }
+
+    if (!post) return null;
+    return {
+      targetType: 'post',
+      targetId: post.postId,
+      writer: post.writer,
+      contentLabel: '제목',
+      content: post.title,
+    };
+  })();
+
+  const isError = isCommentReport ? isCommentsError || (!isLoading && !target) : isPostError;
+
+  return { target, isLoading, isError };
+};

--- a/apps/web/src/app-pages/post/report/model/useReportTarget.ts
+++ b/apps/web/src/app-pages/post/report/model/useReportTarget.ts
@@ -19,14 +19,19 @@ type ReportTarget = {
  * 신고 화면에 보여줄 대상(게시글 또는 댓글)의 작성자·제목/내용을 해석한다.
  * commentId가 있으면 댓글 신고, 없으면 게시글 신고.
  */
-export const useReportTarget = (postId: number, commentId: number | null) => {
+export const useReportTarget = (
+  postId: number,
+  commentId: number | null,
+  options?: { enabled?: boolean },
+) => {
+  const enabled = options?.enabled ?? true;
   const isCommentReport = commentId !== null;
 
   const {
     data: post,
     isLoading: isPostLoading,
     isError: isPostError,
-  } = usePostDetail(postId, { enabled: !isCommentReport });
+  } = usePostDetail(postId, { enabled: enabled && !isCommentReport });
 
   const {
     data: commentPages,
@@ -35,7 +40,7 @@ export const useReportTarget = (postId: number, commentId: number | null) => {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
-  } = useInfiniteCommentsQuery(postId, COMMENT_PAGE_SIZE, isCommentReport);
+  } = useInfiniteCommentsQuery(postId, COMMENT_PAGE_SIZE, enabled && isCommentReport);
 
   const targetComment = isCommentReport
     ? (commentPages?.pages
@@ -45,9 +50,9 @@ export const useReportTarget = (postId: number, commentId: number | null) => {
 
   // 신고 대상 댓글이 아직 불러오지 않은 페이지에 있을 수 있어, 찾을 때까지 다음 페이지를 가져온다
   useEffect(() => {
-    if (!isCommentReport || targetComment || !hasNextPage || isFetchingNextPage) return;
+    if (!enabled || !isCommentReport || targetComment || !hasNextPage || isFetchingNextPage) return;
     void fetchNextPage();
-  }, [isCommentReport, targetComment, hasNextPage, isFetchingNextPage, fetchNextPage]);
+  }, [enabled, isCommentReport, targetComment, hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   const isCommentSearching =
     isCommentReport && !targetComment && (isCommentsLoading || isFetchingNextPage || hasNextPage);

--- a/apps/web/src/app-pages/post/report/ui/PostReportPage.tsx
+++ b/apps/web/src/app-pages/post/report/ui/PostReportPage.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+
+import { useReportTarget } from '../model/useReportTarget';
+import { ReportForm } from '@/features/report';
+
+interface PostReportPageProps {
+  postId: number;
+}
+
+const PostReportPage = ({ postId }: PostReportPageProps) => {
+  const searchParams = useSearchParams();
+  const parsedCommentId = Number(searchParams.get('commentId'));
+  const commentId =
+    Number.isFinite(parsedCommentId) && parsedCommentId > 0 ? parsedCommentId : null;
+
+  const { target, isLoading, isError } = useReportTarget(postId, commentId);
+
+  if (isLoading) return <div className="flex h-full w-full items-center justify-center" />;
+
+  if (isError || !target) {
+    return (
+      <div className="flex h-full w-full items-center justify-center">
+        <span className="text-body-body8 text-foreground-tertiary">
+          신고 대상을 불러오지 못했습니다.
+        </span>
+      </div>
+    );
+  }
+
+  return <ReportForm {...target} />;
+};
+
+export default PostReportPage;

--- a/apps/web/src/app-pages/post/report/ui/PostReportPage.tsx
+++ b/apps/web/src/app-pages/post/report/ui/PostReportPage.tsx
@@ -4,6 +4,7 @@ import { useSearchParams } from 'next/navigation';
 
 import { useReportTarget } from '../model/useReportTarget';
 import { ReportForm } from '@/features/report';
+import { PageError, PageLoading } from '@/shared/ui/page-status/PageStatus';
 
 interface PostReportPageProps {
   postId: number;
@@ -11,23 +12,25 @@ interface PostReportPageProps {
 
 const PostReportPage = ({ postId }: PostReportPageProps) => {
   const searchParams = useSearchParams();
-  const parsedCommentId = Number(searchParams.get('commentId'));
+
+  // commentId가 없으면 게시글 신고. 있는데 유효하지 않으면 대상을 특정할 수 없으므로 오류로 처리한다.
+  const commentIdParam = searchParams.get('commentId');
+  const parsedCommentId = commentIdParam === null ? null : Number(commentIdParam);
   const commentId =
-    Number.isFinite(parsedCommentId) && parsedCommentId > 0 ? parsedCommentId : null;
+    parsedCommentId !== null && Number.isSafeInteger(parsedCommentId) && parsedCommentId > 0
+      ? parsedCommentId
+      : null;
+  const hasInvalidCommentId = commentIdParam !== null && commentId === null;
 
-  const { target, isLoading, isError } = useReportTarget(postId, commentId);
+  const { target, isLoading, isError } = useReportTarget(postId, commentId, {
+    enabled: !hasInvalidCommentId,
+  });
 
-  if (isLoading) return <div className="flex h-full w-full items-center justify-center" />;
+  if (hasInvalidCommentId) return <PageError message="신고할 댓글을 찾을 수 없어요." />;
 
-  if (isError || !target) {
-    return (
-      <div className="flex h-full w-full items-center justify-center">
-        <span className="text-body-body8 text-foreground-tertiary">
-          신고 대상을 불러오지 못했습니다.
-        </span>
-      </div>
-    );
-  }
+  if (isLoading) return <PageLoading label="신고 대상을 불러오는 중이에요" />;
+
+  if (isError || !target) return <PageError message="신고 대상을 불러오지 못했습니다." />;
 
   return <ReportForm {...target} />;
 };

--- a/apps/web/src/app/(protected)/(sub)/board/[boardId]/post/[postId]/report/page.tsx
+++ b/apps/web/src/app/(protected)/(sub)/board/[boardId]/post/[postId]/report/page.tsx
@@ -1,0 +1,20 @@
+import { redirect } from 'next/navigation';
+import PostReportPage from '@/app-pages/post/report/ui/PostReportPage';
+
+const Page = async ({ params }: { params: Promise<{ boardId: string; postId: string }> }) => {
+  const { boardId, postId: postIdParam } = await params;
+  const numericBoardId = Number(boardId);
+  const numericPostId = Number(postIdParam);
+
+  if (!Number.isFinite(numericBoardId)) {
+    redirect('/board/1');
+  }
+
+  if (!Number.isFinite(numericPostId)) {
+    redirect(`/board/${numericBoardId}`);
+  }
+
+  return <PostReportPage postId={numericPostId} />;
+};
+
+export default Page;

--- a/apps/web/src/entities/post/ui/post-image/PostImage.tsx
+++ b/apps/web/src/entities/post/ui/post-image/PostImage.tsx
@@ -1,4 +1,5 @@
 'use client';
+import Image from 'next/image';
 import { useState } from 'react';
 
 export const PostImage = ({ src, alt }: { src: string; alt: string }) => {
@@ -13,6 +14,15 @@ export const PostImage = ({ src, alt }: { src: string; alt: string }) => {
   }
 
   return (
-    <img src={src} alt={alt} className="w-full rounded-[0.5rem]" onError={() => setError(true)} />
+    <Image
+      src={src}
+      alt={alt}
+      width={800}
+      height={600}
+      sizes="100vw"
+      style={{ width: '100%', height: 'auto' }}
+      className="rounded-[0.5rem]"
+      onError={() => setError(true)}
+    />
   );
 };

--- a/apps/web/src/features/report/api/createReport.client.ts
+++ b/apps/web/src/features/report/api/createReport.client.ts
@@ -1,0 +1,8 @@
+import { axiosInstance } from '@/shared/lib/axiosInstance';
+import type { CreateReportRequest, CreateReportResponse } from './types';
+
+// 신고 접수 요청
+export const createReport = async (body: CreateReportRequest): Promise<CreateReportResponse> => {
+  const response = await axiosInstance.post<CreateReportResponse>('/v1/user/reports', body);
+  return response.data;
+};

--- a/apps/web/src/features/report/api/types.ts
+++ b/apps/web/src/features/report/api/types.ts
@@ -1,0 +1,21 @@
+import type { CommonResponse } from '@/shared/api/types';
+
+// BE ReportTargetType
+export type ReportTargetTypeDTO = 'POST' | 'COMMENT' | 'PROFILE';
+
+// BE ReportReasonType
+export type ReportReasonTypeDTO =
+  | 'HATE_OR_ABUSE'
+  | 'SPAM_OR_PROMOTION'
+  | 'ILLEGAL_CONTENT'
+  | 'OBSCENE_CONTENT'
+  | 'UNPLEASANT_EXPRESSION';
+
+// POST /v1/user/reports 요청
+export type CreateReportRequest = {
+  targetType: ReportTargetTypeDTO;
+  targetId: number;
+  reasonType: ReportReasonTypeDTO;
+};
+
+export type CreateReportResponse = CommonResponse<null>;

--- a/apps/web/src/features/report/index.ts
+++ b/apps/web/src/features/report/index.ts
@@ -1,0 +1,2 @@
+export { ReportForm } from './ui/ReportForm';
+export type { ReportReasonCode, ReportTargetType } from './model/types';

--- a/apps/web/src/features/report/model/constants.ts
+++ b/apps/web/src/features/report/model/constants.ts
@@ -1,0 +1,34 @@
+import type { ReportGuideSectionItem, ReportReason } from './types';
+
+// 신고 사유 목록 (중복 선택 불가 — 단일 선택만 허용)
+export const REPORT_REASONS: ReportReason[] = [
+  { code: 'HATE_OR_ABUSE', label: '혐오차별적/생명경시/욕설 표현입니다.' },
+  { code: 'SPAM_OR_PROMOTION', label: '스팸홍보/도배글입니다.' },
+  { code: 'ILLEGAL_CONTENT', label: '불법정보를 포함하고 있습니다.' },
+  { code: 'OBSCENE_CONTENT', label: '음란물입니다.' },
+  { code: 'UNPLEASANT_EXPRESSION', label: '불쾌한 표현이 있습니다.' },
+];
+
+// 신고 접수 및 처리 안내
+export const REPORT_GUIDE_SECTIONS: ReportGuideSectionItem[] = [
+  {
+    title: '신고 처리 프로세스',
+    descriptions: ['접수된 신고는 SURF 운영진이 검토 후 약관 및 운영 정책에 따라 처리됩니다.'],
+  },
+  {
+    title: '허위 신고 제재 안내',
+    descriptions: [
+      '허위 또는 악의적인 목적으로 신고를 반복할 경우, 서비스 이용에 제한(활동 정지 등)을 받을 수 있습니다.',
+    ],
+  },
+  {
+    title: '처리 기준 및 비밀보장',
+    descriptions: [
+      '신고 내용 및 신고자 정보는 비밀로 유지되며, 작성자에게 노출되지 않습니다.',
+      '신고된 게시글/댓글은 운영진 검토 완료 시까지 즉시 블라인드(숨김) 처리될 수 있습니다.',
+    ],
+  },
+];
+
+export const REPORT_SUCCESS_MESSAGE = '신고접수가 완료되었습니다.';
+export const REPORT_ERROR_MESSAGE = '신고 접수에 실패했습니다. 잠시 후 다시 시도해주세요.';

--- a/apps/web/src/features/report/model/mappers.ts
+++ b/apps/web/src/features/report/model/mappers.ts
@@ -1,0 +1,20 @@
+import type { CreateReportRequest, ReportTargetTypeDTO } from '../api/types';
+import type { ReportFormValue, ReportTargetType } from './types';
+
+const REPORT_TARGET_TYPE_DTO: Record<ReportTargetType, ReportTargetTypeDTO> = {
+  post: 'POST',
+  comment: 'COMMENT',
+  profile: 'PROFILE',
+};
+
+/** 신고 폼 값 → POST /v1/user/reports 요청 바디 */
+export const toCreateReportRequest = ({
+  targetType,
+  targetId,
+  reasonCode,
+}: ReportFormValue): CreateReportRequest => ({
+  targetType: REPORT_TARGET_TYPE_DTO[targetType],
+  targetId,
+  // 사유 코드는 BE ReportReasonType과 이름이 같다. 어긋나면 타입 에러로 잡힌다.
+  reasonType: reasonCode,
+});

--- a/apps/web/src/features/report/model/types.ts
+++ b/apps/web/src/features/report/model/types.ts
@@ -1,0 +1,29 @@
+// 신고 대상 종류 (UI) — 라우팅/쿼리스트링에서 소문자로 다룬다
+export type ReportTargetType = 'post' | 'comment' | 'profile';
+
+// 신고 사유 코드 (UI) — BE ReportReasonType과 이름을 1:1로 맞춘다
+export type ReportReasonCode =
+  | 'HATE_OR_ABUSE'
+  | 'SPAM_OR_PROMOTION'
+  | 'ILLEGAL_CONTENT'
+  | 'OBSCENE_CONTENT'
+  | 'UNPLEASANT_EXPRESSION';
+
+// 신고 폼이 만들어내는 값
+export type ReportFormValue = {
+  targetType: ReportTargetType;
+  targetId: number;
+  reasonCode: ReportReasonCode;
+};
+
+// 사유 선택 목록 아이템
+export type ReportReason = {
+  code: ReportReasonCode;
+  label: string;
+};
+
+// 신고 접수 및 처리 안내 문단
+export type ReportGuideSectionItem = {
+  title: string;
+  descriptions: string[];
+};

--- a/apps/web/src/features/report/model/useCreateReportMutation.ts
+++ b/apps/web/src/features/report/model/useCreateReportMutation.ts
@@ -1,0 +1,27 @@
+import { useToastStore } from '@surf/ui/store/toastStore';
+import { useMutation } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+
+import { createReport } from '../api/createReport.client';
+import { REPORT_ERROR_MESSAGE, REPORT_SUCCESS_MESSAGE } from './constants';
+import { toCreateReportRequest } from './mappers';
+import type { ReportFormValue } from './types';
+
+// 신고 접수 뮤테이션
+export const useCreateReportMutation = () => {
+  const router = useRouter();
+  const showToast = useToastStore((s) => s.show);
+
+  return useMutation({
+    mutationFn: (value: ReportFormValue) => createReport(toCreateReportRequest(value)),
+    onSuccess: () => {
+      // 토스트는 전역 store라 뒤로가기 후 게시글 상세에서 그대로 노출됩니다.
+      showToast(REPORT_SUCCESS_MESSAGE);
+      router.back();
+    },
+    onError: (error) => {
+      console.error('신고 접수 실패:', error);
+      showToast(REPORT_ERROR_MESSAGE);
+    },
+  });
+};

--- a/apps/web/src/features/report/model/useReportForm.ts
+++ b/apps/web/src/features/report/model/useReportForm.ts
@@ -1,0 +1,34 @@
+'use client';
+
+import { useState } from 'react';
+
+import type { ReportReasonCode, ReportTargetType } from './types';
+import { useCreateReportMutation } from './useCreateReportMutation';
+
+type UseReportFormParams = {
+  targetType: ReportTargetType;
+  targetId: number;
+};
+
+export const useReportForm = ({ targetType, targetId }: UseReportFormParams) => {
+  // 중복 사유 선택 불가 — 하나만 담는다
+  const [selectedReason, setSelectedReason] = useState<ReportReasonCode | null>(null);
+  const { mutate, isPending } = useCreateReportMutation();
+
+  const submit = () => {
+    if (!selectedReason || isPending) return;
+    mutate({ targetType, targetId, reasonCode: selectedReason });
+  };
+
+  return {
+    state: {
+      selectedReason,
+      isPending,
+      isSubmittable: selectedReason !== null && !isPending,
+    },
+    actions: {
+      selectReason: setSelectedReason,
+      submit,
+    },
+  };
+};

--- a/apps/web/src/features/report/ui/ReportForm.tsx
+++ b/apps/web/src/features/report/ui/ReportForm.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { SolidButton } from '@surf/ui/button';
+
+import type { ReportTargetType } from '../model/types';
+import { useReportForm } from '../model/useReportForm';
+import { ReportGuideSection } from './ReportGuideSection';
+import { ReportReasonList } from './ReportReasonList';
+import { ReportTargetSummary } from './ReportTargetSummary';
+
+type ReportFormProps = {
+  targetType: ReportTargetType;
+  targetId: number;
+  writer: string;
+  contentLabel: string;
+  content: string;
+};
+
+export const ReportForm = ({
+  targetType,
+  targetId,
+  writer,
+  contentLabel,
+  content,
+}: ReportFormProps) => {
+  const { state, actions } = useReportForm({ targetType, targetId });
+
+  return (
+    <div className="bg-background-normal flex h-full flex-col">
+      <div className="flex flex-1 flex-col overflow-y-auto">
+        <ReportTargetSummary writer={writer} contentLabel={contentLabel} content={content} />
+        <ReportReasonList
+          selectedReason={state.selectedReason}
+          onSelectReason={actions.selectReason}
+        />
+        <ReportGuideSection />
+      </div>
+
+      <div className="shrink-0 px-13 pt-13 pb-15">
+        <SolidButton
+          size="l"
+          variant="primary"
+          onClick={actions.submit}
+          isDisabled={!state.isSubmittable}
+        >
+          {state.isPending ? '접수 중...' : '신고하기'}
+        </SolidButton>
+      </div>
+    </div>
+  );
+};

--- a/apps/web/src/features/report/ui/ReportGuideSection.tsx
+++ b/apps/web/src/features/report/ui/ReportGuideSection.tsx
@@ -1,0 +1,24 @@
+import { REPORT_GUIDE_SECTIONS } from '../model/constants';
+
+/** 신고 접수 및 처리 안내 */
+export const ReportGuideSection = () => (
+  <section className="border-border-normal text-foreground-normal flex flex-1 flex-col gap-8 border-b-[var(--stroke-weight-0)] px-15 py-13">
+    <h2 className="text-body-body8">신고 접수 및 처리 안내</h2>
+    <div className="flex flex-col gap-5">
+      {REPORT_GUIDE_SECTIONS.map(({ title, descriptions }, index) => (
+        <div key={title} className="flex flex-col gap-3">
+          <ol start={index + 1} className="list-decimal">
+            <li className="text-body-body9 ms-[1.3rem]">{title}</li>
+          </ol>
+          <ul className="list-disc">
+            {descriptions.map((description) => (
+              <li key={description} className="text-caption-caption4 ms-[1.125rem]">
+                {description}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  </section>
+);

--- a/apps/web/src/features/report/ui/ReportGuideSection.tsx
+++ b/apps/web/src/features/report/ui/ReportGuideSection.tsx
@@ -4,21 +4,21 @@ import { REPORT_GUIDE_SECTIONS } from '../model/constants';
 export const ReportGuideSection = () => (
   <section className="border-border-normal text-foreground-normal flex flex-1 flex-col gap-8 border-b-[var(--stroke-weight-0)] px-15 py-13">
     <h2 className="text-body-body8">신고 접수 및 처리 안내</h2>
-    <div className="flex flex-col gap-5">
-      {REPORT_GUIDE_SECTIONS.map(({ title, descriptions }, index) => (
-        <div key={title} className="flex flex-col gap-3">
-          <ol start={index + 1} className="list-decimal">
-            <li className="text-body-body9 ms-[1.3rem]">{title}</li>
-          </ol>
-          <ul className="list-disc">
+    {/* 안내 절차와 각 설명은 하나의 순서 목록으로 묶는다 (설명 ul은 해당 li의 자식) */}
+    <ol className="flex list-decimal flex-col gap-5">
+      {REPORT_GUIDE_SECTIONS.map(({ title, descriptions }) => (
+        <li key={title} className="text-body-body9 ms-[1.3rem]">
+          {title}
+          {/* 시안에서 설명 불릿은 번호보다 3px 왼쪽에 놓여, 중첩으로 밀린 만큼 되돌린다 */}
+          <ul className="flex list-disc flex-col pt-3">
             {descriptions.map((description) => (
-              <li key={description} className="text-caption-caption4 ms-[1.125rem]">
+              <li key={description} className="text-caption-caption4 ms-[-0.1875rem]">
                 {description}
               </li>
             ))}
           </ul>
-        </div>
+        </li>
       ))}
-    </div>
+    </ol>
   </section>
 );

--- a/apps/web/src/features/report/ui/ReportReasonList.tsx
+++ b/apps/web/src/features/report/ui/ReportReasonList.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { SurfIcon } from '@surf/ui/icon';
+
+import { REPORT_REASONS } from '../model/constants';
+import type { ReportReasonCode } from '../model/types';
+
+type ReportReasonListProps = {
+  selectedReason: ReportReasonCode | null;
+  onSelectReason: (code: ReportReasonCode) => void;
+};
+
+/** 신고 사유 선택 — 중복 선택이 불가능하므로 radiogroup으로 구성 */
+export const ReportReasonList = ({ selectedReason, onSelectReason }: ReportReasonListProps) => (
+  <section className="flex flex-col gap-11 px-15 py-13">
+    <h2 className="text-body-body6 text-foreground-normal">사유 선택</h2>
+    <div role="radiogroup" aria-label="신고 사유" className="flex flex-col gap-10">
+      {REPORT_REASONS.map(({ code, label }) => {
+        const isSelected = selectedReason === code;
+
+        return (
+          <button
+            key={code}
+            type="button"
+            role="radio"
+            aria-checked={isSelected}
+            onClick={() => onSelectReason(code)}
+            className="flex items-center gap-7 pr-10 text-left"
+          >
+            <SurfIcon
+              name="Check"
+              size="m"
+              className={isSelected ? 'text-background-primary' : 'text-foreground-tertiary'}
+            />
+            <span className="text-body-body8 text-foreground-normal-lighter">{label}</span>
+          </button>
+        );
+      })}
+    </div>
+  </section>
+);

--- a/apps/web/src/features/report/ui/ReportTargetSummary.tsx
+++ b/apps/web/src/features/report/ui/ReportTargetSummary.tsx
@@ -1,0 +1,23 @@
+type ReportTargetSummaryProps = {
+  writer: string;
+  contentLabel: string;
+  content: string;
+};
+
+/** 신고 대상(게시글/댓글)의 작성자와 제목·내용 요약 */
+export const ReportTargetSummary = ({
+  writer,
+  contentLabel,
+  content,
+}: ReportTargetSummaryProps) => (
+  <dl className="border-border-normal text-foreground-normal flex flex-col border-b-[var(--stroke-weight-0)] px-15 py-13">
+    <div className="flex items-start gap-5">
+      <dt className="text-body-body8 w-[2.25rem] shrink-0">작성자</dt>
+      <dd className="text-body-body9 min-w-0 flex-1">{writer}</dd>
+    </div>
+    <div className="flex items-start gap-5">
+      <dt className="text-body-body8 w-[2.25rem] shrink-0">{contentLabel}</dt>
+      <dd className="text-body-body9 min-w-0 flex-1 truncate">{content}</dd>
+    </div>
+  </dl>
+);

--- a/apps/web/src/shared/config/path.ts
+++ b/apps/web/src/shared/config/path.ts
@@ -32,6 +32,14 @@ export const PAGE_ROUTES = {
     POST_DETAIL: (boardId: string | number, postId: string | number) =>
       `/board/${boardId}/post/${postId}`,
     POST_CREATE: (boardId: string | number) => `/board/${boardId}/post/create`,
+    POST_REPORT: (
+      boardId: string | number,
+      postId: string | number,
+      options?: { commentId?: number },
+    ) => {
+      const path = `/board/${boardId}/post/${postId}/report`;
+      return options?.commentId ? `${path}?commentId=${options.commentId}` : path;
+    },
     POST_SCHEDULE: '/post/schedule', // PostEditorToolbar.tsx
     COMMUNITY: '/board/2',
   },

--- a/apps/web/src/shared/config/routes.tsx
+++ b/apps/web/src/shared/config/routes.tsx
@@ -215,6 +215,16 @@ export const createRouteConfig = (router: RouterInstance): RouteConfig[] => [
     },
   },
   {
+    id: 'post-report',
+    path: /^\/board\/\d+\/post\/\d+\/report$/,
+    backPath: PAGE_ROUTES.BOARD.MAIN,
+    header: {
+      mode: HeaderMode.Default,
+      title: '신고하기',
+      hasLeftIcon: true,
+    },
+  },
+  {
     id: 'mypage-password',
     path: PAGE_ROUTES.MYPAGE.PASSWORD,
     backPath: PAGE_ROUTES.MYPAGE.MAIN,

--- a/apps/web/src/shared/ui/page-status/PageStatus.tsx
+++ b/apps/web/src/shared/ui/page-status/PageStatus.tsx
@@ -1,0 +1,27 @@
+/**
+ * 페이지 전체를 차지하는 로딩/오류 상태 표시.
+ *
+ * 로딩은 시각적으로 비어 있지만 화면 낭독기에는 상태를 알려야 하므로
+ * role="status" + 읽기 전용 텍스트를 둔다. 오류는 즉시 전달돼야 해서 role="alert".
+ */
+
+type PageLoadingProps = {
+  /** 화면에는 보이지 않고 화면 낭독기로만 읽히는 안내 문구 */
+  label?: string;
+};
+
+export const PageLoading = ({ label = '불러오는 중이에요' }: PageLoadingProps) => (
+  <div role="status" aria-live="polite" className="flex h-full w-full items-center justify-center">
+    <span className="sr-only">{label}</span>
+  </div>
+);
+
+type PageErrorProps = {
+  message: string;
+};
+
+export const PageError = ({ message }: PageErrorProps) => (
+  <div role="alert" className="flex h-full w-full items-center justify-center">
+    <span className="text-body-body8 text-foreground-tertiary">{message}</span>
+  </div>
+);

--- a/apps/web/src/widgets/comment-section/ui/CommentSection.tsx
+++ b/apps/web/src/widgets/comment-section/ui/CommentSection.tsx
@@ -36,6 +36,8 @@ interface Props {
   emptyMessage?: string;
   // 답글 시작을 부모로 올림
   onStartReply: (info: { commentId: number; memberId: number; nickname: string }) => void;
+  // 댓글 신고 화면 이동을 부모로 올림 (boardId를 아는 쪽에서 라우팅)
+  onReportComment: (commentId: number) => void;
 }
 
 export const CommentSection = ({
@@ -45,6 +47,7 @@ export const CommentSection = ({
   isInteractionDisabled = false,
   emptyMessage = '첫 댓글을 남겨보세요!',
   onStartReply,
+  onReportComment,
 }: Props) => {
   const router = useRouter();
   const myId = useAuthStore((s) => s.memberId);
@@ -96,7 +99,7 @@ export const CommentSection = ({
       props: {
         isMine: isMine(c),
         onDelete: () => clickDelete(c.id),
-        onReport: clickReport,
+        onReport: () => onReportComment(c.id),
       },
     });
   };
@@ -136,10 +139,6 @@ export const CommentSection = ({
         },
       ],
     });
-  };
-
-  const clickReport = () => {
-    showToast('신고 기능 준비 중입니다.');
   };
 
   if (isLoading) {

--- a/packages/ui/components/header/Header.tsx
+++ b/packages/ui/components/header/Header.tsx
@@ -70,7 +70,7 @@ export type HeaderProps = (
 const renderLeftIcon = (hasLeftIcon?: boolean, onClickBack?: () => void) =>
   hasLeftIcon && (
     <button
-      className="-m-8 shrink-0 border-none bg-transparent p-8"
+      className="-m-8 flex shrink-0 border-none bg-transparent p-8"
       onClick={onClickBack}
       type="button"
     >
@@ -90,7 +90,7 @@ const renderRightIcons = (icons: MaxThree<HeaderIcon> = []) => (
         icon.label && (
           <button
             key={idx}
-            className="relative -m-8 shrink-0 border-none bg-transparent p-8"
+            className="relative -m-8 flex shrink-0 border-none bg-transparent p-8"
             onClick={icon.onClickIcon}
             type="button"
           >
@@ -103,6 +103,16 @@ const renderRightIcons = (icons: MaxThree<HeaderIcon> = []) => (
     )}
   </div>
 );
+
+// 헤더 높이는 3rem(48px)로 고정이고, 내용 높이에 맞춰 세로 패딩만 달라진다.
+// - 아이콘/타이틀(24px) → py-11(12px) : 24 + 24 = 48
+// - 검색창(36px)        → py-7(6px)   : 36 + 12 = 48
+const paddingByMode: Record<HeaderMode, string> = {
+  [HeaderMode.Default]: 'px-13 py-11',
+  [HeaderMode.Logo]: 'px-13 py-11',
+  [HeaderMode.TextBtn]: 'px-13 py-11',
+  [HeaderMode.SearchBar]: 'py-7 pl-13 pr-11',
+};
 
 export const Header = ({ className, ...props }: HeaderProps) => {
   let content: React.ReactNode;
@@ -166,7 +176,7 @@ export const Header = ({ className, ...props }: HeaderProps) => {
         <>
           {renderLeftIcon(hasLeftIcon, onClickBack)}
           {renderTitle(title)}
-          <div className="ml-auto flex justify-center">
+          <div className="-my-7 ml-auto flex justify-center">
             <TextButton
               size="s"
               variant={btnVariant}
@@ -187,7 +197,7 @@ export const Header = ({ className, ...props }: HeaderProps) => {
 
   return (
     <header
-      className={`app-header px-13 top-0 flex min-h-[3rem] w-full items-center justify-between py-11 ${className ?? 'bg-background-normal'} border-border-normal border-b-[var(--stroke-weight-0)]`}
+      className={`app-header ${paddingByMode[props.mode]} top-0 flex h-[3rem] w-full shrink-0 items-center justify-between ${className ?? 'bg-background-normal'} border-border-normal border-b-[var(--stroke-weight-0)]`}
     >
       {content}
     </header>


### PR DESCRIPTION
## Summary
- 게시글/댓글 신고 화면(`/board/[boardId]/post/[postId]/report`) 신규 구현 — 신고 사유 선택, 신고 대상(게시글/댓글) 요약, 신고 접수 안내 포함
- 게시글 옵션 시트·댓글 옵션 시트의 "신고하기"를 위 화면과 연결 (기존 "준비 중" 토스트 제거)
- 신고 대상 조회 시 `commentId` 쿼리 파라미터가 유효하지 않으면(0, 음수 등) 대상을 특정할 수 없는 것으로 판단해 에러 처리
- 페이지 전체 로딩/에러 상태를 위한 공통 `PageStatus`(`PageLoading`/`PageError`) 컴포넌트 도입, 게시글 상세·신고 화면에 적용 (a11y `role="status"`/`role="alert"` 포함)
- 그 외 개선: 헤더 모드별 높이 불일치 수정, `PostImage`를 `next/image`로 교체, 신고 안내 목록 마크업을 시맨틱하게 정리

## Test plan
- [ ] 게시글 상세 > 옵션 > 신고하기 진입 → 사유 선택 → 접수 확인
- [ ] 댓글 옵션 > 신고하기 진입 → 신고 대상 댓글 내용이 올바르게 요약되는지 확인
- [ ] 잘못된 `commentId`로 신고 화면 진입 시 에러 화면 노출 확인
- [ ] 게시글 상세 로딩/에러 상태에서 PageStatus 정상 노출 확인
- [ ] 헤더 각 모드(Default/Logo/TextBtn/SearchBar)에서 높이 및 정렬 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CMAwKnQfJQ51kUBbuSATdF